### PR TITLE
Specify max buffer size when spawning a new process

### DIFF
--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.226.0",
+    "version": "3.229.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.226.0",
+    "version": "3.229.0",
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",

--- a/common-npm-packages/packaging-common/universal/ArtifactToolRunner.ts
+++ b/common-npm-packages/packaging-common/universal/ArtifactToolRunner.ts
@@ -50,7 +50,9 @@ export function runArtifactTool(artifactToolPath: string, command: string[], exe
             execOptions.outStream.write(getCommandString(artifactToolPath, command) + os.EOL);
         }
 
-        let result = child.spawnSync(artifactToolPath, command, execOptions);
+        const spawnOptions = { ...execOptions, maxBuffer: 1024 * 1024 * 1024 };
+
+        let result = child.spawnSync(artifactToolPath, command, spawnOptions);
 
         if (!execOptions.silent && result.stdout && result.stdout.length > 0) {
             execOptions.outStream.write(result.stdout);

--- a/common-npm-packages/packaging-common/universal/ClientToolRunner.ts
+++ b/common-npm-packages/packaging-common/universal/ClientToolRunner.ts
@@ -38,7 +38,9 @@ export function runClientTool(clientToolPath: string, command: string[], execOpt
             execOptions.outStream.write(getCommandString(clientToolPath, command) + os.EOL);
         }
 
-        let result = child.spawnSync(clientToolPath, command, execOptions);
+        const spawnOptions = { ...execOptions, maxBuffer: 1024 * 1024 * 1024 };
+
+        let result = child.spawnSync(clientToolPath, command, spawnOptions);
 
         if (!execOptions.silent && result.stdout && result.stdout.length > 0) {
             execOptions.outStream.write(result.stdout);


### PR DESCRIPTION
The max buffer size was limited in Node 16. We have to increase it manually, like we did in the task-lib https://github.com/microsoft/azure-pipelines-task-lib/pull/873

