### PR TITLE
[azure-arm-rest] Added method to fetch storage account by name

### DIFF
--- a/common-npm-packages/azure-arm-rest/azure-arm-storage.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-storage.ts
@@ -125,7 +125,7 @@ export class StorageAccounts {
          return deferred.promise;
      }
 
-    public async GetClassicOrArmAccountByName(accountName: string, options: any): Promise<Model.StorageAccount> {
+    public async getClassicOrArmAccountByName(accountName: string, options: any): Promise<Model.StorageAccount> {
         const httpRequest = new webClient.WebRequest();
         httpRequest.method = 'GET';
         httpRequest.headers = this.client.setCustomHeaders(options);

--- a/common-npm-packages/azure-arm-rest/azure-arm-storage.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-storage.ts
@@ -129,6 +129,7 @@ export class StorageAccounts {
         const httpRequest = new webClient.WebRequest();
         httpRequest.method = 'GET';
         httpRequest.headers = this.client.setCustomHeaders(options);
+        // TODO: I think we should use newer api versions in the future?
         httpRequest.uri = `https://management.azure.com/resources?api-version=2014-04-01-preview&%24filter=(subscriptionId%20eq%20'${this.client.subscriptionId}')%20and%20(resourceType%20eq%20'microsoft.storage%2Fstorageaccounts'%20or%20resourceType%20eq%20'microsoft.classicstorage%2Fstorageaccounts')%20and%20(name%20eq%20'${accountName}')`;
 
         const res = await this.client.beginRequest(httpRequest);

--- a/common-npm-packages/azure-arm-rest/azure-arm-storage.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-storage.ts
@@ -125,6 +125,23 @@ export class StorageAccounts {
          return deferred.promise;
      }
 
+    public async GetClassicOrArmAccountByName(accountName: string, options: any): Promise<Model.StorageAccount> {
+        const httpRequest = new webClient.WebRequest();
+        httpRequest.method = 'GET';
+        httpRequest.headers = this.client.setCustomHeaders(options);
+        httpRequest.uri = `https://management.azure.com/resources?api-version=2014-04-01-preview&%24filter=(subscriptionId%20eq%20'${this.client.subscriptionId}')%20and%20(resourceType%20eq%20'microsoft.storage%2Fstorageaccounts'%20or%20resourceType%20eq%20'microsoft.classicstorage%2Fstorageaccounts')%20and%20(name%20eq%20'${accountName}')`;
+
+        const res = await this.client.beginRequest(httpRequest);
+
+        if (res.statusCode == 200 && res.body.value) {
+            const storageAccounts: Model.StorageAccount[] = res.body.value;
+
+            return storageAccounts[0];
+        } else {
+            throw azureServiceClientBase.ToError(res);
+        }
+    }
+
     public async listKeys(resourceGroupName: string, accountName: string, options, storageAccountType?: string): Promise<string[]> {
         if (resourceGroupName === null || resourceGroupName === undefined || typeof resourceGroupName.valueOf() !== 'string') {
             throw new Error(tl.loc("ResourceGroupCannotBeNull"));

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.219.0",
+  "version": "3.219.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.219.0",
+  "version": "3.219.1",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds the `getClassicOrArmAccountByName` method which allows to get storage account info by it's name.

Tested with JavaToolInstallerV0 task, works good.