### PR TITLE
[webdeployment-common] Resolve CVE-2023-0842 in xml2js 0.4.19

### DIFF
--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.225.0",
+    "version": "4.226.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -625,9 +625,9 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         },
         "shelljs": {
             "version": "0.8.5",
@@ -779,18 +779,18 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "xml2js": {
-            "version": "0.4.13",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.13.tgz",
-            "integrity": "sha1-+EQ+B0Oeb/ktmVKPSbvTScyfMGs=",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
             "requires": {
                 "sax": ">=0.6.0",
-                "xmlbuilder": ">=2.4.6"
+                "xmlbuilder": "~11.0.0"
             }
         },
         "xmlbuilder": {
-            "version": "15.1.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
-            "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
         },
         "xtend": {
             "version": "4.0.2",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.225.0",
+    "version": "4.226.0",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",
@@ -25,7 +25,7 @@
         "ltx": "2.8.0",
         "q": "1.4.1",
         "winreg": "1.2.2",
-        "xml2js": "0.4.13"
+        "xml2js": "^0.6.2"
     },
     "devDependencies": {
         "typescript": "4.0.2"

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -25,7 +25,7 @@
         "ltx": "2.8.0",
         "q": "1.4.1",
         "winreg": "1.2.2",
-        "xml2js": "^0.6.2"
+        "xml2js": "0.6.2"
     },
     "devDependencies": {
         "typescript": "4.0.2"


### PR DESCRIPTION
This PR fixes https://github.com/advisories/GHSA-776f-qx25-q3cc in `webdeployment-common` package.

**Description:**
`xml2js` versions before `0.5.0` allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the `__proto__` property to be edited.

**What was changed:**
- `xml2js` bumped from `0.4.13` to `0.6.2`

**How it was tested:**
Local build & tests
Build & tests in CI