### PR TITLE
Add mask hint for msdeploy when basic auth is disabled

### DIFF
--- a/common-npm-packages/azurermdeploycommon/package-lock.json
+++ b/common-npm-packages/azurermdeploycommon/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azurermdeploycommon",
-  "version": "3.221.2",
+  "version": "3.221.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azurermdeploycommon/package.json
+++ b/common-npm-packages/azurermdeploycommon/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azurermdeploycommon",
-    "version": "3.221.2",
+    "version": "3.221.3",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Though bearer AuthN is used, lets try to set publish profile password for mask hints to maintain compat with old behavior for MSDEPLOY on best effort basis.
This needs to be cleaned up once MSDEPLOY suppport is reomve. Safe handle the exception setting up mask hint as we dont want to fail here.

Backported from https://github.com/microsoft/azure-pipelines-tasks/pull/18183