### PR TITLE
[codeanalysis-common] Resolve CVE-2023-0842 in xml2js 0.4.19

### DIFF
--- a/common-npm-packages/codeanalysis-common/Tests/BuildOutputTests.ts
+++ b/common-npm-packages/codeanalysis-common/Tests/BuildOutputTests.ts
@@ -5,9 +5,7 @@ import * as path from 'path';
 import * as rewire from 'rewire';
 import * as sinon from 'sinon';
 import * as tl from 'azure-pipelines-task-lib/task';
-import { ModuleOutput } from '../Common/ModuleOutput';
 import { flattenObject } from './Helpers/flattenObject';
-import { getMaxListeners } from 'process';
 import { BuildEngine } from '../Common/BuildOutput';
 
 const buildOutputRewired = rewire('../Common/BuildOutput');

--- a/common-npm-packages/codeanalysis-common/Tests/CheckstyleToolTests.ts
+++ b/common-npm-packages/codeanalysis-common/Tests/CheckstyleToolTests.ts
@@ -6,7 +6,6 @@ import * as sinon from 'sinon';
 import * as tl from 'azure-pipelines-task-lib/task';
 
 import { BuildEngine, BuildOutput } from '../Common/BuildOutput';
-import { SSL_OP_NETSCAPE_CHALLENGE_BUG } from 'constants';
 
 export function CheckstyleToolTests() {
     const sandbox = sinon.createSandbox();

--- a/common-npm-packages/codeanalysis-common/package-lock.json
+++ b/common-npm-packages/codeanalysis-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-codeanalysis-common",
-    "version": "2.223.0",
+    "version": "2.226.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -308,11 +308,6 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
         },
-        "boolbase": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-        },
         "brace-expansion": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -381,32 +376,6 @@
                         "has-flag": "^4.0.0"
                     }
                 }
-            }
-        },
-        "cheerio": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
-            "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
-            "requires": {
-                "cheerio-select": "^1.5.0",
-                "dom-serializer": "^1.3.2",
-                "domhandler": "^4.2.0",
-                "htmlparser2": "^6.1.0",
-                "parse5": "^6.0.1",
-                "parse5-htmlparser2-tree-adapter": "^6.0.1",
-                "tslib": "^2.2.0"
-            }
-        },
-        "cheerio-select": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
-            "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
-            "requires": {
-                "css-select": "^4.1.3",
-                "css-what": "^5.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0",
-                "domutils": "^2.7.0"
             }
         },
         "chokidar": {
@@ -486,23 +455,6 @@
                 "which": "^2.0.1"
             }
         },
-        "css-select": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
-            "integrity": "sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==",
-            "requires": {
-                "boolbase": "^1.0.0",
-                "css-what": "^5.1.0",
-                "domhandler": "^4.3.0",
-                "domutils": "^2.8.0",
-                "nth-check": "^2.0.1"
-            }
-        },
-        "css-what": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
-            "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw=="
-        },
         "debug": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -546,39 +498,6 @@
                 "esutils": "^2.0.2"
             }
         },
-        "dom-serializer": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-            "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-            "requires": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
-            }
-        },
-        "domelementtype": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
-        },
-        "domhandler": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
-            "integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
-            "requires": {
-                "domelementtype": "^2.2.0"
-            }
-        },
-        "domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-            "requires": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
-            }
-        },
         "emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -591,11 +510,6 @@
             "requires": {
                 "ansi-colors": "^4.1.1"
             }
-        },
-        "entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         },
         "escalade": {
             "version": "3.1.1",
@@ -672,9 +586,9 @@
                     }
                 },
                 "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -872,18 +786,6 @@
                 "mime-types": "^2.1.12"
             }
         },
-        "fs-extra": {
-            "version": "0.30.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-            "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^2.1.0",
-                "klaw": "^1.0.0",
-                "path-is-absolute": "^1.0.0",
-                "rimraf": "^2.2.8"
-            }
-        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -954,11 +856,6 @@
                 "type-fest": "^0.20.2"
             }
         },
-        "graceful-fs": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-        },
         "growl": {
             "version": "1.10.5",
             "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -986,17 +883,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
-        },
-        "htmlparser2": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-            "requires": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.0.0",
-                "domutils": "^2.5.2",
-                "entities": "^2.0.0"
-            }
         },
         "http-basic": {
             "version": "8.1.3",
@@ -1132,26 +1018,10 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
         },
-        "jsonfile": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-            "requires": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
         "just-extend": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
             "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
-        },
-        "klaw": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-            "requires": {
-                "graceful-fs": "^4.1.9"
-            }
         },
         "levn": {
             "version": "0.4.1",
@@ -1324,14 +1194,6 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
-        "nth-check": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
-            "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
-            "requires": {
-                "boolbase": "^1.0.0"
-            }
-        },
         "object-inspect": {
             "version": "1.12.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -1357,11 +1219,6 @@
                 "type-check": "^0.4.0",
                 "word-wrap": "^1.2.3"
             }
-        },
-        "os": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-            "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
         },
         "p-limit": {
             "version": "3.1.0",
@@ -1391,19 +1248,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
             "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
-        },
-        "parse5": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
-        },
-        "parse5-htmlparser2-tree-adapter": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-            "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-            "requires": {
-                "parse5": "^6.0.1"
-            }
         },
         "path-exists": {
             "version": "4.0.0",
@@ -1562,14 +1406,6 @@
                 "eslint": "^7.32.0"
             }
         },
-        "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-            "requires": {
-                "glob": "^7.0.5"
-            }
-        },
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -1578,7 +1414,7 @@
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
             "version": "5.7.1",
@@ -1690,11 +1526,6 @@
                 "ansi-regex": "^5.0.1"
             }
         },
-        "strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-        },
         "strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -1799,11 +1630,6 @@
                 "is-number": "^7.0.0"
             }
         },
-        "tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
         "type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1902,9 +1728,9 @@
             }
         },
         "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
         },
         "workerpool": {
             "version": "6.1.0",
@@ -1927,18 +1753,18 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "xml2js": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
             "requires": {
                 "sax": ">=0.6.0",
-                "xmlbuilder": "~9.0.1"
+                "xmlbuilder": "~11.0.0"
             }
         },
         "xmlbuilder": {
-            "version": "9.0.6",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.6.tgz",
-            "integrity": "sha1-fIJtjYb0eISwWHLL6dJ7Ab7VA/Y="
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
         },
         "y18n": {
             "version": "5.0.8",

--- a/common-npm-packages/codeanalysis-common/package.json
+++ b/common-npm-packages/codeanalysis-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codeanalysis-common",
-  "version": "2.223.0",
+  "version": "2.226.0",
   "author": "Microsoft Corporation",
   "description": "Build with Gradle",
   "license": "MIT",
@@ -10,15 +10,11 @@
   "dependencies": {
     "@types/node": "^10.17.0",
     "azure-pipelines-task-lib": "^3.1.0",
-    "cheerio": "1.0.0-rc.10",
-    "fs-extra": "^0.30.0",
     "glob": "7.1.0",
     "mocha": "^8.4.0",
-    "os": "^0.1.1",
     "rewire": "^6.0.0",
     "sinon": "^14.0.0",
-    "strip-bom": "^3.0.0",
-    "xml2js": "^0.4.17"
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.6",


### PR DESCRIPTION
This PR fixes https://github.com/advisories/GHSA-776f-qx25-q3cc in `codeanalysis-common` package.

**Description:**
`xml2js` versions before `0.5.0` allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the `__proto__` property to be edited.

**What was changed:**
- `xml2js` bumped from `^0.4.17` to `^0.6.2`

Unused dependencies removed:
- "cheerio": "1.0.0-rc.10"
- "fs-extra": "^0.30.0"
- "os": "^0.1.1"
- "strip-bom": "^3.0.0"

**How it was tested:**
Local build & tests
Build & tests in CI