### PR TITLE
[ios-signing-common] - Add error class for openssl errors

### DIFF
--- a/common-npm-packages/ios-signing-common/errors/OpenSSlError.ts
+++ b/common-npm-packages/ios-signing-common/errors/OpenSSlError.ts
@@ -1,0 +1,6 @@
+export class OpenSSlError extends Error{
+    constructor(message: string){
+        super(message);
+        Object.setPrototypeOf(this, OpenSSlError.prototype);
+    }
+}

--- a/common-npm-packages/ios-signing-common/package-lock.json
+++ b/common-npm-packages/ios-signing-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-ios-signing-common",
-  "version": "2.225.0",
+  "version": "2.227.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/ios-signing-common/package.json
+++ b/common-npm-packages/ios-signing-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-ios-signing-common",
-  "version": "2.225.0",
+  "version": "2.227.0",
   "description": "Azure Pipelines tasks iOS Signing Common",
   "main": "ios-signing-common.js",
   "scripts": {


### PR DESCRIPTION
- Added a new error class for openssl errors. 
This will allow us to catch openssl errors and handle them in a more graceful way.