### PR TITLE
Kubelogin only supports pfx format for SP certificate authentication 

### DIFF
--- a/common-npm-packages/kubernetes-common/kubelogin.ts
+++ b/common-npm-packages/kubernetes-common/kubelogin.ts
@@ -3,6 +3,7 @@ import toolRunner = require('azure-pipelines-task-lib/toolrunner');
 
 import fs = require('fs');
 import path = require('path');
+import forge = require('node-forge');
 
 import { IRequestHandler } from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces';
 import { getHandlerFromToken, WebApi } from 'azure-devops-node-api';
@@ -57,28 +58,42 @@ export class Kubelogin {
       await kubectaskLibTool.exec();
     } else if (authScheme.toLowerCase() == 'serviceprincipal') {
       const authType: string = taskLib.getEndpointAuthorizationParameter(connectedService, 'authenticationType', true);
-      let servicePrincipalKey: string = null;
       const servicePrincipalId: string = taskLib.getEndpointAuthorizationParameter(connectedService, 'serviceprincipalid', false);
       const tenantId: string = taskLib.getEndpointAuthorizationParameter(connectedService, 'tenantid', false);
 
       if (authType == 'spnCertificate') {
         taskLib.debug('certificate based endpoint');
-        throw taskLib.loc('AuthSchemeNotSupported', `${authScheme} with a certificate`);
+        let certificateContent: string = taskLib.getEndpointAuthorizationParameter(connectedService, 'servicePrincipalCertificate', false);
+        let certificatePath: string = path.join(taskLib.getVariable('Agent.TempDirectory') || taskLib.getVariable('system.DefaultWorkingDirectory'), 'spnCert.pfx');
+        
+        // kubelogin works only with pfx. Hence converting pem to pfx
+        fs.writeFileSync(certificatePath, Kubelogin.convertToPFX(certificateContent), 'binary');
+
+        const kubectaskLibTool: toolRunner.ToolRunner = taskLib.tool(this.toolPath);
+        kubectaskLibTool.arg('convert-kubeconfig');
+        kubectaskLibTool.arg(['-l', 'spn']);
+        if (taskLib.getVariable('System.Debug')) {
+          kubectaskLibTool.arg(['--v', '20']);
+        }
+        await kubectaskLibTool.exec();
+
+        process.env['AAD_SERVICE_PRINCIPAL_CLIENT_ID'] = servicePrincipalId;
+        process.env['AAD_SERVICE_PRINCIPAL_CLIENT_CERTIFICATE'] = certificatePath;
       } else {
         taskLib.debug('key based endpoint');
-        servicePrincipalKey = taskLib.getEndpointAuthorizationParameter(connectedService, 'serviceprincipalkey', false);
-      }
+        let servicePrincipalKey: string = taskLib.getEndpointAuthorizationParameter(connectedService, 'serviceprincipalkey', false);
 
-      let escapedCliPassword: string = servicePrincipalKey.replace(/"/g, '\\"');
-      taskLib.setSecret(escapedCliPassword.replace(/\\/g, '"'));
-
-      const kubectaskLibTool: toolRunner.ToolRunner = taskLib.tool(this.toolPath);
-      kubectaskLibTool.arg('convert-kubeconfig');
-      kubectaskLibTool.arg(['-l', 'spn', '--client-id', servicePrincipalId, '--client-secret', escapedCliPassword, '--tenant-id', tenantId]);
-      if (taskLib.getVariable('System.Debug')) {
-        kubectaskLibTool.arg(['--v', '20']);
+        let escapedCliPassword: string = servicePrincipalKey.replace(/"/g, '\\"');
+        taskLib.setSecret(escapedCliPassword.replace(/\\/g, '"'));
+  
+        const kubectaskLibTool: toolRunner.ToolRunner = taskLib.tool(this.toolPath);
+        kubectaskLibTool.arg('convert-kubeconfig');
+        kubectaskLibTool.arg(['-l', 'spn', '--client-id', servicePrincipalId, '--client-secret', escapedCliPassword, '--tenant-id', tenantId]);
+        if (taskLib.getVariable('System.Debug')) {
+          kubectaskLibTool.arg(['--v', '20']);
+        }
+        await kubectaskLibTool.exec();
       }
-      await kubectaskLibTool.exec();
     } else if (authScheme.toLowerCase() == 'managedserviceidentity') {
       const kubectaskLibTool: toolRunner.ToolRunner = taskLib.tool(this.toolPath);
       kubectaskLibTool.arg('convert-kubeconfig');
@@ -123,5 +138,25 @@ export class Kubelogin {
     } else {
       taskLib.warning('Could not determine credentials to use');
     }
+  }
+
+  private static convertToPFX(pemBuffer: string) {
+    const parsedData = forge.pem.decode(pemBuffer);
+    let privateKey: forge.pki.PrivateKey;
+    let certificate: forge.pki.Certificate;
+    
+    parsedData.forEach((pemEntry) => {
+        const pem = forge.pem.encode(pemEntry);
+    
+        if (pemEntry.type === 'PRIVATE KEY') {
+          privateKey = forge.pki.privateKeyFromPem(pem);
+        } 
+        else if (pemEntry.type === 'CERTIFICATE') {
+          certificate = forge.pki.certificateFromPem(pem);
+        }
+      });
+
+    const pfx = forge.pkcs12.toPkcs12Asn1(privateKey, [certificate], '', { generateLocalKeyId: true, algorithm: '3des', useMac: true });
+    return forge.asn1.toDer(pfx).getBytes();
   }
 }

--- a/common-npm-packages/kubernetes-common/kubelogin.ts
+++ b/common-npm-packages/kubernetes-common/kubelogin.ts
@@ -63,9 +63,7 @@ export class Kubelogin {
 
       if (authType == 'spnCertificate') {
         taskLib.debug('certificate based endpoint');
-        let certificateContent: string = taskLib.getEndpointAuthorizationParameter(connectedService, 'servicePrincipalCertificate', false);
-        servicePrincipalKey = path.join(taskLib.getVariable('Agent.TempDirectory') || taskLib.getVariable('system.DefaultWorkingDirectory'), 'spnCert.pem');
-        fs.writeFileSync(servicePrincipalKey, certificateContent);
+        throw taskLib.loc('AuthSchemeNotSupported', `${authScheme} with a certificate`);
       } else {
         taskLib.debug('key based endpoint');
         servicePrincipalKey = taskLib.getEndpointAuthorizationParameter(connectedService, 'serviceprincipalkey', false);

--- a/common-npm-packages/kubernetes-common/package-lock.json
+++ b/common-npm-packages/kubernetes-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-kubernetes-common",
-  "version": "2.224.0",
+  "version": "2.224.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/kubernetes-common/package-lock.json
+++ b/common-npm-packages/kubernetes-common/package-lock.json
@@ -30,6 +30,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.0.tgz",
       "integrity": "sha512-wuJwN2KV4tIRz1bu9vq5kSPasJ8IsEjZaP1ZR7KlmdUZvGF/rXy8DmXOVwUD0kAtvtJ7aqMKPqUXC0NUTDbrDg=="
     },
+    "@types/node-forge": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-TzX3ahoi9xbmaoT58smrBu7oa6dQXb/+PTNCslZyD/55tlJ/osofIMClzZsoo6buDFrg7e4DvVGkZqVgv6OLxw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -335,6 +343,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
       "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
+    },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "object-inspect": {
       "version": "1.12.3",

--- a/common-npm-packages/kubernetes-common/package.json
+++ b/common-npm-packages/kubernetes-common/package.json
@@ -13,13 +13,15 @@
     },
     "homepage": "https://github.com/Microsoft/azure-pipelines-tasks-common-packages#readme",
     "dependencies": {
-        "@types/node": "10.17.0",
         "@types/mocha": "5.2.7",
+        "@types/node": "10.17.0",
+        "@types/node-forge": "^1.3.2",
         "@types/uuid": "8.3.0",
         "azure-devops-node-api": "^12.0.0",
         "azure-pipelines-task-lib": "^3.1.0",
         "azure-pipelines-tool-lib": "^1.0.2",
-        "js-yaml": "3.13.1"
+        "js-yaml": "3.13.1",
+        "node-forge": "^1.3.1"
     },
     "devDependencies": {
         "shelljs": "^0.8.5",

--- a/common-npm-packages/kubernetes-common/package.json
+++ b/common-npm-packages/kubernetes-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-kubernetes-common",
-    "version": "2.224.0",
+    "version": "2.224.1",
     "description": "Common Library for Kubernetes",
     "repository": {
         "type": "git",


### PR DESCRIPTION
kubelogin does not support certificates in PEM format for now. There is [a ticket](https://github.com/Azure/kubelogin/issues/169) opened for kubelogin to add support for PEM format . 
I added conversion from pem to pfx using node-forge 