### PR TITLE
Replace azure-arm-rest-v2 in docker-common

### DIFF
--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.225.0",
+    "version": "2.225.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -154,10 +154,10 @@
                 }
             }
         },
-        "azure-pipelines-tasks-azure-arm-rest-v2": {
+        "azure-pipelines-tasks-azure-arm-rest": {
             "version": "3.224.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.224.0.tgz",
-            "integrity": "sha512-G76zBn1hthbrAdB6AnQbbe9Yh6zLZzv5NBNaBVqMqkb8VvaciqKCLEYAIc2FAdhqy/w7lwqWEPr82dJX59J7aQ==",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.224.0.tgz",
+            "integrity": "sha512-1S77+wBJIBA97ioWpMlVf/9WHCMcTN7zNzI70LM2Gub24c/CNi6C+9wXTHPMCrt8o2IlylBI/UeVB+oWG8U/hQ==",
             "requires": {
                 "@azure/msal-node": "1.14.5",
                 "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.225.0",
+    "version": "2.225.1",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",
@@ -18,7 +18,7 @@
         "@types/q": "1.5.4",
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^3.1.0",
-        "azure-pipelines-tasks-azure-arm-rest-v2": "^3.224.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.224.0",
         "del": "2.2.0",
         "q": "1.4.1"
     },

--- a/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
@@ -1,9 +1,9 @@
 "use strict";
 
 import Q = require('q');
-import { ApplicationTokenCredentials } from "azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-common";
-import { AzureRMEndpoint } from "azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint";
-import * as webClient from "azure-pipelines-tasks-azure-arm-rest-v2/webClient";
+import { ApplicationTokenCredentials } from "azure-pipelines-tasks-azure-arm-rest/azure-arm-common";
+import { AzureRMEndpoint } from "azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint";
+import * as webClient from "azure-pipelines-tasks-azure-arm-rest/webClient";
 import * as tl from "azure-pipelines-task-lib/task";
 import AuthenticationTokenProvider from "./authenticationtokenprovider";
 import RegistryAuthenticationToken from "./registryauthenticationtoken";


### PR DESCRIPTION
Replaced `azure-arm-rest-v2@3.224.0` with `azure-arm-rest@3.224.0` in docker-common package.

We moved the source code of the `azure-arm-rest-v2`  from the [tasks](https://github.com/microsoft/azure-pipelines-tasks/tree/master/common-npm-packages) repository to azure-pipelines-tasks-common-packages [repository](https://github.com/microsoft/azure-pipelines-tasks-common-packages/tree/main/common-npm-packages).

During migration, we get rid of redundant -v2/-v3 folders. So `azure-arm-rest-v2` will be deprecated (see details:  [MIGRATION_OF_COMMON_PACKAGES.md](https://github.com/microsoft/azure-pipelines-tasks/blob/master/common-npm-packages/MIGRATION_OF_COMMON_PACKAGES.md))

- [x] The package version was bumped: 
"2.225.0" =>  "2.225.1"
