### PR TITLE
ARM rest: Expose isSitePublishingCredentialsEnabled

### DIFF
--- a/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.d.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.d.ts
@@ -22,7 +22,7 @@ export declare class Kudu {
     getProcess(processID: number): Promise<any>;
     killProcess(processID: number): Promise<void>;
     getAppSettings(): Promise<Map<string, string>>;
-    listDir(physicalPath: string): Promise<void>;
+    listDir(physicalPath: string): Promise<any>;
     getFileContent(physicalPath: string, fileName: string): Promise<string>;
     uploadFile(physicalPath: string, fileName: string, filePath: string): Promise<void>;
     createPath(physicalPath: string): Promise<any>;

--- a/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
@@ -291,7 +291,7 @@ export class Kudu {
         }
     }
 
-    public async listDir(physicalPath: string): Promise<void> {
+    public async listDir(physicalPath: string): Promise<any> {
         physicalPath = physicalPath.replace(/[\\]/g, "/");
         physicalPath = physicalPath[0] == "/" ? physicalPath.slice(1): physicalPath;
         var httpRequest = new webClient.WebRequest();

--- a/common-npm-packages/azure-arm-rest/azureAppServiceUtility.d.ts
+++ b/common-npm-packages/azure-arm-rest/azureAppServiceUtility.d.ts
@@ -11,5 +11,6 @@ export declare class AzureAppServiceUtility {
     updateAndMonitorAppSettings(addProperties?: any, deleteProperties?: any, formatJSON?: boolean): Promise<boolean>;
     enableRenameLockedFiles(): Promise<void>;
     updateStartupCommandAndRuntimeStack(runtimeStack: string, startupCommand?: string): Promise<void>;
+    isSitePublishingCredentialsEnabled(): Promise<boolean>;
     isFunctionAppOnCentauri(): Promise<boolean>;
 }

--- a/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
+++ b/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
@@ -242,11 +242,11 @@ export class AzureAppServiceUtility {
             let scmAuthPolicy: any = await this._appService.getSitePublishingCredentialPolicies();
             tl.debug(`Site Publishing Policy check: ${JSON.stringify(scmAuthPolicy)}`);
             if (scmAuthPolicy && scmAuthPolicy.properties.allow) {
-                tl.debug("Function App does allow SCM access");
+                tl.debug("Web App does allow SCM access");
                 return true;
             }
             else {
-                tl.debug("Function App does not allow SCM Access");
+                tl.debug("Web App does not allow SCM Access");
                 return false;
             }
         }

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.229.0",
+  "version": "3.229.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.229.0",
+  "version": "3.229.1",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`AzureAppServiceUtility.isSitePublishingCredentialsEnabled` was defined as pubic but it was missing in declaration file so that was not possible to use it by consumers of this npm package. This PR exposes that function and fixes two other tiny issues.