### PR TITLE
Xml Variable Specification

### DIFF
--- a/common-npm-packages/webdeployment-common/xmlvariablesubstitutionutility.ts
+++ b/common-npm-packages/webdeployment-common/xmlvariablesubstitutionutility.ts
@@ -269,6 +269,15 @@ function updateXmlConnectionStringsNodeAttribute(xmlDomNode, variableMap, replac
                 replacableTokenValues[ConfigFileConnStringTokenName] = variableMap[connectionStringName].replace(/"/g, "'");
                 isSubstitutionApplied = true;
             }
+            else if (connectionStringName && variableMap["connectionStrings.".concat(xmlDomNode.getAttribute("name"))])
+            {
+                let configFileMatch = variableMap["connectionStrings.".concat(xmlDomNode.getAttribute("name"))];
+                let ConfigFileConnStringTokenName = ConfigFileConnStringToken + '(' + configFileMatch + ')';
+                tl.debug(tl.loc('SubstitutingConnectionStringValue' , connectionStringName , ConfigFileConnStringTokenName));
+                xmlDomNode.setAttribute("connectionString", ConfigFileConnStringTokenName);
+                replacableTokenValues[ConfigFileConnStringTokenName] = variableMap[configFileMatch].replace(/"/g, "'");
+                isSubstitutionApplied = true;
+            }
             else if(variableMap["connectionString"] != undefined) {
                 let ConfigFileConnStringTokenName = ConfigFileConnStringToken + '(connectionString)';
                 tl.debug(tl.loc('SubstitutingConnectionStringValue' , connectionStringName , ConfigFileConnStringTokenName));

--- a/common-npm-packages/webdeployment-common/xmlvariablesubstitutionutility.ts
+++ b/common-npm-packages/webdeployment-common/xmlvariablesubstitutionutility.ts
@@ -207,8 +207,15 @@ function updateXmlNodeAttribute(xmlDomNode, variableMap, replacableTokenValues):
             let attribute = xmlDomNodeAttributes[i];
             let attributeNameValue = (attribute.nodeName === "key" || attribute.nodeName == "name") ? attribute.nodeValue : attribute.nodeName;
             let attributeName = (attribute.nodeName === "key" || attribute.nodeName == "name") ? "value" : attribute.nodeName;
+            let absoluteAttributeNameValue = attributeNameValue;
+            for(let j = xmlDomNode; j.parentNode.nodeName != "configuration"; j = j.parentNode) {
+                absoluteAttributeNameValue = j.parentNode.nodeName + "." + absoluteAttributeNameValue;
+            }
 
-            if(variableMap[attributeNameValue] != undefined) {
+            if(variableMap[attributeNameValue] != undefined || variableMap[absoluteAttributeNameValue] != undefined) {
+                if (variableMap[absoluteAttributeNameValue] != undefined) {
+                    attributeNameValue = absoluteAttributenameValue;
+                }
                 let ConfigFileAppSettingsTokenName = ConfigFileAppSettingsToken + '(' + attributeNameValue + ')';
                 let isValueReplaced: boolean = false;
                 if (xmlDomNode.hasAttribute(attributeName)) {


### PR DESCRIPTION
Updated Xml file variable replacement to allow absolute variable specification, fixing a variable collision issue where a connection string and an app setting with the same name could not be updated using pipeline variables in FileTransformV2.

Additional information about this issue can be found in [microsoft/azure-devops-yaml-schema#209](https://github.com/MicrosoftDocs/azure-devops-yaml-schema/issues/209)

Variables can now use dot syntax to specify which setting to update.

appSettings.var1 will update var1 in appSettings
connectionStrings.var1 will update var1 in connectionStrings

Variables will still behave as used previously unless the more precise one is given.
