### PR TITLE
Fix finding latest version of new package

### DIFF
--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.221.1",
+    "version": "3.226.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.221.1",
+    "version": "3.226.0",
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",

--- a/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
+++ b/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
@@ -175,5 +175,5 @@ export async function getHighestPackageVersionFromFeed(serviceUri: string, acces
         }
     }
     
-    return null;
+    return "0.0.0";
 }

--- a/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
+++ b/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
@@ -144,6 +144,9 @@ export async function getPackageNameFromId(serviceUri: string, accessToken: stri
     }
 }
 
+/**
+ * Returns the highest package version from a Feed for a given package. If no versions for this package name exist, we will return highest version of 0.0.0
+ */
 export async function getHighestPackageVersionFromFeed(serviceUri: string, accessToken: string, projectId: string, feedId: string, packageName: string): Promise<string> {
     const ApiVersion = "3.0-preview.1";
     const PackagingAreaName = "Packaging";


### PR DESCRIPTION
This PR contains changes to return a correct package version (0.0.0) when publishing a upack with a new unique name