### PR TITLE
[webdeployment-common] - Fix all arguments must begin with "-" in msdeploy

### DIFF
--- a/common-npm-packages/webdeployment-common/deployusingmsdeploy.ts
+++ b/common-npm-packages/webdeployment-common/deployusingmsdeploy.ts
@@ -174,8 +174,9 @@ async function executeMSDeploy(msDeployCmdArgs) {
         for(var i = 0 ; i < msDeployCmdArgs.length ; i++ ) {
             tl.debug("arg#" + i + ": " + msDeployCmdArgs[i]);
         }
-        // for windowsVerbatimArguments: false see https://github.com/microsoft/azure-pipelines-tasks/issues/17634
-        await tl.exec("msdeploy", msDeployCmdArgs, <any>{failOnStdErr: true, errStream: errObj, windowsVerbatimArguments: false});
+        // set shell: true because C:\Program Files\IIS\Microsoft Web Deploy V3\msdeploy.exe has folder with spaces 
+        // see https://github.com/microsoft/azure-pipelines-tasks/issues/17634
+        await tl.exec("msdeploy", msDeployCmdArgs, <any>{failOnStdErr: true, errStream: errObj, windowsVerbatimArguments: true, shell: true});
         deferred.resolve("Azure App service successfully deployed");
     } catch (error) {
         msDeployError = error;

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.226.0",
+    "version": "4.227.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.226.0",
+    "version": "4.227.0",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Fix the "Unrecognized argument" for the ms-deploy on Node16. The fix also works fine for node 10
shell true allows us to use spaces in the folder names for node10 and node16

- Added shell:true option to exec command
- Restored windowsVerbatimArguments option to true