### PR TITLE
[docker-common] Resolve CVE-2023-0842 in xml2js 0.4.19

### DIFF
--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.225.1",
+    "version": "2.226.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -155,9 +155,9 @@
             }
         },
         "azure-pipelines-tasks-azure-arm-rest": {
-            "version": "3.224.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.224.0.tgz",
-            "integrity": "sha512-1S77+wBJIBA97ioWpMlVf/9WHCMcTN7zNzI70LM2Gub24c/CNi6C+9wXTHPMCrt8o2IlylBI/UeVB+oWG8U/hQ==",
+            "version": "3.226.0",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.226.0.tgz",
+            "integrity": "sha512-yHibJejhY8GL+sN/zvrjLkcGzHE6QT9FX6LXNZkBd1dcn0MEBKdgGEM5I841Yaj7RxY+EhSfUJSpBCaJrlfkSQ==",
             "requires": {
                 "@azure/msal-node": "1.14.5",
                 "@types/jsonwebtoken": "^8.5.8",
@@ -172,7 +172,7 @@
                 "node-fetch": "^2.6.7",
                 "q": "1.5.1",
                 "typed-rest-client": "1.8.4",
-                "xml2js": "0.4.13"
+                "xml2js": "0.6.2"
             },
             "dependencies": {
                 "q": {
@@ -548,9 +548,9 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node-fetch": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-            "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+            "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
             "requires": {
                 "whatwg-url": "^5.0.0"
             }
@@ -804,9 +804,9 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+            "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         },
         "tunnel": {
             "version": "0.0.6",
@@ -869,18 +869,18 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "xml2js": {
-            "version": "0.4.13",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.13.tgz",
-            "integrity": "sha512-BoxD65qWA2p4znzbaati/Td19uFEc0X6ydj0bFphJO62RrNaGqOyW6ljLWPo3GKDbvW/6dnxAoRX01BsgEWsMA==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
             "requires": {
                 "sax": ">=0.6.0",
-                "xmlbuilder": ">=2.4.6"
+                "xmlbuilder": "~11.0.0"
             }
         },
         "xmlbuilder": {
-            "version": "15.1.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
-            "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
         }
     }
 }

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.225.1",
+    "version": "2.226.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",
@@ -18,7 +18,7 @@
         "@types/q": "1.5.4",
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^3.1.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.224.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.226.0",
         "del": "2.2.0",
         "q": "1.4.1"
     },


### PR DESCRIPTION
This PR fixes https://github.com/advisories/GHSA-776f-qx25-q3cc in `docker-common` package.

**Description:**
`xml2js` versions before `0.5.0` allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the `__proto__` property to be edited.

**What was changed:**
- `azure-pipelines-tasks-azure-arm-rest` bumped from `3.224.0` to `3.226.0`

**How it was tested:**
Local build & tests
Build & tests in CI