### PR TITLE
[ios-signing-common] - Add arguments for extracting pck12 certificate 

### DIFF
--- a/common-npm-packages/ios-signing-common/Tests/L0GetP12Properties.ts
+++ b/common-npm-packages/ios-signing-common/Tests/L0GetP12Properties.ts
@@ -26,13 +26,15 @@ const stdOuts = [
     { p12Path: 'some1/path1', p12Pwd: 'somepassword', fingerprint: 'BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C', commonName: 'test common name', notBefore: 'Nov 14 03:37:42 2018 GMT', notAfter: 'Nov 14 03:37:42 2019 GMT', error: false },
     { p12Path: 'some2/path2', p12Pwd: 'smpwd', fingerprint: 'BB:26:83:C6:AA:88:35:DE:36:94:F5:CF:37:0A:D4:60:BB:AE:87:0C', commonName: 'another name', notBefore: 'Nov 15 03:37:42 2018 GMT', notAfter: 'Nov 15 03:37:42 2019 GMT', error: false },
     { p12Path: 'some3/path3', p12Pwd: 'somepwd', fingerprint: 'BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:01:D4:60:BB:AE:87:0C', commonName: 'someotheronelinename', notBefore: 'Nov 16 03:37:42 2018 GMT', notAfter: 'Nov 16 03:37:42 2019 GMT', error: false },
+    { p12Path: 'som4/path4', p12Pwd: 'somepwd2', fingerprint: 'BB:26:83:C6:AA:28:65:DE:36:94:F2:CF:37:01:D4:60:BB:AE:87:0C', commonName: 'someothername', notBefore: 'Nov 16 03:37:42 2018 GMT', notAfter: 'Nov 16 03:37:42 2019 GMT', error: false, opensslPkcsArgs: '-testarg' },
     { p12Pwd: 'etst', error: true},
     { p12Pwd: '', error: true}
 ];
 
-const createOpenSSlCommand = (p12Path, p12Pwd, fingerprint, commonName, notBefore, notAfter) => {
+const createOpenSSlCommand = (p12Path, p12Pwd, fingerprint, commonName, notBefore, notAfter, opensslPkcsArgs) => {
+    const args = opensslPkcsArgs ? `${opensslPkcsArgs} ` : ''
     return {
-        command: `${tmAnswers['which']['openssl']} pkcs12 -in ${p12Path} -nokeys -passin pass:${p12Pwd} | ${tmAnswers['which']['openssl']} x509 -sha1 -noout -fingerprint -subject -dates -nameopt utf8,sep_semi_plus_space`,
+        command: `${tmAnswers['which']['openssl']} pkcs12 -in ${p12Path} -nokeys -passin pass:${p12Pwd} ${args}| ${tmAnswers['which']['openssl']} x509 -sha1 -noout -fingerprint -subject -dates -nameopt utf8,sep_semi_plus_space`,
         output: `SHA1 Fingerprint=${fingerprint}${EOL}subject=UID=E848ASUQZY; CN=${commonName}; OU=DJ8T2973U7; O=Chris Sidi; C=US${EOL}notBefore=${notBefore}${EOL}notAfter=${notAfter}`
     }
 }
@@ -60,8 +62,8 @@ export function getP12PropertiesTest() {
     });
 
     for ( let i = 0; i < stdOuts.length; i++) {
-        const { p12Path, p12Pwd, fingerprint, commonName, notBefore, notAfter, error } = stdOuts[i];
-        const { command, output } = createOpenSSlCommand(p12Path, p12Pwd, fingerprint, commonName, notBefore, notAfter);
+        const { p12Path, p12Pwd, fingerprint, commonName, notBefore, notAfter, error, opensslPkcsArgs } = stdOuts[i];
+        const { command, output } = createOpenSSlCommand(p12Path, p12Pwd, fingerprint, commonName, notBefore, notAfter, opensslPkcsArgs);
         tmAnswers['exec'][command] = {
             stdout: output || null,
             code: 0
@@ -72,7 +74,7 @@ export function getP12PropertiesTest() {
             mockery.registerMock('azure-pipelines-task-lib/task', tlClone);
             let iosSigning = require("../ios-signing-common");
             
-            iosSigning.getP12Properties(p12Path, p12Pwd).
+            iosSigning.getP12Properties(p12Path, p12Pwd, opensslPkcsArgs).
                 then(resp => {
                     assert.deepStrictEqual(resp, {
                         fingerprint: fingerprint.replace(/:/g, '').trim(),

--- a/common-npm-packages/ios-signing-common/Tests/L0InstallCertInTemporaryKeychain.ts
+++ b/common-npm-packages/ios-signing-common/Tests/L0InstallCertInTemporaryKeychain.ts
@@ -27,7 +27,7 @@ const stdOuts = [
     { keychainPath: 'keychainPath2', keychainPwd: 'keychainPwd2', p12CertPath: 'p12CertPath2', p12Pwd: 'p12Pwd2', useKeychainIfExists: false, skipPartitionIdAclSetup: true },
     { keychainPath: 'keychainPath3', keychainPwd: 'keychainPwd3', p12CertPath: 'p12CertPath3', p12Pwd: 'p12Pwd3', useKeychainIfExists: true, skipPartitionIdAclSetup: true },
     { keychainPath: 'keychainPath4', keychainPwd: 'keychainPwd4', p12CertPath: 'p12CertPath4', p12Pwd: 'p12Pwd4', useKeychainIfExists: true, skipPartitionIdAclSetup: true },
-    { keychainPath: 'keychainPath5', keychainPwd: 'keychainPwd5', p12CertPath: 'p12CertPath5', p12Pwd: 'p12Pwd5', useKeychainIfExists: true, skipPartitionIdAclSetup: false},
+    { keychainPath: 'keychainPath5', keychainPwd: 'keychainPwd5', p12CertPath: 'p12CertPath5', p12Pwd: 'p12Pwd5', useKeychainIfExists: true, skipPartitionIdAclSetup: false },
     { keychainPath: 'keychainPath6', keychainPwd: 'keychainPwd6', p12CertPath: 'p12CertPath6', p12Pwd: 'p12Pwd6', useKeychainIfExists: true, skipPartitionIdAclSetup: false, opensslPkcsArgs: '-legacy' },
     { keychainPath: 'keychainPath7', keychainPwd: 'keychainPwd7', p12CertPath: 'p12CertPath7', p12Pwd: 'p12Pwd7', useKeychainIfExists: false, skipPartitionIdAclSetup: false },
     { keychainPath: 'keychainPath8', keychainPwd: 'keychainPwd8', p12CertPath: 'p12CertPath8', p12Pwd: 'p12Pwd8', useKeychainIfExists: false, skipPartitionIdAclSetup: false },
@@ -73,7 +73,7 @@ export function installCertInTemporaryKeychainTest() {
     });
 
     for (let i = 0; i < stdOuts.length; i++) {
-        const { keychainPath, keychainPwd, p12CertPath, p12Pwd, useKeychainIfExists, skipPartitionIdAclSetup, opensslPkcsArgs} = stdOuts[i];
+        const { keychainPath, keychainPwd, p12CertPath, p12Pwd, useKeychainIfExists, skipPartitionIdAclSetup, opensslPkcsArgs } = stdOuts[i];
         const paths = createKeychainCommandPaths(stdOuts[i])
 
         tmAnswers['exist'][keychainPath] = true;

--- a/common-npm-packages/ios-signing-common/package-lock.json
+++ b/common-npm-packages/ios-signing-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-ios-signing-common",
-  "version": "2.219.1",
+  "version": "2.225.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/ios-signing-common/package.json
+++ b/common-npm-packages/ios-signing-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-ios-signing-common",
-  "version": "2.219.1",
+  "version": "2.225.0",
   "description": "Azure Pipelines tasks iOS Signing Common",
   "main": "ios-signing-common.js",
   "scripts": {


### PR DESCRIPTION
- Added new inputs to pass arguments for OpenSSL extracting
- Added unit tests for the new logic
Tested with InstallAppleCertificateV2 task

Related issue: https://github.com/microsoft/azure-pipelines-tasks/issues/18560