### PR TITLE
Token authentication in MSDeploy

### DIFF
--- a/common-npm-packages/webdeployment-common/Tests/L0MSDeployUtility.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0MSDeployUtility.ts
@@ -32,6 +32,18 @@ else {
     throw new Error('MSBUILD PACKAGE DEFAULT PARAMS FAILED');
 }
 
+var tokenAuthMSBuildPackageArgument: string = msdeployUtility.getMSDeployCmdArgs('package.zip', 'webapp_name', {
+    publishUrl: 'publishUrl', userName: 'user', userPWD: 'token'
+}, true, false, true, null, null, null, true, false, false, "Bearer");
+
+console.log(` * MSBUILD TOKEN AUTH PARAMS: ${tokenAuthMSBuildPackageArgument}`);
+if(checkParametersIfPresent(tokenAuthMSBuildPackageArgument, ["AuthType=\"'Bearer'\""])) {
+    console.log("MSBUILD TOKEN AUTH PARAMS PASSED");
+}
+else {
+    throw new Error('MSBUILD TOKEN AUTH PARAMS FAILED');
+}
+
 
 var packageWithSetParamArgument: string = msdeployUtility.getMSDeployCmdArgs('package.zip', 'webapp_name', {
     publishUrl: 'http://webapp_name.scm.azurewebsites.net:443', userName: '$webapp_name', userPWD: 'webapp_password'

--- a/common-npm-packages/webdeployment-common/build.cmd
+++ b/common-npm-packages/webdeployment-common/build.cmd
@@ -1,4 +1,0 @@
-node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip ./7zip
-node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M142/MSDeploy.zip ./MSDeploy/M142
-node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M229/MSDeploy.zip ./MSDeploy/M229
-node make.js

--- a/common-npm-packages/webdeployment-common/build.cmd
+++ b/common-npm-packages/webdeployment-common/build.cmd
@@ -1,0 +1,4 @@
+node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip ./7zip
+node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M142/MSDeploy.zip ./MSDeploy/M142
+node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M229/MSDeploy.zip ./MSDeploy/M229
+node make.js

--- a/common-npm-packages/webdeployment-common/build.ps1
+++ b/common-npm-packages/webdeployment-common/build.ps1
@@ -1,0 +1,4 @@
+node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip ./7zip
+node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M142/MSDeploy.zip ./MSDeploy/M142
+node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M229/MSDeploy.zip ./MSDeploy/M229
+node make.js

--- a/common-npm-packages/webdeployment-common/deployusingmsdeploy.ts
+++ b/common-npm-packages/webdeployment-common/deployusingmsdeploy.ts
@@ -24,7 +24,7 @@ const DEFAULT_RETRY_COUNT = 3;
  *
  */
 export async function DeployUsingMSDeploy(webDeployPkg, webAppName, publishingProfile, removeAdditionalFilesFlag,
-        excludeFilesFromAppDataFlag, takeAppOfflineFlag, virtualApplication, setParametersFile, additionalArguments, isFolderBasedDeployment, useWebDeploy) {
+        excludeFilesFromAppDataFlag, takeAppOfflineFlag, virtualApplication, setParametersFile, additionalArguments, isFolderBasedDeployment, useWebDeploy, authType?: string) {
 
     var msDeployPath = await msDeployUtility.getMSDeployFullPath();
     var msDeployDirectory = msDeployPath.slice(0, msDeployPath.lastIndexOf('\\') + 1);
@@ -41,7 +41,7 @@ export async function DeployUsingMSDeploy(webDeployPkg, webAppName, publishingPr
 
     var msDeployCmdArgs = msDeployUtility.getMSDeployCmdArgs(webDeployPkg, webAppName, publishingProfile, removeAdditionalFilesFlag,
         excludeFilesFromAppDataFlag, takeAppOfflineFlag, virtualApplication, setParametersFileName, additionalArguments, isParamFilePresentInPackage, isFolderBasedDeployment,
-        useWebDeploy);
+        useWebDeploy, authType);
 
     var retryCountParam = tl.getVariable("appservice.msdeployretrycount");
     var retryCount = (retryCountParam && !(isNaN(Number(retryCountParam)))) ? Number(retryCountParam): DEFAULT_RETRY_COUNT; 

--- a/common-npm-packages/webdeployment-common/make.js
+++ b/common-npm-packages/webdeployment-common/make.js
@@ -10,7 +10,7 @@ util.cp(path.join(__dirname, 'package.json'), buildPath);
 util.cp(path.join(__dirname, 'package-lock.json'), buildPath);
 util.cp(path.join(__dirname, 'module.json'), buildPath);
 util.cp('-r', '7zip', buildPath);
-util.cp('-r', 'MSDeploy3.6', buildPath);
+util.cp('-r', 'MSDeploy', buildPath);
 util.cp('-r', 'node_modules', buildPath);
 util.cp('-r', 'Strings', buildPath);
 util.cp('-r', 'WebConfigTemplates', buildPath);

--- a/common-npm-packages/webdeployment-common/module.json
+++ b/common-npm-packages/webdeployment-common/module.json
@@ -30,6 +30,10 @@
         "VariableSubstitutionInitiated" : "Initiated variable substitution in config file : %s",
         "ConfigFileUpdated" : "Config file : %s updated.",
         "SkippedUpdatingFile" : "Skipped Updating file: %s",
-        "PwshNotAvailable": "##WARNING##:PowerShell Core (pwsh.exe) is not available on agent machine. Falling back to using Windows PowerShell (powershell.exe). This can cause reduced performance. Please install the newer version of PowerShell for improved performance."
+        "PwshNotAvailable": "##WARNING##:PowerShell Core (pwsh.exe) is not available on agent machine. Falling back to using Windows PowerShell (powershell.exe). This can cause reduced performance. Please install the newer version of PowerShell for improved performance.",
+        "UnabletofindthelocationofMSDeployfromregistryonmachineError": "Unable to find the location of MSDeploy from registry. Error: %s",
+        "MissingMSDeployVersionRegistryKey": "Missing MSDeploy Version registry key.",
+        "UnsupportedMSDeployVersion": "MSDeploy %s does not support token base authentication. Please upgrade to MSDeploy 9.0.7225.0 or higher.",
+        "MissingMSDeployInstallPathRegistryKey": "Missing MSDeploy InstallPath registry key."
     }
 }

--- a/common-npm-packages/webdeployment-common/msdeployutility.ts
+++ b/common-npm-packages/webdeployment-common/msdeployutility.ts
@@ -335,18 +335,17 @@ function compareVersions(version1: string, version2: string): number {
         return 0;
     }
 
-    const parts1 = version1.split(".").map(Number);
-    const parts2 = version2.split(".").map(Number);
+    const separator = ".";
+    const parts1 = version1.split(separator).map(Number);
+    const parts2 = version2.split(separator).map(Number);
 
     const length = Math.min(parts1.length, parts2.length);
 
     for (let i = 0; i < length; i++) {
-        // A bigger than B
         if (parts1[i] > parts2[i]) {
             return 1;
         }
 
-        // B bigger than A
         if (parts1[i] < parts2[i]) {
             return -1;
         }

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.230.0",
+    "version": "4.230.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -7,7 +7,7 @@
         "url": "git+ssh://git@github.com/Microsoft/azure-pipelines-tasks.git"
     },
     "scripts": {
-        "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip ./7zip &&  node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M142/MSDeploy.zip ./MSDeploy3.6 &&  node make.js"
+        "build": "build.cmd"
     },
     "author": "Microsoft Corporation",
     "license": "MIT",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -7,7 +7,7 @@
         "url": "git+ssh://git@github.com/Microsoft/azure-pipelines-tasks.git"
     },
     "scripts": {
-        "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip ./7zip && node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M142/MSDeploy.zip ./MSDeploy/M142 && node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M229/MSDeploy.zip ./MSDeploy/M229 && node make.js"
+        "build": "pwsh build.ps1"
     },
     "author": "Microsoft Corporation",
     "license": "MIT",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -7,7 +7,7 @@
         "url": "git+ssh://git@github.com/Microsoft/azure-pipelines-tasks.git"
     },
     "scripts": {
-        "build": "build.cmd"
+        "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip ./7zip && node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M142/MSDeploy.zip ./MSDeploy/M142 && node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M229/MSDeploy.zip ./MSDeploy/M229 && node make.js"
     },
     "author": "Microsoft Corporation",
     "license": "MIT",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.230.0",
+    "version": "4.230.1",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This PR adds token authentication support to `azure-pipelines-tasks-webdeployment-common` library. Changes are done in two major directions:
- Possibility to pass authentication type as an argument to MSDeploy,
- Provide MSDeploy version that supports token atuhentication.