### PR TITLE
Ticket: 412054808, to fix error related to KuduStackTraceURL

### DIFF
--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
@@ -117,6 +117,7 @@
   "loc.messages.FailedToUpdateAppServiceApplicationSettings": "Failed to update App service '%s' application settings. Error: %s",
   "loc.messages.FailedToUpdateAppServiceConnectionStrings": "Failed to update App service '%s' Connection Strings. Error: %s",
   "loc.messages.KuduSCMDetailsAreEmpty": "KUDU SCM details are empty",
+  "loc.messages.KuduStackTraceURL": "To debug further please check Kudu stack trace URL : %s",
   "loc.messages.FailedToGetContinuousWebJobs": "Failed to get continuous WebJobs. Error: %s",
   "loc.messages.FailedToStartContinuousWebJob": "Failed to start continuous WebJob '%s'. Error: %s",
   "loc.messages.FailedToStopContinuousWebJob": "Failed to stop continuous WebJob '%s'. Error: %s",

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.226.0",
+  "version": "3.228.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.226.0",
+  "version": "3.228.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding back in the missing KuduStackTraceURL

This resolves this issue for the Azure Functions App Tasks.

##[warning]Can't find loc string for key: KuduStackTraceURL for the AzureFunctionsTasks.
This appears to be the only loc String issue for the Function Apps tasks. 

WarningMessage | TaskVersion | count_
-- | -- | --
Can't find loc string for key: KuduStackTraceURL | 1.223.1 | 2106
Can't find loc string for key: KuduStackTraceURL | 1.225.0 | 8419
Can't find loc string for key: KuduStackTraceURL | 1.225.2 | 944
Can't find loc string for key: KuduStackTraceURL | 2.223.1 | 623
Can't find loc string for key: KuduStackTraceURL | 2.224.0 | 2189
Can't find loc string for key: KuduStackTraceURL | 2.225.1 | 236



