### PR TITLE
Add jacocoGradleSingleModuleEnableV2

### DIFF
--- a/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
+++ b/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
@@ -122,6 +122,48 @@ test {
 }`;
 }
 
+export function jacocoGradleSingleModuleEnableV2(
+    excludeFilter: string,
+    includeFilter: string,
+    classFileDirectory: string,
+    reportDir: string,
+    gradle5xOrHigher: boolean
+) {
+    return `
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+
+    apply plugin: 'jacoco'
+}
+
+def jacocoExcludes = [${excludeFilter}]
+def jacocoIncludes = [${includeFilter}]
+
+jacocoTestReport {
+    afterEvaluate {
+        classDirectories.setFrom files(
+            fileTree(dir: "${classFileDirectory}", exclude: jacocoExcludes, include: jacocoIncludes)
+        )
+    }
+
+    reports {
+        html.enabled = true
+        xml.enabled = true
+        xml.destination file("${reportDir}/summary.xml")
+        html.destination file("${reportDir}")
+    }
+}
+
+test {
+    finalizedBy jacocoTestReport
+    jacoco {
+        destinationFile = file("${reportDir}/jacoco.exec")
+    }
+}`;
+}
+
 
 // Enable Cobertura Code Coverage for Gradle builds using this props
 export function coberturaGradleSingleModuleEnable(excludeFilter: string, includeFilter: string, classDir: string, sourceDir: string, reportDir: string) {

--- a/common-npm-packages/codecoverage-tools/jacoco/jacoco.gradle.ccenabler.ts
+++ b/common-npm-packages/codecoverage-tools/jacoco/jacoco.gradle.ccenabler.ts
@@ -25,6 +25,7 @@ export class JacocoGradleCodeCoverageEnabler extends cc.JacocoCodeCoverageEnable
         let reportDir = ccProps["reportdirectory"];
         let gradle5xOrHigher = ccProps["gradle5xOrHigher"] && ccProps["gradle5xOrHigher"] === "true";
         let codeCoveragePluginData = null;
+        let useJacocoGradleTemplateV2 = ccProps["useJacocoGradleTemplateV2"] && ccProps["useJacocoGradleTemplateV2"] === "true";
 
         let filter = _this.extractFilters(classFilter);
         let jacocoExclude = _this.applyFilterPattern(filter.excludeFilter);
@@ -33,7 +34,11 @@ export class JacocoGradleCodeCoverageEnabler extends cc.JacocoCodeCoverageEnable
         if (isMultiModule) {
             codeCoveragePluginData = ccc.jacocoGradleMultiModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
         } else {
-            codeCoveragePluginData = ccc.jacocoGradleSingleModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
+            if (useJacocoGradleTemplateV2) {
+                codeCoveragePluginData = ccc.jacocoGradleSingleModuleEnableV2(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
+            } else {
+                codeCoveragePluginData = ccc.jacocoGradleSingleModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
+            }
         }
 
         try {

--- a/common-npm-packages/codecoverage-tools/package-lock.json
+++ b/common-npm-packages/codecoverage-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "3.226.0",
+  "version": "3.227.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/codecoverage-tools/package.json
+++ b/common-npm-packages/codecoverage-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "3.226.0",
+  "version": "3.227.0",
   "author": "Microsoft Corporation",
   "description": "VSTS Tasks Code Coverage Tools",
   "license": "MIT",


### PR DESCRIPTION
Gradle task is failing when using gradle 6.x and higher with the error message:

```
* What went wrong:
Execution failed for task ':jacocoTestReport'.
>  The value for this file collection is final and cannot be changed.
```

The reason is that we update build.gradle file with the following line:

// build.gradle
classDirectories.setFrom fileTree(dir: "build/classes/java/main/").exclude(jacocoExcludes).include(jacocoIncludes)

In Gradle 6.x and later, classDirectories is read-only.
[JacocoReport - Gradle DSL Version 7.6.1](https://docs.gradle.org/7.6.1/dsl/org.gradle.testing.jacoco.tasks.JacocoReport.html#org.gradle.testing.jacoco.tasks.JacocoReport:classDirectories)

In Gradle 5.x, it was possible to write values to classDirectories, so the problem did not occur.
[JacocoReport - Gradle DSL Version 5.6.4](https://docs.gradle.org/5.6.4/dsl/org.gradle.testing.jacoco.tasks.JacocoReport.html#org.gradle.testing.jacoco.tasks.JacocoReport:classDirectories)

Trying to resolve this issue by updating the related template.

