### PR TITLE
[codecoverage-tools] Resolve CVE-2023-0842 in xml2js 0.4.19

### DIFF
--- a/common-npm-packages/codecoverage-tools/package-lock.json
+++ b/common-npm-packages/codecoverage-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "3.219.0",
+  "version": "3.226.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -681,9 +681,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -1665,11 +1665,6 @@
         "ansi-regex": "^5.0.1"
       }
     },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -1872,9 +1867,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
     },
     "workerpool": {
       "version": "6.1.0",
@@ -1897,18 +1892,18 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.6.tgz",
-      "integrity": "sha1-fIJtjYb0eISwWHLL6dJ7Ab7VA/Y="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/common-npm-packages/codecoverage-tools/package-lock.json
+++ b/common-npm-packages/codecoverage-tools/package-lock.json
@@ -1665,6 +1665,11 @@
         "ansi-regex": "^5.0.1"
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",

--- a/common-npm-packages/codecoverage-tools/package.json
+++ b/common-npm-packages/codecoverage-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "3.219.0",
+  "version": "3.226.0",
   "author": "Microsoft Corporation",
   "description": "VSTS Tasks Code Coverage Tools",
   "license": "MIT",
@@ -18,8 +18,7 @@
     "os": "^0.1.1",
     "rewire": "^6.0.0",
     "sinon": "^14.0.0",
-    "strip-bom": "^3.0.0",
-    "xml2js": "^0.4.17"
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.6",

--- a/common-npm-packages/codecoverage-tools/package.json
+++ b/common-npm-packages/codecoverage-tools/package.json
@@ -18,6 +18,7 @@
     "os": "^0.1.1",
     "rewire": "^6.0.0",
     "sinon": "^14.0.0",
+    "strip-bom": "^3.0.0",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR fixes https://github.com/advisories/GHSA-776f-qx25-q3cc in `codecoverage-tools` package.

**Description:**
`xml2js` versions before `0.5.0` allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the `__proto__` property to be edited.

**What was changed:**
- `xml2js` bumped from `^0.4.17` to `^0.6.2`

**How it was tested:**
Local build & tests
Build & tests in CI