### PR TITLE
Add logic to support Android project

### DIFF
--- a/common-npm-packages/codecoverage-tools/Tests/codecoverageconstantsTests.ts
+++ b/common-npm-packages/codecoverage-tools/Tests/codecoverageconstantsTests.ts
@@ -135,5 +135,27 @@ export function codecoverageconstantsTests() {
             const actual = codecoverageconstantsRewire.coberturaAntProperties(fakeData.reportDir, fakeData.baseDir);
             assert.deepStrictEqual(actual, expectedResults.coberturaAntPropertiesConfiguration);
         });
+        
+        it('function jacocoGradleAndroidSingleModuleEnable should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.jacocoGradleAndroidSingleModuleEnable(
+                fakeData.excludeFilterStringified,
+                fakeData.includeFilterStringified,
+                fakeData.classDir,
+                fakeData.reportDir,
+                true
+            );
+            assert.deepStrictEqual(actual, expectedResults.jacocoGradleAndroidSingleModuleConfiguration);
+        });
+
+        it('function jacocoGradleAndroidMultiModuleEnable should return correct configuration', () => {
+            const actual = codecoverageconstantsRewire.jacocoGradleAndroidMultiModuleEnable(
+                fakeData.excludeFilterStringified,
+                fakeData.includeFilterStringified,
+                fakeData.classDir,
+                fakeData.reportDir,
+                true
+            );
+            assert.deepStrictEqual(actual, expectedResults.jacocoGradleAndroidMultiModuleConfiguration);
+        });
     });
 }

--- a/common-npm-packages/codecoverage-tools/Tests/jacocogradleccenablerTests.ts
+++ b/common-npm-packages/codecoverage-tools/Tests/jacocogradleccenablerTests.ts
@@ -56,6 +56,8 @@ export function jacocogradleccenablerTests() {
                 .returns(fakeData.excludeFilter)
                 .onCall(1)
                 .returns(fakeData.includeFilter);
+                sandbox.stub(ccc, 'jacocoGradleAndroidSingleModuleEnable').returns('Single-MOdule Configuration for Android project');
+                sandbox.stub(ccc, 'jacocoGradleAndroidMultiModuleEnable').returns('Single-MOdule Configuration for Android project');
             sandbox.stub(ccc, 'jacocoGradleMultiModuleEnable').returns('Multi-Module Configuration');
             sandbox.stub(ccc, 'jacocoGradleSingleModuleEnable').returns('Single-MOdule Configuration');
             appendTextToFileSync = sandbox.stub(util, 'appendTextToFileSync').callsFake();
@@ -96,6 +98,38 @@ export function jacocogradleccenablerTests() {
                     gradle5xOrHigher: 'true'
                 });
             sandbox.assert.calledOnce(ccc.jacocoGradleSingleModuleEnable);
+            assert.strictEqual(actual, '');
+        });
+        
+        it('should call \'jacocoGradleAndroidSingleModuleEnable\' if project is single-module and android related', async () => {
+            const actual = await jacocoGradleCodeCoverageEnablerInstance.enableCodeCoverage(
+                {
+                    buildfile: fakeData.buildFile,
+                    classfilter: fakeData.classFilter,
+                    classfilesdirectories: fakeData.classDir,
+                    summaryfile: fakeData.summaryFile,
+                    reportdirectory: fakeData.reportDir,
+                    ismultimodule: 'false',
+                    gradle5xOrHigher: 'true',
+                    isAndroidProject: 'true'
+                });
+            sandbox.assert.calledOnce(ccc.jacocoGradleAndroidSingleModuleEnable);
+            assert.strictEqual(actual, '');
+        });
+
+        it('should call \'jacocoGradleAndroidMultiModuleEnable\' if project is multi-module and android related', async () => {
+            const actual = await jacocoGradleCodeCoverageEnablerInstance.enableCodeCoverage(
+                {
+                    buildfile: fakeData.buildFile,
+                    classfilter: fakeData.classFilter,
+                    classfilesdirectories: fakeData.classDir,
+                    summaryfile: fakeData.summaryFile,
+                    reportdirectory: fakeData.reportDir,
+                    ismultimodule: 'true',
+                    gradle5xOrHigher: 'true',
+                    isAndroidProject: 'true'
+                });
+            sandbox.assert.calledOnce(ccc.jacocoGradleAndroidMultiModuleEnable);
             assert.strictEqual(actual, '');
         });
 

--- a/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
+++ b/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
@@ -122,6 +122,87 @@ test {
 }`;
 }
 
+export function jacocoGradleAndroidSingleModuleEnable(
+    excludeFilter: string,
+    includeFilter: string,
+    classFileDirectory: string,
+    reportDir: string,
+    gradle5xOrHigher: boolean
+) {
+    return `
+allprojects {
+    apply plugin: 'jacoco'
+}
+gradle.projectsEvaluated {
+    def jacocoExcludes = [${excludeFilter}]
+    def jacocoIncludes = [${includeFilter}]
+    task jacocoTestReport (type:JacocoReport, dependsOn: 'test') {
+        group = "Reporting"
+        description = "Generates Jacoco coverage report for rootProject."
+        rootProject.tasks.getByName('test').finalizedBy jacocoTestReport
+        
+        ${getFormattedFileCollectionAssignGradle('classDirectories', gradle5xOrHigher)} fileTree(dir: "\${rootProject.buildDir}/${classFileDirectory}",  excludes: jacocoExcludes, includes: jacocoIncludes)
+        ${getFormattedFileCollectionAssignGradle('executionData', gradle5xOrHigher)} fileTree(dir: "\${rootProject.buildDir}/jacoco", includes: ['**/*.exec'])
+        ${getFormattedFileCollectionAssignGradle('sourceDirectories', gradle5xOrHigher)} files("\${rootProject.projectDir}/src/main/java")
+        reports {
+            xml.required  = true
+            xml.outputLocation = file("${reportDir}/summary.xml")
+            html.required  = true
+            html.outputLocation = file("${reportDir}")
+        }
+    }
+}`;
+}
+
+export function jacocoGradleAndroidMultiModuleEnable(
+    excludeFilter: string,
+    includeFilter: string,
+    classFileDirectory: string,
+    reportDir: string,
+    gradle5xOrHigher: boolean
+) {
+    return `
+allprojects {
+    apply plugin: 'jacoco'
+}
+subprojects {
+    apply plugin: 'com.android.application'
+    afterEvaluate {
+        def jacocoExcludes = [${excludeFilter}]
+        def jacocoIncludes = [${includeFilter}]
+        task jacocoTestReport (type:JacocoReport, dependsOn: 'test') {
+            group = "Reporting"
+            description = "Generates Jacoco coverage report for project."
+            project.tasks.getByName('test').finalizedBy jacocoTestReport
+            
+            ${getFormattedFileCollectionAssignGradle('classDirectories', gradle5xOrHigher)} fileTree(dir: "\${project.buildDir}/${classFileDirectory}",  excludes: jacocoExcludes, includes: jacocoIncludes)
+            ${getFormattedFileCollectionAssignGradle('executionData', gradle5xOrHigher)} fileTree(dir: "\${project.buildDir}/outputs/unit_test_code_coverage", includes: ['**/*.exec'])
+            ${getFormattedFileCollectionAssignGradle('sourceDirectories', gradle5xOrHigher)} files("\${project.projectDir}/src/main/java")
+            reports {
+                xml.required  = true
+                xml.outputLocation = file("\${project.buildDir}/jacocoHtml/summary.xml")
+                html.required  = true
+                html.outputLocation = file("\${project.buildDir}/jacocoHtml")
+            }
+        }
+    }
+}
+gradle.projectsEvaluated {
+    task jacocoRootReport(type: JacocoReport, dependsOn: subprojects.test) {
+        group = "Reporting"
+        description = "Generates overall Jacoco coverage report."
+        ${getFormattedFileCollectionAssignGradle('executionData', gradle5xOrHigher)} files(subprojects.jacocoTestReport.executionData)
+        ${getFormattedFileCollectionAssignGradle('sourceDirectories', gradle5xOrHigher)} files(subprojects.jacocoTestReport.sourceDirectories)
+        ${getFormattedFileCollectionAssignGradle('classDirectories', gradle5xOrHigher)} files(subprojects.jacocoTestReport.classDirectories)
+        reports {
+            html.required = true
+            xml.required = true
+            xml.destination file("${reportDir}/summary.xml")
+            html.destination file("${reportDir}")
+        }
+    }
+}`;
+}
 
 // Enable Cobertura Code Coverage for Gradle builds using this props
 export function coberturaGradleSingleModuleEnable(excludeFilter: string, includeFilter: string, classDir: string, sourceDir: string, reportDir: string) {

--- a/common-npm-packages/codecoverage-tools/jacoco/jacoco.gradle.ccenabler.ts
+++ b/common-npm-packages/codecoverage-tools/jacoco/jacoco.gradle.ccenabler.ts
@@ -24,6 +24,7 @@ export class JacocoGradleCodeCoverageEnabler extends cc.JacocoCodeCoverageEnable
         let classFileDirs = ccProps["classfilesdirectories"];
         let reportDir = ccProps["reportdirectory"];
         let gradle5xOrHigher = ccProps["gradle5xOrHigher"] && ccProps["gradle5xOrHigher"] === "true";
+        let isAndroidProject = ccProps["isAndroidProject"] && ccProps["isAndroidProject"] === "true";
         let codeCoveragePluginData = null;
 
         let filter = _this.extractFilters(classFilter);
@@ -31,9 +32,13 @@ export class JacocoGradleCodeCoverageEnabler extends cc.JacocoCodeCoverageEnable
         let jacocoInclude = _this.applyFilterPattern(filter.includeFilter);
 
         if (isMultiModule) {
-            codeCoveragePluginData = ccc.jacocoGradleMultiModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
+            codeCoveragePluginData = isAndroidProject
+                ? ccc.jacocoGradleAndroidMultiModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher)
+                : ccc.jacocoGradleMultiModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
         } else {
-            codeCoveragePluginData = ccc.jacocoGradleSingleModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
+            codeCoveragePluginData = isAndroidProject
+                ? ccc.jacocoGradleAndroidSingleModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher)
+                : ccc.jacocoGradleSingleModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
         }
 
         try {

--- a/common-npm-packages/codecoverage-tools/package-lock.json
+++ b/common-npm-packages/codecoverage-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "3.219.0",
+  "version": "3.222.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/codecoverage-tools/package.json
+++ b/common-npm-packages/codecoverage-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "3.219.0",
+  "version": "3.222.0",
   "author": "Microsoft Corporation",
   "description": "VSTS Tasks Code Coverage Tools",
   "license": "MIT",


### PR DESCRIPTION
**Description:** Need to add support for gradle android projects to enable code coverage by JaCoCo. The changes are required since android projects need different configuration because they are not compatible with java plugin

Change log:

- added android related functions to get correct gradle configuration in codecoverageconstants.ts
- added logic to call the function if it's android project in jacoco.gradle.ccenabler.ts
- covered new logic by unit tests

**Documentation changes required:** (Y/N) I think we need to mention that now we support JaCoCo (only) code coverage reports for Android projects

**Added unit tests:** (Y/N) Y

**Attached related issue:** (Y/N) N

**Checklist:**

- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected