### PR TITLE
UniversalPackageV0 latest version fix

### DIFF
--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.221.1",
+    "version": "3.226.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.221.1",
+    "version": "3.226.0",
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",

--- a/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
+++ b/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
@@ -175,5 +175,5 @@ export async function getHighestPackageVersionFromFeed(serviceUri: string, acces
         }
     }
     
-    return null;
+    return "0.0.0";
 }


### PR DESCRIPTION
This PR contains changes to return a correct package version when publishing a upack with a new unique name, that is similar to an existing name