### PR TITLE
Transform webdeployment-common tests into real test suites

### DIFF
--- a/common-npm-packages/webdeployment-common/.gitignore
+++ b/common-npm-packages/webdeployment-common/.gitignore
@@ -1,2 +1,3 @@
 7zip
-MSDeploy3.6
+MSDeploy
+coverage

--- a/common-npm-packages/webdeployment-common/.gitignore
+++ b/common-npm-packages/webdeployment-common/.gitignore
@@ -1,3 +1,4 @@
 7zip
 MSDeploy
 coverage
+ctt

--- a/common-npm-packages/webdeployment-common/Tests/L0.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0.ts
@@ -1,9 +1,12 @@
 import { runGetMSDeployCmdArgsTests, runGetWebDeployErrorCodeTests } from './L0MSDeployUtility';
 import { runCopyDirectoryTests } from "./L0CopyDirectory";
+import { runGenerateWebCongigTests } from "./L0GenerateWebConfig";
 
 describe('MSDeploy tests', () => {
     describe('GetMSDeployCmdArgs tests', runGetMSDeployCmdArgsTests);
     describe('GetWebDeployErrorCode tests', runGetWebDeployErrorCodeTests);
 
     describe("CopyDirectory tests", runCopyDirectoryTests);
+
+    describe("GenerateWebConfig tests", runGenerateWebCongigTests);
 });

--- a/common-npm-packages/webdeployment-common/Tests/L0.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0.ts
@@ -1,6 +1,7 @@
 import { runGetMSDeployCmdArgsTests, runGetWebDeployErrorCodeTests } from './L0MSDeployUtility';
 import { runCopyDirectoryTests } from "./L0CopyDirectory";
 import { runGenerateWebCongigTests } from "./L0GenerateWebConfig";
+import { runL1XmlVarSubTests } from "./L1XmlVarSub";
 
 describe('MSDeploy tests', () => {
     describe('GetMSDeployCmdArgs tests', runGetMSDeployCmdArgsTests);
@@ -9,4 +10,6 @@ describe('MSDeploy tests', () => {
     describe("CopyDirectory tests", runCopyDirectoryTests);
 
     describe("GenerateWebConfig tests", runGenerateWebCongigTests);
+
+    describe("L1XmlVarSub tests", runL1XmlVarSubTests);
 });

--- a/common-npm-packages/webdeployment-common/Tests/L0.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0.ts
@@ -1,6 +1,9 @@
 import { runGetMSDeployCmdArgsTests, runGetWebDeployErrorCodeTests } from './L0MSDeployUtility';
+import { runCopyDirectoryTests } from "./L0CopyDirectory";
 
 describe('MSDeploy tests', () => {
     describe('GetMSDeployCmdArgs tests', runGetMSDeployCmdArgsTests);
     describe('GetWebDeployErrorCode tests', runGetWebDeployErrorCodeTests);
+
+    describe("CopyDirectory tests", runCopyDirectoryTests);
 });

--- a/common-npm-packages/webdeployment-common/Tests/L0.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0.ts
@@ -3,15 +3,14 @@ import { runCopyDirectoryTests } from "./L0CopyDirectory";
 import { runGenerateWebCongigTests } from "./L0GenerateWebConfig";
 import { runL1XmlVarSubTests } from "./L1XmlVarSub";
 import { runL1XdtTransformTests } from "./L1XdtTransform"
+import { runL1JSONVarSubWithCommentsTests } from "./L1JSONVarSubWithComments";
 
 describe('MSDeploy tests', () => {
     describe('GetMSDeployCmdArgs tests', runGetMSDeployCmdArgsTests);
     describe('GetWebDeployErrorCode tests', runGetWebDeployErrorCodeTests);
-
     describe("CopyDirectory tests", runCopyDirectoryTests);
-
     describe("GenerateWebConfig tests", runGenerateWebCongigTests);
-
     describe("L1XmlVarSub tests", runL1XmlVarSubTests);
     describe("L1XdtTransform tests", runL1XdtTransformTests);
+    describe("L1JSONVarSubWithComments tests", runL1JSONVarSubWithCommentsTests);
 });

--- a/common-npm-packages/webdeployment-common/Tests/L0.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0.ts
@@ -4,8 +4,11 @@ import { runGenerateWebCongigTests } from "./L0GenerateWebConfig";
 import { runL1XmlVarSubTests } from "./L1XmlVarSub";
 import { runL1XdtTransformTests } from "./L1XdtTransform"
 import { runL1JSONVarSubWithCommentsTests } from "./L1JSONVarSubWithComments";
+import { runL1JsonVarSubTests } from "./L1JsonVarSub";
+import { runL1JsonVarSubV2Tests } from "./L1JsonVarSubV2";
+import { runL1ValidateFileEncodingTests } from "./L1ValidateFileEncoding";
 
-describe('MSDeploy tests', () => {
+describe('Web deployment common tests', () => {
     describe('GetMSDeployCmdArgs tests', runGetMSDeployCmdArgsTests);
     describe('GetWebDeployErrorCode tests', runGetWebDeployErrorCodeTests);
     describe("CopyDirectory tests", runCopyDirectoryTests);
@@ -13,4 +16,7 @@ describe('MSDeploy tests', () => {
     describe("L1XmlVarSub tests", runL1XmlVarSubTests);
     describe("L1XdtTransform tests", runL1XdtTransformTests);
     describe("L1JSONVarSubWithComments tests", runL1JSONVarSubWithCommentsTests);
+    describe("L1JsonVarSub tests", runL1JsonVarSubTests);
+    describe("L1JsonVarSubV2 tests", runL1JsonVarSubV2Tests);
+    describe("L1ValidateFileEncoding tests", runL1ValidateFileEncodingTests);
 });

--- a/common-npm-packages/webdeployment-common/Tests/L0.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0.ts
@@ -2,6 +2,7 @@ import { runGetMSDeployCmdArgsTests, runGetWebDeployErrorCodeTests } from './L0M
 import { runCopyDirectoryTests } from "./L0CopyDirectory";
 import { runGenerateWebCongigTests } from "./L0GenerateWebConfig";
 import { runL1XmlVarSubTests } from "./L1XmlVarSub";
+import { runL1XdtTransformTests } from "./L1XdtTransform"
 
 describe('MSDeploy tests', () => {
     describe('GetMSDeployCmdArgs tests', runGetMSDeployCmdArgsTests);
@@ -12,4 +13,5 @@ describe('MSDeploy tests', () => {
     describe("GenerateWebConfig tests", runGenerateWebCongigTests);
 
     describe("L1XmlVarSub tests", runL1XmlVarSubTests);
+    describe("L1XdtTransform tests", runL1XdtTransformTests);
 });

--- a/common-npm-packages/webdeployment-common/Tests/L0.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0.ts
@@ -1,0 +1,6 @@
+import { runGetMSDeployCmdArgsTests, runGetWebDeployErrorCodeTests } from './L0MSDeployUtility';
+
+describe('MSDeploy tests', () => {
+    describe('GetMSDeployCmdArgs tests', runGetMSDeployCmdArgsTests);
+    describe('GetWebDeployErrorCode tests', runGetWebDeployErrorCodeTests);
+});

--- a/common-npm-packages/webdeployment-common/Tests/L0CopyDirectory.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0CopyDirectory.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import * as mockery from "mockery";
+import * as path from "path";
 
 export function runCopyDirectoryTests(): void {
     const fileList: string[] = [];
@@ -73,16 +74,16 @@ export function runCopyDirectoryTests(): void {
 
     it("Should copy files and folders as expected", async () => {
         fileList.push(
-            "C:\\source\\path",
-            "C:\\source\\path\\myfile.txt",
-            "C:\\source\\path\\New Folder",
-            "C:\\source\\path\\New Folder\\Another New Folder",
-            "C:\\source\\New Folder\\anotherfile.py",
-            "C:\\source\\New Folder\\Another New Folder\\mynewfile.txt"
+            path.join("C:", "source", "path"),
+            path.join("C:", "source", "path", "myfile.txt"),
+            path.join("C:", "source", "path", "New Folder"),
+            path.join("C:", "source", "path", "New Folder", "Another New Folder"),
+            path.join("C:", "source", "New Folder", "anotherfile.py"),
+            path.join("C:", "source", "New Folder", "Another New Folder", "mynewfile.txt")
         );
         const utility = await import('../utility');
 
-        utility.copyDirectory('C:\\source', 'C:\\destination');
+        utility.copyDirectory(path.join('C:','source'), path.join('C:', 'destination'));
 
         assert.strictEqual(cpfilesCount, 3, '## Copy Files Successful ##');
         assert.strictEqual(mkdirPCount, 6, '## mkdir Successful ##');

--- a/common-npm-packages/webdeployment-common/Tests/L0CopyDirectory.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0CopyDirectory.ts
@@ -2,15 +2,7 @@ import * as assert from "assert";
 import * as mockery from "mockery";
 
 export function runCopyDirectoryTests(): void {
-    const fileList = [
-        "C:\\source\\path",
-        "C:\\source\\path\\myfile.txt",
-        "C:\\source\\path\\New Folder",
-        "C:\\source\\path\\New Folder\\Another New Folder",
-        "C:\\source\\New Folder\\anotherfile.py",
-        "C:\\source\\New Folder\\Another New Folder\\mynewfile.txt"
-    ];
-
+    const fileList: string[] = [];
     let mkdirPCount: number;
     let cpfilesCount: number;
 
@@ -75,12 +67,23 @@ export function runCopyDirectoryTests(): void {
     beforeEach(() => {
         mkdirPCount = 0;
         cpfilesCount = 0;
+        fileList.splice(0);
     });
 
 
     it("Should copy files and folders as expected", async () => {
+        fileList.push(
+            "C:\\source\\path",
+            "C:\\source\\path\\myfile.txt",
+            "C:\\source\\path\\New Folder",
+            "C:\\source\\path\\New Folder\\Another New Folder",
+            "C:\\source\\New Folder\\anotherfile.py",
+            "C:\\source\\New Folder\\Another New Folder\\mynewfile.txt"
+        );
         const utility = await import('../utility');
+
         utility.copyDirectory('C:\\source', 'C:\\destination');
+
         assert.strictEqual(cpfilesCount, 3, '## Copy Files Successful ##');
         assert.strictEqual(mkdirPCount, 6, '## mkdir Successful ##');
     });

--- a/common-npm-packages/webdeployment-common/Tests/L0CopyDirectory.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0CopyDirectory.ts
@@ -85,7 +85,7 @@ export function runCopyDirectoryTests(): void {
 
         utility.copyDirectory(path.join('C:','source'), path.join('C:', 'destination'));
 
-        assert.strictEqual(cpfilesCount, 3, '## Copy Files Successful ##');
-        assert.strictEqual(mkdirPCount, 6, '## mkdir Successful ##');
+        assert.strictEqual(cpfilesCount, 3, 'Should create three files');
+        assert.strictEqual(mkdirPCount, 6, 'Should create six folder including destination folder');
     });
 }

--- a/common-npm-packages/webdeployment-common/Tests/L0MSDeployUtility.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0MSDeployUtility.ts
@@ -1,128 +1,119 @@
-var msdeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
+import assert = require("assert");
+import { getMSDeployCmdArgs, getWebDeployErrorCode } from "../msdeployutility";
 
-var errorMessages = {
-    'ERROR_INSUFFICIENT_ACCESS_TO_SITE_FOLDER': 'ERROR_INSUFFICIENT_ACCESS_TO_SITE_FOLDER',
-    "An error was encountered when processing operation 'Delete Directory' on 'D:\\home\\site\\wwwroot\\app_data\\jobs\\continous'": "WebJobsInProgressIssue",
-    "Cannot delete file main.dll. Error code: FILE_IN_USE": "FILE_IN_USE",
-    "transport connection": "transport connection",
-    "error code: ERROR_CONNECTION_TERMINATED": "ERROR_CONNECTION_TERMINATED"
-}
 
-function checkParametersIfPresent(argumentString: string, argumentCheckArray: Array<string>) {
-    for(var argument of argumentCheckArray) {
-        if(argumentString.indexOf(argument) == -1) {
-            return false;
+
+export function runGetMSDeployCmdArgsTests() {
+
+    it('Should produce default valid args', () => {
+        const profile = createDefaultPublishProfile();
+        const args = getMSDeployCmdArgs('package.zip', 'webapp_name', profile, true, false, true, null, null, null, true, false, false);
+
+        const expectedArgs = [
+            "-source:package=\"'package.zip'\"",
+            "-dest:auto,ComputerName=\"'https://http://webapp_name.scm.azurewebsites.net:443/msdeploy.axd?site=webapp_name'\",UserName=\"'$webapp_name'\",Password=\"'webapp_password'\",AuthType=\"'Basic'\"",
+            "-setParam:name=\"'IIS Web Application Name'\",value=\"'webapp_name'\"",
+            "-enableRule:AppOffline"];
+
+        const notExpectedArgs = ["-setParamFile"];
+
+        checkParametersIfPresent(args, expectedArgs);
+        checkParametersNotPresent(args, notExpectedArgs);
+    });
+
+
+    it('Should produce valid args with token auth', () => {
+        const profile = createDefaultPublishProfile();
+        const args = getMSDeployCmdArgs('package.zip', 'webapp_name', profile, true, false, true, null, null, null, true, false, false, "Bearer");
+        checkParametersIfPresent(args, ["AuthType=\"'Bearer'\""]);
+    });
+
+
+    it('Should produce valid args with parameter file', () => {
+        const profile = createDefaultPublishProfile();
+        const args = getMSDeployCmdArgs('package.zip', 'webapp_name', profile, false, false, true, null, 'temp_param.xml', null, false, false, true);
+
+        const expectedArgs = ['-setParamFile=temp_param.xml', "-dest:contentPath=\"'webapp_name'\"", '-enableRule:DoNotDelete'];
+        checkParametersIfPresent(args, expectedArgs);
+    });
+
+
+    it('Should produce valid args with folder package', () => {
+
+        const profile = createDefaultPublishProfile();
+        const args: string = getMSDeployCmdArgs('c:/package/folder', 'webapp_name', profile, true, false, true, null, null, null, true, true, true);
+
+        const expectedArgs = [
+            "-source:IisApp=\"'c:/package/folder'\"",
+            " -dest:iisApp=\"'webapp_name'\""
+        ];
+        checkParametersIfPresent(args, expectedArgs);
+    });
+
+
+    it('Should produce valid args with exclude data', () => {
+        const profile = createDefaultPublishProfile();
+        const args: string = getMSDeployCmdArgs('package.zip', 'webapp_name', profile, false, true, true, null, null, null, false, false, true);
+
+        checkParametersIfPresent(args, ['-skip:Directory=App_Data']);
+    });
+
+
+    it("Should produce valid args with war file", () => {
+        const profile = createDefaultPublishProfile();
+        const args = getMSDeployCmdArgs('package.war', 'webapp_name', profile, false, true, true, null, null, null, false, false, true);
+
+        checkParametersIfPresent(args, [
+            " -source:contentPath=\"'package.war'\"",
+            " -dest:contentPath=\"'/site/webapps/package.war'\""
+        ]);
+    });
+
+    it("Should override retry arguments", () => {
+        const profile = createDefaultPublishProfile();
+        const args = getMSDeployCmdArgs('package.zip', 'webapp_name', profile, false, true, true, null, null, '-retryAttempts:11 -retryInterval:5000', false, false, true);
+
+        checkParametersIfPresent(args, ['-retryAttempts:11', '-retryInterval:5000']);
+    });
+
+    function checkParametersIfPresent(argumentString: string, argumentCheckArray: string[]): void {
+        for (const argument of argumentCheckArray) {
+            if (argumentString.indexOf(argument) === -1) {
+                assert.strictEqual(argumentString.indexOf(argument), -1, `Argument ${argument} not found in ${argumentString}`);
+            }
         }
     }
 
-    return true;
-}
+    function checkParametersNotPresent(argumentString: string, argumentCheckArray: string[]): void {
+        for (var argument of argumentCheckArray) {
+            if (argumentString.indexOf(argument) !== -1) {
+                assert.strictEqual(argumentString.indexOf(argument), -1, `Argument ${argument} found in ${argumentString}`);
+            }
+        }
+    }
 
-var defaultMSBuildPackageArgument: string = msdeployUtility.getMSDeployCmdArgs('package.zip', 'webapp_name', {
-    publishUrl: 'http://webapp_name.scm.azurewebsites.net:443', userName: '$webapp_name', userPWD: 'webapp_password'
-}, true, false, true, null, null, null, true, false, false);
-
-console.log(` * MSBUILD DEFAULT PARAMS: ${defaultMSBuildPackageArgument}`);
-if(checkParametersIfPresent(defaultMSBuildPackageArgument, ["-source:package=\"'package.zip'\"", 
-    " -dest:auto,ComputerName=\"'https://http://webapp_name.scm.azurewebsites.net:443/msdeploy.axd?site=webapp_name'\",UserName=\"'$webapp_name'\",Password=\"'webapp_password'\",AuthType=\"'Basic'\"",
-    " -setParam:name=\"'IIS Web Application Name'\",value=\"'webapp_name'\"", '-enableRule:AppOffline']) && defaultMSBuildPackageArgument.indexOf('-setParamFile') == -1) {
-    console.log("MSBUILD DEFAULT PARAMS PASSED");
-}
-else {
-    throw new Error('MSBUILD PACKAGE DEFAULT PARAMS FAILED');
-}
-
-var tokenAuthMSBuildPackageArgument: string = msdeployUtility.getMSDeployCmdArgs('package.zip', 'webapp_name', {
-    publishUrl: 'publishUrl', userName: 'user', userPWD: 'token'
-}, true, false, true, null, null, null, true, false, false, "Bearer");
-
-console.log(` * MSBUILD TOKEN AUTH PARAMS: ${tokenAuthMSBuildPackageArgument}`);
-if(checkParametersIfPresent(tokenAuthMSBuildPackageArgument, ["AuthType=\"'Bearer'\""])) {
-    console.log("MSBUILD TOKEN AUTH PARAMS PASSED");
-}
-else {
-    throw new Error('MSBUILD TOKEN AUTH PARAMS FAILED');
-}
-
-
-var packageWithSetParamArgument: string = msdeployUtility.getMSDeployCmdArgs('package.zip', 'webapp_name', {
-    publishUrl: 'http://webapp_name.scm.azurewebsites.net:443', userName: '$webapp_name', userPWD: 'webapp_password'
-}, false, false, true, null, 'temp_param.xml', null, false, false, true);
-
-
-console.log(` * PACKAGE WITh SET PARAMS: ${packageWithSetParamArgument}`);
-
-
-if(checkParametersIfPresent(packageWithSetParamArgument, ['-setParamFile=temp_param.xml', "-dest:contentPath=\"'webapp_name'\"" , '-enableRule:DoNotDelete'])) {
-    console.log('ARGUMENTS WITH SET PARAMS PASSED');
-}
-else {
-    throw Error('ARGUMENTS WITH SET PARAMS FAILED');
-}
-
-var folderPackageArgument: string = msdeployUtility.getMSDeployCmdArgs('c:/package/folder', 'webapp_name', {
-    publishUrl: 'http://webapp_name.scm.azurewebsites.net:443', userName: '$webapp_name', userPWD: 'webapp_password'
-}, true, false, true, null, null, null, true, true, true);
-
-console.log(` * ARGUMENT WITh FOLDER AS PACKAGE: ${folderPackageArgument}`);
-if(checkParametersIfPresent(folderPackageArgument, [
- "-source:IisApp=\"'c:/package/folder'\"",
- " -dest:iisApp=\"'webapp_name'\""
-])) {
-    console.log('ARGUMENT WITH FOLDER PACKAGE PASSED');
-}
-else {
-    throw Error('ARGUMENT WITH FOLDER PACKAGE FAILED');
-}
-
-
-var packageWithExcludeAppDataArgument: string = msdeployUtility.getMSDeployCmdArgs('package.zip', 'webapp_name', {
-    publishUrl: 'http://webapp_name.scm.azurewebsites.net:443', userName: '$webapp_name', userPWD: 'webapp_password'
-}, false, true, true, null, null, null, false, false, true);
-
-console.log(` * ARGUMENT WITh FOLDER AS PACKAGE: ${packageWithExcludeAppDataArgument}`);
-
-if(checkParametersIfPresent(packageWithExcludeAppDataArgument, ['-skip:Directory=App_Data'])) {
-    console.log('ARGUMENT WITH EXCLUDE APP DATA PASSED');
-}
-else {
-    throw new Error('ARGUMENT WITH EXCLUDE APP DATA FAILED');   
-}
-
-
-var warDeploymentArgument: string =  msdeployUtility.getMSDeployCmdArgs('package.war', 'webapp_name', {
-    publishUrl: 'http://webapp_name.scm.azurewebsites.net:443', userName: '$webapp_name', userPWD: 'webapp_password'
-}, false, true, true, null, null, null, false, false, true);
-
-console.log(` * ARGUMENT WITh WAR FILE AS PACKAGE: ${warDeploymentArgument}`);
-if(checkParametersIfPresent(warDeploymentArgument, [
-    " -source:contentPath=\"'package.war'\"",
-    " -dest:contentPath=\"'/site/webapps/package.war'\""
-])) {
-    console.log('ARGUMENT WITH WAR PACKAGE PASSED');
-}
-else {
-    throw new Error('ARGUMENT WITH WAR PACKAGE FAILED');
-}
-
-var overrideRetryArgument: string = msdeployUtility.getMSDeployCmdArgs('package.zip', 'webapp_name', {
-    publishUrl: 'http://webapp_name.scm.azurewebsites.net:443', userName: '$webapp_name', userPWD: 'webapp_password'
-}, false, true, true, null, null, '-retryAttempts:11 -retryInterval:5000', false, false, true);
-
-console.log(` * ARGUMENTS WITH WAR FILE: ${overrideRetryArgument}`);
-
-if(checkParametersIfPresent(overrideRetryArgument, ['-retryAttempts:11', '-retryInterval:5000'])) {
-    console.log('ARGUMENT WITH OVERRIDE RETRY FLAG PASSED');
-}
-else {
-    throw new Error('ARGUMENT WITH OVERRIDE RETRY FLAG FAILED');
-}
-
-// msdeployutility getWebDeployErrorCode
-for(var errorMessage in errorMessages) {
-    if(msdeployUtility.getWebDeployErrorCode(errorMessage) != errorMessages[errorMessage]) {
-        throw new Error('MSDEPLOY getWebDeployErrorCode failed');
+    function createDefaultPublishProfile(): { publishUrl: string, userName: string, userPWD: string } {
+        return {
+            publishUrl: 'http://webapp_name.scm.azurewebsites.net:443',
+            userName: '$webapp_name',
+            userPWD: 'webapp_password'
+        };
     }
 }
 
-console.log('MSDEPLOY getWebDeployErrorCode passed');
+export function runGetWebDeployErrorCodeTests(): void {
+    it("Should return proper error messages", () => {
+
+        const errorMessages = {
+            'ERROR_INSUFFICIENT_ACCESS_TO_SITE_FOLDER': 'ERROR_INSUFFICIENT_ACCESS_TO_SITE_FOLDER',
+            "An error was encountered when processing operation 'Delete Directory' on 'D:\\home\\site\\wwwroot\\app_data\\jobs\\continous'": "WebJobsInProgressIssue",
+            "Cannot delete file main.dll. Error code: FILE_IN_USE": "FILE_IN_USE",
+            "transport connection": "transport connection",
+            "error code: ERROR_CONNECTION_TERMINATED": "ERROR_CONNECTION_TERMINATED"
+        }
+
+        for (var errorMessage in errorMessages) {
+            assert.strictEqual(getWebDeployErrorCode(errorMessage), errorMessages[errorMessage]);
+        }
+    });
+}

--- a/common-npm-packages/webdeployment-common/Tests/L1JSONVarSubWithComments.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1JSONVarSubWithComments.ts
@@ -1,52 +1,40 @@
-var jsonSubUtil = require('azure-pipelines-tasks-webdeployment-common/jsonvariablesubstitutionutility.js');
-import fs = require('fs');
-import path = require('path');
+import * as fs from 'fs';
+import * as path from 'path';
+import * as assert from 'assert';
 
-var envVarObject = jsonSubUtil.createEnvTree([
-    { name: 'dataSourceBindings.0.target', value: 'AppServiceName', secret: false},
-    { name: 'name', value: 'App Service Deploy', secret: false},
-    { name: 'Hello.World', value: 'Hello World', secret: false},
-    { name: 'dataSourceBindings.1.parameters.WebAppName', value: 'App Service Name params', secret: false},
-    { name: 'messages.Invalidwebapppackageorfolderpathprovided', value: 'Invalidwebapppackageorfolderpathprovided', secret: true}
-]);
+import { createEnvTree, stripJsonComments, substituteJsonVariable } from "../jsonvariablesubstitutionutility";
 
-function validateJSONWithComments() {
-    var fileContent: string = fs.readFileSync(path.join(__dirname, 'L1JSONVarSub', 'JSONWithComments.json'), 'utf-8');
-    var jsonContent: string = jsonSubUtil.stripJsonComments(fileContent);
-    var jsonObject = JSON.parse(jsonContent);
-    jsonSubUtil.substituteJsonVariable(jsonObject, envVarObject);
 
-    if(jsonObject['dataSourceBindings']['0']['target'] != 'AppServiceName') {
-        throw new Error('JSON VAR SUB FAIL #1');
-    }
-    if(jsonObject['name'] != 'App Service Deploy') {
-        throw new Error('JSON VAR SUB FAIL #2');
-    }
-    if(jsonObject['Hello']['World'] != 'Hello World') {
-        throw new Error('JSON VAR SUB FAIL #3');
-    }
-    if(jsonObject['dataSourceBindings']['1']['parameters']['WebAppName'] != 'App Service Name params') {
-        throw new Error('JSON VAR SUB FAIL #4');
-    }
-    if(jsonObject['messages']['Invalidwebapppackageorfolderpathprovided'] != 'Invalidwebapppackageorfolderpathprovided') {
-        throw new Error('JSON VAR SUB FAIL #5');
-    }
-    console.log("VALID JSON COMMENTS TESTS PASSED");
-}
+export function runL1JSONVarSubWithCommentsTests(): void {
 
-function validateInvalidJSONWithComments() {
-    var fileContent: string = fs.readFileSync(path.join(__dirname, 'L1JSONVarSub', 'InvalidJSONWithComments.json'), 'utf-8');
-    var jsonContent: string = jsonSubUtil.stripJsonComments(fileContent);
-    try {
-        var jsonObject = JSON.parse(jsonContent);
-        throw new Error('JSON VAR SUB FAIL #6');
-    }
-    catch(error) {
-        console.log("INVALID JSON COMMENTS TESTS PASSED");
-    }
-}
+    it("Should substitute variables in JSON with comments", (done: Mocha.Done) => {
+        const envVarObject = createEnvTree([
+            { name: 'dataSourceBindings.0.target', value: 'AppServiceName', secret: false },
+            { name: 'name', value: 'App Service Deploy', secret: false },
+            { name: 'Hello.World', value: 'Hello World', secret: false },
+            { name: 'dataSourceBindings.1.parameters.WebAppName', value: 'App Service Name params', secret: false },
+            { name: 'messages.Invalidwebapppackageorfolderpathprovided', value: 'Invalidwebapppackageorfolderpathprovided', secret: true }
+        ]);
 
-export function validate() {
-    validateJSONWithComments();
-    validateInvalidJSONWithComments();
+        const fileContent: string = fs.readFileSync(path.join(__dirname, 'L1JSONVarSub', 'JSONWithComments.json'), 'utf-8');
+        const jsonContent: string = stripJsonComments(fileContent);
+        const jsonObject = JSON.parse(jsonContent);
+        substituteJsonVariable(jsonObject, envVarObject);
+
+        assert.strictEqual(jsonObject['dataSourceBindings']['0']['target'], 'AppServiceName', 'Should have substituted target variable');
+        assert.strictEqual(jsonObject['name'], 'App Service Deploy', 'Should have substituted name variable');
+        assert.strictEqual(jsonObject['Hello']['World'], 'Hello World', 'Should have substituted Hello.World variable');
+        assert.strictEqual(jsonObject['dataSourceBindings']['1']['parameters']['WebAppName'], 'App Service Name params', 'Should have substituted WebAppName variable');
+        assert.strictEqual(jsonObject['messages']['Invalidwebapppackageorfolderpathprovided'], 'Invalidwebapppackageorfolderpathprovided', 'Should have substituted Invalidwebapppackageorfolderpathprovided variable');
+
+        done();
+    });
+
+    it("Should throw exception for invalid JSON with comments", (done: Mocha.Done) => {
+        const fileContent = fs.readFileSync(path.join(__dirname, 'L1JSONVarSub', 'InvalidJSONWithComments.json'), 'utf-8');
+        const jsonContent = stripJsonComments(fileContent);
+        console.log(jsonContent);
+        assert.throws(() => JSON.parse(jsonContent), "Parse is expected to throw an error");
+        done();
+    });
 }

--- a/common-npm-packages/webdeployment-common/Tests/L1JsonVarSub.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1JsonVarSub.ts
@@ -1,68 +1,72 @@
-var jsonSubUtil = require('azure-pipelines-tasks-webdeployment-common/jsonvariablesubstitutionutility.js');
+import * as assert from 'assert';
 
-var envVarObject = jsonSubUtil.createEnvTree([
-    { name: 'system.debug', value: 'true', secret: false},
-    { name: 'data.ConnectionString', value: 'database_connection', secret: false},
-    { name: 'data.userName', value: 'db_admin', secret: false},
-    { name: 'data.password', value: 'db_pass', secret: true},
-    { name: '&pl.ch@r@cter.k^y', value: '*.config', secret: false},
-    { name: 'build.sourceDirectory', value: 'DefaultWorkingDirectory', secret: false},
-    { name: 'user.profile.name.first', value: 'firstName', secret: false},
-    { name: 'user.profile', value: 'replace_all', secret: false},
-    { name: 'constructor.name', value: 'newConstructorName', secret: false},
-    { name: 'constructor.valueOf', value: 'constructorNewValue', secret: false},
-    { name: 'systemsettings.appurl', value: 'https://dev.azure.com/helloworld', secret: false}
-]);
+import { createEnvTree, substituteJsonVariable } from '../jsonvariablesubstitutionutility';
 
-var jsonObject = {
-    'User.Profile': 'do_not_replace',
-    'data': {
-        'ConnectionString' : 'connect_string',
-        'userName': 'name',
-        'password': 'pass'
-    },
-    '&pl': {
-        'ch@r@cter.k^y': 'v@lue'
-    },
-    'system': {
-        'debug' : 'no_change'
-    },
-    'user.profile': {
-        'name.first' : 'fname'
-    },
-    'constructor.name': 'myconstructorname',
-    'constructor': {
-        'name': 'myconstructorname',
-        'valueOf': 'myconstructorvalue'
-    },
-    'systemsettings': {
-        'appurl': 'https://helloworld.visualstudio.com'
-    }
-}
-// Method to be checked for JSON variable substitution
-jsonSubUtil.substituteJsonVariable(jsonObject, envVarObject);
 
-if(typeof jsonObject['user.profile'] === 'object') {
-    console.log('JSON - eliminating object variables validated');
+export function runL1JsonVarSubTests(): void {
+
+    it("Should substitute JSON variables", (done: Mocha.Done) => {
+        const envVarObject = createEnvTree([
+            { name: 'system.debug', value: 'true', secret: false },
+            { name: 'data.ConnectionString', value: 'database_connection', secret: false },
+            { name: 'data.userName', value: 'db_admin', secret: false },
+            { name: 'data.password', value: 'db_pass', secret: true },
+            { name: '&pl.ch@r@cter.k^y', value: '*.config', secret: false },
+            { name: 'build.sourceDirectory', value: 'DefaultWorkingDirectory', secret: false },
+            { name: 'user.profile.name.first', value: 'firstName', secret: false },
+            { name: 'user.profile', value: 'replace_all', secret: false },
+            { name: 'constructor.name', value: 'newConstructorName', secret: false },
+            { name: 'constructor.valueOf', value: 'constructorNewValue', secret: false },
+            { name: 'systemsettings.appurl', value: 'https://dev.azure.com/helloworld', secret: false }
+        ]);
+
+        const jsonObject = {
+            'User.Profile': 'do_not_replace',
+            'data': {
+                'ConnectionString': 'connect_string',
+                'userName': 'name',
+                'password': 'pass'
+            },
+            '&pl': {
+                'ch@r@cter.k^y': 'v@lue'
+            },
+            'system': {
+                'debug': 'no_change'
+            },
+            'user.profile': {
+                'name.first': 'fname'
+            },
+            'constructor.name': 'myconstructorname',
+            'constructor': {
+                'name': 'myconstructorname',
+                'valueOf': 'myconstructorvalue'
+            },
+            'systemsettings': {
+                'appurl': 'https://helloworld.visualstudio.com'
+            }
+        };
+
+        substituteJsonVariable(jsonObject, envVarObject);
+
+        assert.strictEqual(typeof jsonObject['user.profile'], 'object');
+        assert.strictEqual(jsonObject['data']['ConnectionString'], 'database_connection');
+        assert.strictEqual(jsonObject['data']['userName'], 'db_admin');
+        assert.strictEqual(jsonObject['systemsettings']['appurl'], 'https://dev.azure.com/helloworld');
+        assert.strictEqual(jsonObject['system']['debug'], 'no_change');
+        assert.strictEqual(jsonObject['&pl']['ch@r@cter.k^y'], '*.config');
+        assert.strictEqual(jsonObject['user.profile']['name.first'], 'firstName');
+        assert.strictEqual(jsonObject['User.Profile'], 'do_not_replace');
+        assert.strictEqual(jsonObject['constructor.name'], 'newConstructorName');
+        assert.strictEqual(jsonObject['constructor']['name'], 'newConstructorName');
+        assert.strictEqual(jsonObject['constructor']['valueOf'], 'constructorNewValue');
+
+        done();
+    });
+
 }
-if(jsonObject['data']['ConnectionString'] === 'database_connection'
-    && jsonObject['data']['userName'] === 'db_admin'
-    && jsonObject['systemsettings']['appurl'] == 'https://dev.azure.com/helloworld') {
-    console.log('JSON - simple string change validated');
-}
-if(jsonObject['system']['debug'] === 'no_change') {
-    console.log('JSON - system variable elimination validated');
-}
-if(jsonObject['&pl']['ch@r@cter.k^y'] === '*.config') {
-    console.log('JSON - special variables validated');
-}
-if(jsonObject['user.profile']['name.first'] === 'firstName') {
-    console.log('JSON - variables with dot character validated');
-}
-if(jsonObject['User.Profile'] === 'do_not_replace') {
-    console.log('JSON - case sensitive variables validated');
-}
-if(jsonObject['constructor.name'] === 'newConstructorName' && 
-    jsonObject['constructor']['name'] === 'newConstructorName' && jsonObject['constructor']['valueOf'] === 'constructorNewValue') {
-        console.log('JSON - substitute inbuilt JSON attributes validated');
-}
+
+
+
+
+
+

--- a/common-npm-packages/webdeployment-common/Tests/L1JsonVarSub.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1JsonVarSub.ts
@@ -1,4 +1,3 @@
-import { validate } from './L1JSONVarSubWithComments';
 var jsonSubUtil = require('azure-pipelines-tasks-webdeployment-common/jsonvariablesubstitutionutility.js');
 
 var envVarObject = jsonSubUtil.createEnvTree([
@@ -67,5 +66,3 @@ if(jsonObject['constructor.name'] === 'newConstructorName' &&
     jsonObject['constructor']['name'] === 'newConstructorName' && jsonObject['constructor']['valueOf'] === 'constructorNewValue') {
         console.log('JSON - substitute inbuilt JSON attributes validated');
 }
-
-validate();

--- a/common-npm-packages/webdeployment-common/Tests/L1JsonVarSubV2.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1JsonVarSubV2.ts
@@ -1,100 +1,97 @@
-import { validate } from './L1JSONVarSubWithComments';
-var jsonSubUtil = require('azure-pipelines-tasks-webdeployment-common/jsonvariablesubstitutionutility.js');
+// var jsonSubUtil = require('azure-pipelines-tasks-webdeployment-common/jsonvariablesubstitutionutility.js');
 
-var envVarObject = jsonSubUtil.createEnvTree([
-    { name: 'system.debug', value: 'true', secret: false},
-    { name: 'data.ConnectionString', value: 'database_connection', secret: false},
-    { name: 'data.userName', value: 'db_admin', secret: false},
-    { name: 'data.password', value: 'db_pass', secret: true},
-    { name: '&pl.ch@r@cter.k^y', value: '*.config', secret: false},
-    { name: 'build.sourceDirectory', value: 'DefaultWorkingDirectory', secret: false},
-    { name: 'user.profile.name.first', value: 'firstName', secret: false},
-    { name: 'user.profile', value: 'replace_all', secret: false},
-    { name: 'constructor.name', value: 'newConstructorName', secret: false},
-    { name: 'constructor.valueOf', value: 'constructorNewValue', secret: false},
-    { name: 'profile.users', value: '["suaggar","rok","asranja", "chaitanya"]', secret: false},
-    { name: 'profile.enabled', value: 'false', secret: false},
-    { name: 'profile.version', value: '1173', secret: false},
-    { name: 'profile.somefloat', value: '97.75', secret: false},
-    { name: 'profile.preimum_level', value: '{"suaggar": "V4", "rok": "V5", "asranja": { "type" : "V6"}}', secret: false},
-    { name: 'systemsettings.appurl', value: 'https://dev.azure.com/helloworld', secret: false}
-]);
+// var envVarObject = jsonSubUtil.createEnvTree([
+//     { name: 'system.debug', value: 'true', secret: false},
+//     { name: 'data.ConnectionString', value: 'database_connection', secret: false},
+//     { name: 'data.userName', value: 'db_admin', secret: false},
+//     { name: 'data.password', value: 'db_pass', secret: true},
+//     { name: '&pl.ch@r@cter.k^y', value: '*.config', secret: false},
+//     { name: 'build.sourceDirectory', value: 'DefaultWorkingDirectory', secret: false},
+//     { name: 'user.profile.name.first', value: 'firstName', secret: false},
+//     { name: 'user.profile', value: 'replace_all', secret: false},
+//     { name: 'constructor.name', value: 'newConstructorName', secret: false},
+//     { name: 'constructor.valueOf', value: 'constructorNewValue', secret: false},
+//     { name: 'profile.users', value: '["suaggar","rok","asranja", "chaitanya"]', secret: false},
+//     { name: 'profile.enabled', value: 'false', secret: false},
+//     { name: 'profile.version', value: '1173', secret: false},
+//     { name: 'profile.somefloat', value: '97.75', secret: false},
+//     { name: 'profile.preimum_level', value: '{"suaggar": "V4", "rok": "V5", "asranja": { "type" : "V6"}}', secret: false},
+//     { name: 'systemsettings.appurl', value: 'https://dev.azure.com/helloworld', secret: false}
+// ]);
 
-var jsonObject = {
-    'User.Profile': 'do_not_replace',
-    'data': {
-        'ConnectionString' : 'connect_string',
-        'userName': 'name',
-        'password': 'pass'
-    },
-    '&pl': {
-        'ch@r@cter.k^y': 'v@lue'
-    },
-    'system': {
-        'debug' : 'no_change'
-    },
-    'user.profile': {
-        'name.first' : 'fname'
-    },
-    'constructor.name': 'myconstructorname',
-    'constructor': {
-        'name': 'myconstructorname',
-        'valueOf': 'myconstructorvalue'
-    },
-    'profile': {
-        'users': ['arjgupta', 'raagra', 'muthuk'],
-        'preimum_level': {
-            'arjgupta': 'V1',
-            'raagra': 'V2',
-            'muthuk': {
-                'type': 'V3'
-            }
-        },
-        "enabled": true,
-        "version": 2,
-        "somefloat": 2.3456
-    },
-    'systemsettings': {
-        'appurl': 'https://helloworld.visualstudio.com'
-    }
+// var jsonObject = {
+//     'User.Profile': 'do_not_replace',
+//     'data': {
+//         'ConnectionString' : 'connect_string',
+//         'userName': 'name',
+//         'password': 'pass'
+//     },
+//     '&pl': {
+//         'ch@r@cter.k^y': 'v@lue'
+//     },
+//     'system': {
+//         'debug' : 'no_change'
+//     },
+//     'user.profile': {
+//         'name.first' : 'fname'
+//     },
+//     'constructor.name': 'myconstructorname',
+//     'constructor': {
+//         'name': 'myconstructorname',
+//         'valueOf': 'myconstructorvalue'
+//     },
+//     'profile': {
+//         'users': ['arjgupta', 'raagra', 'muthuk'],
+//         'preimum_level': {
+//             'arjgupta': 'V1',
+//             'raagra': 'V2',
+//             'muthuk': {
+//                 'type': 'V3'
+//             }
+//         },
+//         "enabled": true,
+//         "version": 2,
+//         "somefloat": 2.3456
+//     },
+//     'systemsettings': {
+//         'appurl': 'https://helloworld.visualstudio.com'
+//     }
 
-}
-// Method to be checked for JSON variable substitution
-jsonSubUtil.substituteJsonVariableV2(jsonObject, envVarObject);
+// }
+// // Method to be checked for JSON variable substitution
+// jsonSubUtil.substituteJsonVariableV2(jsonObject, envVarObject);
 
-if(jsonObject['data']['ConnectionString'] === 'database_connection'
-    && jsonObject['data']['userName'] === 'db_admin'
-    && jsonObject['systemsettings']['appurl'] == 'https://dev.azure.com/helloworld') {
-    console.log('JSON - simple string change validated');
-}
-if(jsonObject['system']['debug'] === 'no_change') {
-    console.log('JSON - system variable elimination validated');
-}
-if(jsonObject['&pl']['ch@r@cter.k^y'] === '*.config') {
-    console.log('JSON - special variables validated');
-}
-if(jsonObject['User.Profile'] === 'do_not_replace') {
-    console.log('JSON - case sensitive variables validated');
-}
-if(jsonObject['constructor.name'] === 'newConstructorName' && 
-    jsonObject['constructor']['name'] === 'newConstructorName' && jsonObject['constructor']['valueOf'] === 'constructorNewValue') {
-        console.log('JSON - substitute inbuilt JSON attributes validated');
-}
-let newArray = ["suaggar", "rok", "asranja", "chaitanya"];
-if (jsonObject['profile']['users'].length == 4 && (jsonObject['profile']['users']).every((value, index) => {return value == newArray[index]}) ) {
-    console.log('JSON - Array Object validated');
-}
-if(jsonObject['profile']['enabled'] == false) {
-    console.log('JSON - Boolean validated');
-}
-if(jsonObject['profile']['somefloat'] == 97.75) {
-    console.log('JSON - Number(float) validated');
-}
-if(jsonObject['profile']['version'] == 1173) {
-    console.log('JSON - Number(int) validated');
-}
-if(JSON.stringify(jsonObject['profile']['preimum_level']) == JSON.stringify({"suaggar": "V4", "rok": "V5", "asranja": { "type" : "V6"}})) {
-    console.log('JSON - Object validated');
-}
-
-validate();
+// if(jsonObject['data']['ConnectionString'] === 'database_connection'
+//     && jsonObject['data']['userName'] === 'db_admin'
+//     && jsonObject['systemsettings']['appurl'] == 'https://dev.azure.com/helloworld') {
+//     console.log('JSON - simple string change validated');
+// }
+// if(jsonObject['system']['debug'] === 'no_change') {
+//     console.log('JSON - system variable elimination validated');
+// }
+// if(jsonObject['&pl']['ch@r@cter.k^y'] === '*.config') {
+//     console.log('JSON - special variables validated');
+// }
+// if(jsonObject['User.Profile'] === 'do_not_replace') {
+//     console.log('JSON - case sensitive variables validated');
+// }
+// if(jsonObject['constructor.name'] === 'newConstructorName' && 
+//     jsonObject['constructor']['name'] === 'newConstructorName' && jsonObject['constructor']['valueOf'] === 'constructorNewValue') {
+//         console.log('JSON - substitute inbuilt JSON attributes validated');
+// }
+// let newArray = ["suaggar", "rok", "asranja", "chaitanya"];
+// if (jsonObject['profile']['users'].length == 4 && (jsonObject['profile']['users']).every((value, index) => {return value == newArray[index]}) ) {
+//     console.log('JSON - Array Object validated');
+// }
+// if(jsonObject['profile']['enabled'] == false) {
+//     console.log('JSON - Boolean validated');
+// }
+// if(jsonObject['profile']['somefloat'] == 97.75) {
+//     console.log('JSON - Number(float) validated');
+// }
+// if(jsonObject['profile']['version'] == 1173) {
+//     console.log('JSON - Number(int) validated');
+// }
+// if(JSON.stringify(jsonObject['profile']['preimum_level']) == JSON.stringify({"suaggar": "V4", "rok": "V5", "asranja": { "type" : "V6"}})) {
+//     console.log('JSON - Object validated');
+// }

--- a/common-npm-packages/webdeployment-common/Tests/L1JsonVarSubV2.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1JsonVarSubV2.ts
@@ -1,97 +1,88 @@
-// var jsonSubUtil = require('azure-pipelines-tasks-webdeployment-common/jsonvariablesubstitutionutility.js');
+import assert = require('assert');
+import { createEnvTree, substituteJsonVariableV2 } from '../jsonvariablesubstitutionutility';
 
-// var envVarObject = jsonSubUtil.createEnvTree([
-//     { name: 'system.debug', value: 'true', secret: false},
-//     { name: 'data.ConnectionString', value: 'database_connection', secret: false},
-//     { name: 'data.userName', value: 'db_admin', secret: false},
-//     { name: 'data.password', value: 'db_pass', secret: true},
-//     { name: '&pl.ch@r@cter.k^y', value: '*.config', secret: false},
-//     { name: 'build.sourceDirectory', value: 'DefaultWorkingDirectory', secret: false},
-//     { name: 'user.profile.name.first', value: 'firstName', secret: false},
-//     { name: 'user.profile', value: 'replace_all', secret: false},
-//     { name: 'constructor.name', value: 'newConstructorName', secret: false},
-//     { name: 'constructor.valueOf', value: 'constructorNewValue', secret: false},
-//     { name: 'profile.users', value: '["suaggar","rok","asranja", "chaitanya"]', secret: false},
-//     { name: 'profile.enabled', value: 'false', secret: false},
-//     { name: 'profile.version', value: '1173', secret: false},
-//     { name: 'profile.somefloat', value: '97.75', secret: false},
-//     { name: 'profile.preimum_level', value: '{"suaggar": "V4", "rok": "V5", "asranja": { "type" : "V6"}}', secret: false},
-//     { name: 'systemsettings.appurl', value: 'https://dev.azure.com/helloworld', secret: false}
-// ]);
+export function runL1JsonVarSubV2Tests(): void {
+    it("Should substitute JSON variables V2", (done: Mocha.Done) => {
+        const envVarObject = createEnvTree([
+            { name: 'system.debug', value: 'true', secret: false },
+            { name: 'data.ConnectionString', value: 'database_connection', secret: false },
+            { name: 'data.userName', value: 'db_admin', secret: false },
+            { name: 'data.password', value: 'db_pass', secret: true },
+            { name: '&pl.ch@r@cter.k^y', value: '*.config', secret: false },
+            { name: 'build.sourceDirectory', value: 'DefaultWorkingDirectory', secret: false },
+            { name: 'user.profile.name.first', value: 'firstName', secret: false },
+            { name: 'user.profile', value: 'replace_all', secret: false },
+            { name: 'constructor.name', value: 'newConstructorName', secret: false },
+            { name: 'constructor.valueOf', value: 'constructorNewValue', secret: false },
+            { name: 'profile.users', value: '["suaggar","rok","asranja", "chaitanya"]', secret: false },
+            { name: 'profile.enabled', value: 'false', secret: false },
+            { name: 'profile.version', value: '1173', secret: false },
+            { name: 'profile.somefloat', value: '97.75', secret: false },
+            { name: 'profile.preimum_level', value: '{"suaggar": "V4", "rok": "V5", "asranja": { "type" : "V6"}}', secret: false },
+            { name: 'systemsettings.appurl', value: 'https://dev.azure.com/helloworld', secret: false }
+        ]);
 
-// var jsonObject = {
-//     'User.Profile': 'do_not_replace',
-//     'data': {
-//         'ConnectionString' : 'connect_string',
-//         'userName': 'name',
-//         'password': 'pass'
-//     },
-//     '&pl': {
-//         'ch@r@cter.k^y': 'v@lue'
-//     },
-//     'system': {
-//         'debug' : 'no_change'
-//     },
-//     'user.profile': {
-//         'name.first' : 'fname'
-//     },
-//     'constructor.name': 'myconstructorname',
-//     'constructor': {
-//         'name': 'myconstructorname',
-//         'valueOf': 'myconstructorvalue'
-//     },
-//     'profile': {
-//         'users': ['arjgupta', 'raagra', 'muthuk'],
-//         'preimum_level': {
-//             'arjgupta': 'V1',
-//             'raagra': 'V2',
-//             'muthuk': {
-//                 'type': 'V3'
-//             }
-//         },
-//         "enabled": true,
-//         "version": 2,
-//         "somefloat": 2.3456
-//     },
-//     'systemsettings': {
-//         'appurl': 'https://helloworld.visualstudio.com'
-//     }
+        const jsonObject = {
+            'User.Profile': 'do_not_replace',
+            'data': {
+                'ConnectionString': 'connect_string',
+                'userName': 'name',
+                'password': 'pass'
+            },
+            '&pl': {
+                'ch@r@cter.k^y': 'v@lue'
+            },
+            'system': {
+                'debug': 'no_change'
+            },
+            'user.profile': {
+                'name.first': 'fname'
+            },
+            'constructor.name': 'myconstructorname',
+            'constructor': {
+                'name': 'myconstructorname',
+                'valueOf': 'myconstructorvalue'
+            },
+            'profile': {
+                'users': ['arjgupta', 'raagra', 'muthuk'],
+                'preimum_level': {
+                    'arjgupta': 'V1',
+                    'raagra': 'V2',
+                    'muthuk': {
+                        'type': 'V3'
+                    }
+                },
+                "enabled": true,
+                "version": 2,
+                "somefloat": 2.3456
+            },
+            'systemsettings': {
+                'appurl': 'https://helloworld.visualstudio.com'
+            }
 
-// }
-// // Method to be checked for JSON variable substitution
-// jsonSubUtil.substituteJsonVariableV2(jsonObject, envVarObject);
+        };
 
-// if(jsonObject['data']['ConnectionString'] === 'database_connection'
-//     && jsonObject['data']['userName'] === 'db_admin'
-//     && jsonObject['systemsettings']['appurl'] == 'https://dev.azure.com/helloworld') {
-//     console.log('JSON - simple string change validated');
-// }
-// if(jsonObject['system']['debug'] === 'no_change') {
-//     console.log('JSON - system variable elimination validated');
-// }
-// if(jsonObject['&pl']['ch@r@cter.k^y'] === '*.config') {
-//     console.log('JSON - special variables validated');
-// }
-// if(jsonObject['User.Profile'] === 'do_not_replace') {
-//     console.log('JSON - case sensitive variables validated');
-// }
-// if(jsonObject['constructor.name'] === 'newConstructorName' && 
-//     jsonObject['constructor']['name'] === 'newConstructorName' && jsonObject['constructor']['valueOf'] === 'constructorNewValue') {
-//         console.log('JSON - substitute inbuilt JSON attributes validated');
-// }
-// let newArray = ["suaggar", "rok", "asranja", "chaitanya"];
-// if (jsonObject['profile']['users'].length == 4 && (jsonObject['profile']['users']).every((value, index) => {return value == newArray[index]}) ) {
-//     console.log('JSON - Array Object validated');
-// }
-// if(jsonObject['profile']['enabled'] == false) {
-//     console.log('JSON - Boolean validated');
-// }
-// if(jsonObject['profile']['somefloat'] == 97.75) {
-//     console.log('JSON - Number(float) validated');
-// }
-// if(jsonObject['profile']['version'] == 1173) {
-//     console.log('JSON - Number(int) validated');
-// }
-// if(JSON.stringify(jsonObject['profile']['preimum_level']) == JSON.stringify({"suaggar": "V4", "rok": "V5", "asranja": { "type" : "V6"}})) {
-//     console.log('JSON - Object validated');
-// }
+        substituteJsonVariableV2(jsonObject, envVarObject);
+
+        assert.strictEqual(jsonObject['data']['ConnectionString'], 'database_connection');
+        assert.strictEqual(jsonObject['data']['userName'], 'db_admin');
+        assert.strictEqual(jsonObject['systemsettings']['appurl'], 'https://dev.azure.com/helloworld');
+        assert.strictEqual(jsonObject['system']['debug'], 'no_change');
+        assert.strictEqual(jsonObject['&pl']['ch@r@cter.k^y'], '*.config');
+        assert.strictEqual(jsonObject['User.Profile'], 'do_not_replace');
+        assert.strictEqual(jsonObject['constructor.name'], 'newConstructorName');
+        assert.strictEqual(jsonObject['constructor']['name'], 'newConstructorName');
+        assert.strictEqual(jsonObject['constructor']['valueOf'], 'constructorNewValue');
+        assert.strictEqual(jsonObject['profile']['users'].length, 4);
+        assert.notStrictEqual(jsonObject['profile']['users'].indexOf('suaggar'), -1);
+        assert.notStrictEqual(jsonObject['profile']['users'].indexOf('rok'), -1);
+        assert.notStrictEqual(jsonObject['profile']['users'].indexOf('asranja'), -1);
+        assert.notStrictEqual(jsonObject['profile']['users'].indexOf('chaitanya'), -1);
+        assert.strictEqual(jsonObject['profile']['enabled'], false);
+        assert.strictEqual(jsonObject['profile']['somefloat'], 97.75);
+        assert.strictEqual(jsonObject['profile']['version'], 1173);
+        assert.deepStrictEqual(jsonObject['profile']['preimum_level'], { suaggar: "V4", rok: "V5", asranja: { type: "V6" } });
+
+        done();
+    });
+}

--- a/common-npm-packages/webdeployment-common/Tests/L1ValidateFileEncoding.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1ValidateFileEncoding.ts
@@ -1,77 +1,61 @@
-var fileEncoding = require('../fileencoding.js');
+import * as assert from 'assert';
+import { detectFileEncoding } from '../fileencoding';
 
-var fileEncodeType = fileEncoding.detectFileEncoding('utf-8.txt', new Buffer([239, 187, 191, 0]));
-if(fileEncodeType[0] === 'utf-8' && fileEncodeType[1]) {
-    console.log('UTF-8 with BOM validated');
-}
+export function runL1ValidateFileEncodingTests(this: Mocha.Suite): void {
 
-try {
-    var fileEncodeType = fileEncoding.detectFileEncoding('utf-32le.txt', new Buffer([255, 254, 0, 0]));
-}
-catch(exception) {
-    console.log('UTF-32LE with BOM validated');
-}
+    it("UTF-8 with BOM", () => {
+        const fileEncodeType = detectFileEncoding('utf-8.txt', Buffer.from([239, 187, 191, 0]));
+        assert.strictEqual(fileEncodeType[0], 'utf-8');
+        assert.strictEqual(fileEncodeType[1], true);
+    });
 
-try {
-    var fileEncodeType = fileEncoding.detectFileEncoding('utf-16be.txt', new Buffer([254, 255, 0 ,0]));
-}
-catch(exception) {
-    console.log('UTF-16BE with BOM validated');
-}
+    it("UTF-32LE with BOM", () => {
+        assert.throws(() => detectFileEncoding('utf-32le.txt', Buffer.from([255, 254, 0, 0])));
+    });
 
-var fileEncodeType = fileEncoding.detectFileEncoding('utf-16le.txt', new Buffer([255, 254, 10, 10]));
-if(fileEncodeType[0] === 'utf-16le' && fileEncodeType[1]) {
-    console.log('UTF-16LE with BOM validated');
-}
+    it("UTF-16BE with BOM", () => {
+        assert.throws(() => detectFileEncoding('utf-16be.txt', Buffer.from([254, 255, 0, 0])));
+    });
 
-try {
-    var fileEncodeType = fileEncoding.detectFileEncoding('utf-32BE.txt', new Buffer([0, 0, 254, 255]));
-}
-catch(exception) {
-    console.log('UTF-32BE with BOM validated');
-}
+    it("UTF-16LE with BOM", () => {
+        const fileEncodeType = detectFileEncoding('utf-16le.txt', Buffer.from([255, 254, 10, 10]));
+        assert.strictEqual(fileEncodeType[0], 'utf-16le');
+        assert.strictEqual(fileEncodeType[1], true);
+    });
 
-var fileEncodeType = fileEncoding.detectFileEncoding('utf-8.txt', new Buffer([10, 11, 12, 13]));
-if(fileEncodeType[0] === 'utf-8' && !fileEncodeType[1]) {
-    console.log('UTF-8 without BOM validated');
-}
+    it("UTF-32BE with BOM", () => {
+        assert.throws(() => detectFileEncoding('utf-32BE.txt', Buffer.from([0, 0, 254, 255])));
+    });
 
-try {
-    var fileEncodeType = fileEncoding.detectFileEncoding('utf-32le.txt', new Buffer([255, 0, 0, 0]));
-}
-catch(exception) {
-    console.log('UTF-32LE without BOM validated');
-}
+    it("UTF-8 without BOM", () => {
+        const fileEncodeType = detectFileEncoding('utf-8.txt', Buffer.from([10, 11, 12, 13]));
+        assert.strictEqual(fileEncodeType[0], 'utf-8');
+        assert.strictEqual(fileEncodeType[1], false);
+    });
 
-try {
-    var fileEncodeType = fileEncoding.detectFileEncoding('utf-32be.txt', new Buffer([0, 0, 0, 255]));
-}
-catch(exception) {
-    console.log('UTF-32BE without BOM validated');
-}
+    it("UTF-32LE without BOM", () => {
+        assert.throws(() => detectFileEncoding('utf-32le.txt', Buffer.from([255, 0, 0, 0])));
+    });
 
-try {
-    var fileEncodeType = fileEncoding.detectFileEncoding('utf-16be.txt', new Buffer([0, 10, 0 ,20]));
-}
-catch(exception) {
-    console.log('UTF-16BE without BOM validated');
-}
+    it("UTF-32BE without BOM", () => {
+        assert.throws(() => detectFileEncoding('utf-32be.txt', Buffer.from([0, 0, 0, 255])));
+    });
 
-var fileEncodeType = fileEncoding.detectFileEncoding('utf-16le.txt', new Buffer([20, 0, 10, 0]));
-if(fileEncodeType[0] === 'utf-16le' && !fileEncodeType[1]) {
-    console.log('UTF-16LE without BOM validated');
-}
+    it("UTF-16BE without BOM", () => {
+        assert.throws(() => detectFileEncoding('utf-16be.txt', Buffer.from([0, 10, 0 ,20])));
+    });
 
-try {
-    fileEncoding.detectFileEncoding('utfShort.txt', new Buffer([20, 0]));
-}
-catch(exception) {
-    console.log('Short File Buffer Error');
-}
+    it("UTF-16LE without BOM", () => {
+        const fileEncodeType = detectFileEncoding('utf-16le.txt', Buffer.from([20, 0, 10, 0]));
+        assert.strictEqual(fileEncodeType[0], 'utf-16le');
+        assert.strictEqual(fileEncodeType[1], false);
+    });
 
-try {
-    fileEncoding.detectFileEncoding('utfUnknown.txt', new Buffer([0, 10, 20, 30]));
-}
-catch(exception) {
-    console.log('Unknown encoding type')
-}
+    it("Short File Buffer Error", () => {
+        assert.throws(() => detectFileEncoding('utfShort.txt', Buffer.from([20, 0])));
+    });
+
+    it("Unknown encoding type", () => {
+        assert.throws(() => detectFileEncoding('utfUnknown.txt', Buffer.from([0, 10, 20, 30])));
+    });
+} 

--- a/common-npm-packages/webdeployment-common/Tests/L1XdtTransform.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1XdtTransform.ts
@@ -8,7 +8,9 @@ import { applyXdtTransformation } from "../xdttransformationutility";
 import { detectFileEncoding } from "../fileencoding";
 
 
-export function runL1XdtTransformTests() {
+export function runL1XdtTransformTests(this: Mocha.Suite) {
+
+    this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
     beforeEach(done => {
         tl.cp(getAbsolutePath('Web.config'), getAbsolutePath('Web_test.config'), '-f', false);
@@ -32,8 +34,6 @@ export function runL1XdtTransformTests() {
         if (tl.getPlatform() !== tl.Platform.Windows) {
             this.skip();
         }
-
-        this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
         applyXdtTransformation(getAbsolutePath('Web_test.config'), getAbsolutePath('Web.Debug.config'));
 

--- a/common-npm-packages/webdeployment-common/Tests/L1XdtTransform.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1XdtTransform.ts
@@ -28,11 +28,9 @@ export function runL1XdtTransformTests() {
         }
     });
 
-    it('Runs successfully with XML Transformation (L1)', (done) => {
-
+    it('Runs successfully with XML Transformation (L1)', function(done: Mocha.Done) {
         if (tl.getPlatform() !== tl.Platform.Windows) {
             this.skip();
-            return;
         }
 
         this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);

--- a/common-npm-packages/webdeployment-common/Tests/L1XdtTransform.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1XdtTransform.ts
@@ -1,6 +1,59 @@
-var path = require('path');
-var ltx = require('ltx');
-var xdtTransform = require('azure-pipelines-tasks-webdeployment-common/xdttransformationutility.js');
-process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] = path.join(__dirname, 'L1XdtTransform');
-xdtTransform.applyXdtTransformation(path.join(__dirname, 'L1XdtTransform', 'Web_test.config'), path.join(__dirname, 'L1XdtTransform', 'Web.Debug.config'));
-process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] = 'DefaultWorkingDirectory';
+import * as tl from 'azure-pipelines-task-lib';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ltx from 'ltx';
+
+import { applyXdtTransformation } from "../xdttransformationutility";
+import { detectFileEncoding } from "../fileencoding";
+
+
+export function runL1XdtTransformTests() {
+
+    beforeEach(done => {
+        tl.cp(getAbsolutePath('Web.config'), getAbsolutePath('Web_test.config'), '-f', false);
+ 
+        done();
+    });
+ 
+    afterEach(done => {
+        try {
+            tl.rmRF(getAbsolutePath('Web_test.config'));
+        }
+        catch (error) {
+            tl.debug(error);
+        }
+        finally {
+            done();
+        }
+    });
+
+    it('Runs successfully with XML Transformation (L1)', (done) => {
+
+        if (tl.getPlatform() !== tl.Platform.Windows) {
+            this.skip();
+            return;
+        }
+
+        this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+
+        applyXdtTransformation(getAbsolutePath('Web_test.config'), getAbsolutePath('Web.Debug.config'));
+
+        const resultFile = readXmlFile(getAbsolutePath('Web_test.config'));
+        const expectFile = readXmlFile(getAbsolutePath('Web_Expected.config'));
+        assert(ltx.equal(resultFile, expectFile), 'Should Transform attributes on Web.config');
+        done();
+
+    });
+
+    function getAbsolutePath(file: string): string {
+        return path.join(__dirname, 'L1XdtTransform', file);
+    }
+
+    function readXmlFile(path: string): ltx.Element {
+        const buffer = fs.readFileSync(path);
+        const encoding = detectFileEncoding(path, buffer)[0].toString();
+        const xml = buffer.toString(encoding).replace( /(?<!\r)[\n]+/gm, "\r\n" );
+        return ltx.parse(xml);
+    }
+}

--- a/common-npm-packages/webdeployment-common/Tests/L1XmlVarSub.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1XmlVarSub.ts
@@ -87,7 +87,13 @@ export function runL1XmlVarSubTests() {
         transformedFileAsBuffer = Buffer.from(transformedFileAsString, transformedFileEncodeType);
         var resultFile = ltx.parse(transformedFileAsBuffer);
         var expectFile = ltx.parse(expectedFileAsBuffer);
-        return ltx.equal(resultFile, expectFile);
+        const result = ltx.equal(resultFile, expectFile);
+
+        if (!result) {
+            console.debug(transformedFileAsString);
+        }
+
+        return result;
     }
 }
 

--- a/common-npm-packages/webdeployment-common/Tests/L1XmlVarSub.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1XmlVarSub.ts
@@ -10,33 +10,34 @@ import { detectFileEncoding } from "../fileencoding";
 
 export function runL1XmlVarSubTests() {
 
-    this.timeout(60000);
 
-    beforeEach(done => {
-       tl.cp(getAbsolutePath('Web.config'), getAbsolutePath('Web_test.config'), '-f', false);
-       tl.cp(getAbsolutePath('Web.Debug.config'), getAbsolutePath('Web_test.Debug.config'), '-f', false);
-       tl.cp(getAbsolutePath('parameters.xml'), getAbsolutePath('parameters_test.xml'), '-f', false);
+    beforeEach(function (done: Mocha.Done) {
+        this.timeout(60000);
 
-       done();
-   });
+        tl.cp(getAbsolutePath('Web.config'), getAbsolutePath('Web_test.config'), '-f', false);
+        tl.cp(getAbsolutePath('Web.Debug.config'), getAbsolutePath('Web_test.Debug.config'), '-f', false);
+        tl.cp(getAbsolutePath('parameters.xml'), getAbsolutePath('parameters_test.xml'), '-f', false);
 
-   afterEach(done => {
-       try {
-           tl.rmRF(getAbsolutePath('parameters_test.xml'));
-           tl.rmRF(getAbsolutePath('Web_test.Debug.config'));
-           tl.rmRF(getAbsolutePath('Web_test.config'));
-       }
-       catch (error) {
-           tl.debug(error);
-       }
-       finally {
-           done();
-       }
-   });
+        done();
+    });
+
+    afterEach(done => {
+        try {
+            tl.rmRF(getAbsolutePath('parameters_test.xml'));
+            tl.rmRF(getAbsolutePath('Web_test.Debug.config'));
+            tl.rmRF(getAbsolutePath('Web_test.config'));
+        }
+        catch (error) {
+            tl.debug(error);
+        }
+        finally {
+            done();
+        }
+    });
 
     it("Runs successfully with XML variable substitution", done => {
         const parameterFilePath = getAbsolutePath('parameters_test.xml');
-        const tags = [ "applicationSettings", "appSettings", "connectionStrings", "configSections" ];
+        const tags = ["applicationSettings", "appSettings", "connectionStrings", "configSections"];
         const variableMap = {
             'conntype': 'new_connType',
             "MyDB": "TestDB",
@@ -52,7 +53,7 @@ export function runL1XmlVarSubTests() {
             'log_level': 'error,warning',
             'Email:ToOverride': ''
         };
-        
+
         substituteXmlVariables(getAbsolutePath('Web_test.config'), tags, variableMap, parameterFilePath);
         substituteXmlVariables(getAbsolutePath('Web_test.Debug.config'), tags, variableMap, parameterFilePath);
 
@@ -80,7 +81,7 @@ export function runL1XmlVarSubTests() {
     function readFile(path: string): string {
         const buffer = fs.readFileSync(path);
         const encoding = detectFileEncoding(path, buffer)[0].toString();
-        return buffer.toString(encoding).replace( /(?<!\r)[\n]+/gm, "\r\n" );
+        return buffer.toString(encoding).replace(/(?<!\r)[\n]+/gm, "\r\n");
     }
 }
 

--- a/common-npm-packages/webdeployment-common/Tests/L1XmlVarSub.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1XmlVarSub.ts
@@ -8,12 +8,11 @@ import * as tl from 'azure-pipelines-task-lib';
 import { substituteXmlVariables } from '../xmlvariablesubstitutionutility';
 import { detectFileEncoding } from "../fileencoding";
 
-export function runL1XmlVarSubTests() {
+export function runL1XmlVarSubTests(this: Mocha.Suite): void {
 
+    this.timeout(60000);
 
     beforeEach(function (done: Mocha.Done) {
-        this.timeout(60000);
-
         tl.cp(getAbsolutePath('Web.config'), getAbsolutePath('Web_test.config'), '-f', false);
         tl.cp(getAbsolutePath('Web.Debug.config'), getAbsolutePath('Web_test.Debug.config'), '-f', false);
         tl.cp(getAbsolutePath('parameters.xml'), getAbsolutePath('parameters_test.xml'), '-f', false);

--- a/common-npm-packages/webdeployment-common/Tests/L1XmlVarSub.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1XmlVarSub.ts
@@ -1,10 +1,12 @@
-import * as tl from 'azure-pipelines-task-lib';
-import { substituteXmlVariables } from '../xmlvariablesubstitutionutility';
-import { detectFileEncoding } from "../fileencoding";
-import * as  path from 'path';
-import assert = require('assert');
+import * as path from 'path';
+import * as assert from 'assert';
 import * as ltx from 'ltx';
 import * as fs from 'fs';
+
+import * as tl from 'azure-pipelines-task-lib';
+
+import { substituteXmlVariables } from '../xmlvariablesubstitutionutility';
+import { detectFileEncoding } from "../fileencoding";
 
 export function runL1XmlVarSubTests() {
 
@@ -32,7 +34,7 @@ export function runL1XmlVarSubTests() {
        }
    });
 
-    it("Should replace xml variables", done => {
+    it("Runs successfully with XML variable substitution", done => {
         const parameterFilePath = getAbsolutePath('parameters_test.xml');
         const tags = [ "applicationSettings", "appSettings", "connectionStrings", "configSections" ];
         const variableMap = {

--- a/common-npm-packages/webdeployment-common/Tests/L1XmlVarSub.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1XmlVarSub.ts
@@ -1,29 +1,93 @@
-var xmlSubstitutionUtility = require('azure-pipelines-tasks-webdeployment-common/xmlvariablesubstitutionutility.js');
-var path = require('path');
+import * as tl from 'azure-pipelines-task-lib';
+import { substituteXmlVariables } from '../xmlvariablesubstitutionutility';
+import { detectFileEncoding } from "../fileencoding";
+import * as  path from 'path';
+import assert = require('assert');
+import * as ltx from 'ltx';
+import * as fs from 'fs';
 
-async function xmlVarSub() {
-    var tags = ["applicationSettings", "appSettings", "connectionStrings", "configSections"];
-    var configFiles = [path.join(__dirname, 'L1XmlVarSub/Web_test.config'), path.join(__dirname, 'L1XmlVarSub/Web_test.Debug.config')];
-    var variableMap = {
-        'conntype' : 'new_connType',
-        "MyDB": "TestDB",
-        'webpages:Version' : '1.1.7.3',
-        'xdt:Transform' : 'DelAttributes',
-        'xdt:Locator' : 'Match(tag)',
-        'DefaultConnection': "Url=https://primary;Database=db1;ApiKey=11111111-1111-1111-1111-111111111111;Failover = {Url:'https://secondary', ApiKey:'11111111-1111-1111-1111-111111111111'}",
-        'OtherDefaultConnection': 'connectionStringValue2',
-        'ParameterConnection': 'New_Connection_String From xml var subs',
-        'connectionString': 'replaced_value',
-        'invariantName': 'System.Data.SqlServer',
-        'blatvar': 'ApplicationSettingReplacedValue',
-        'log_level': 'error,warning',
-        'Email:ToOverride': ''
+export function runL1XmlVarSubTests() {
+
+    this.timeout(60000);
+
+    beforeEach(done => {
+       tl.cp(getAbsolutePath('Web.config'), getAbsolutePath('Web_test.config'), '-f', false);
+       tl.cp(getAbsolutePath('Web.Debug.config'), getAbsolutePath('Web_test.Debug.config'), '-f', false);
+       tl.cp(getAbsolutePath('parameters.xml'), getAbsolutePath('parameters_test.xml'), '-f', false);
+
+       done();
+   });
+
+   afterEach(done => {
+       try {
+           tl.rmRF(getAbsolutePath('parameters_test.xml'));
+           tl.rmRF(getAbsolutePath('Web_test.Debug.config'));
+           tl.rmRF(getAbsolutePath('Web_test.config'));
+       }
+       catch (error) {
+           tl.debug(error);
+       }
+       finally {
+           done();
+       }
+   });
+
+    it("Should replace xml variables", done => {
+        const tags = ["applicationSettings", "appSettings", "connectionStrings", "configSections"];
+        const configFiles = [
+            getAbsolutePath('Web_test.config'),
+            getAbsolutePath('Web_test.Debug.config')
+        ];
+        const variableMap = {
+            'conntype': 'new_connType',
+            "MyDB": "TestDB",
+            'webpages:Version': '1.1.7.3',
+            'xdt:Transform': 'DelAttributes',
+            'xdt:Locator': 'Match(tag)',
+            'DefaultConnection': "Url=https://primary;Database=db1;ApiKey=11111111-1111-1111-1111-111111111111;Failover = {Url:'https://secondary', ApiKey:'11111111-1111-1111-1111-111111111111'}",
+            'OtherDefaultConnection': 'connectionStringValue2',
+            'ParameterConnection': 'New_Connection_String From xml var subs',
+            'connectionString': 'replaced_value',
+            'invariantName': 'System.Data.SqlServer',
+            'blatvar': 'ApplicationSettingReplacedValue',
+            'log_level': 'error,warning',
+            'Email:ToOverride': ''
+        };
+
+        const parameterFilePath = getAbsolutePath('parameters_test.xml');
+        for (const configFile of configFiles) {
+            substituteXmlVariables(configFile, tags, variableMap, parameterFilePath);
+        }
+
+        let transformedFilePath = getAbsolutePath('Web_test.config');
+        let expectedFilePath = getAbsolutePath('Web_Expected.config');
+        assert(compareXmlFiles(transformedFilePath, expectedFilePath), 'Should have substituted variables in Web.config file');
+        
+        transformedFilePath = getAbsolutePath('Web_test.Debug.config');
+        expectedFilePath = getAbsolutePath('Web_Expected.Debug.config');
+        assert(compareXmlFiles(transformedFilePath, expectedFilePath), 'Should have substituted variables in Web.Debug.config file');
+
+        var resultParamFile = ltx.parse(fs.readFileSync(getAbsolutePath('parameters_test.xml')));
+        var expectParamFile = ltx.parse(fs.readFileSync(getAbsolutePath('parameters_Expected.xml')));
+        assert(ltx.equal(resultParamFile, expectParamFile), 'Should have substituted variables in parameters.xml file');
+
+        done();
+    });
+
+    function getAbsolutePath(file: string): string {
+        return path.join(__dirname, 'L1XmlVarSub', file);
     }
 
-    var parameterFilePath = path.join(__dirname, 'L1XmlVarSub/parameters_test.xml');
-    for(var configFile of configFiles) {
-        await xmlSubstitutionUtility.substituteXmlVariables(configFile, tags, variableMap, parameterFilePath);
+    function compareXmlFiles(actualFilePath: string, expectedFilePath: string): boolean {
+        let transformedFileAsBuffer = fs.readFileSync(actualFilePath);
+        const expectedFileAsBuffer = fs.readFileSync(expectedFilePath);
+        const transformedFileEncodeType = detectFileEncoding(actualFilePath, transformedFileAsBuffer)[0].toString();
+        let transformedFileAsString = transformedFileAsBuffer.toString(transformedFileEncodeType);
+        transformedFileAsString = transformedFileAsString.replace( /(?<!\r)[\n]+/gm, "\r\n" );
+        transformedFileAsBuffer = Buffer.from(transformedFileAsString, transformedFileEncodeType);
+        var resultFile = ltx.parse(transformedFileAsBuffer);
+        var expectFile = ltx.parse(expectedFileAsBuffer);
+        return ltx.equal(resultFile, expectFile);
     }
 }
 
-xmlVarSub();

--- a/common-npm-packages/webdeployment-common/build.ps1
+++ b/common-npm-packages/webdeployment-common/build.ps1
@@ -1,4 +1,5 @@
 node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip ./7zip
 node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M142/MSDeploy.zip ./MSDeploy/M142
 node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M229/MSDeploy.zip ./MSDeploy/M229
+node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/ctt/1.6/ctt.zip ./ctt
 node make.js

--- a/common-npm-packages/webdeployment-common/jsonvariablesubstitutionutility.ts
+++ b/common-npm-packages/webdeployment-common/jsonvariablesubstitutionutility.ts
@@ -1,7 +1,6 @@
 import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
 import fs = require('fs');
-import { isNumber, isBoolean } from 'util';
 
 var varUtility = require ('./variableutility.js');
 var fileEncoding = require('./fileencoding.js');

--- a/common-npm-packages/webdeployment-common/make.js
+++ b/common-npm-packages/webdeployment-common/make.js
@@ -10,6 +10,7 @@ util.cp(path.join(__dirname, 'package.json'), buildPath);
 util.cp(path.join(__dirname, 'package-lock.json'), buildPath);
 util.cp(path.join(__dirname, 'module.json'), buildPath);
 util.cp('-r', '7zip', buildPath);
+util.cp('-r', 'ctt', buildPath);
 util.cp('-r', 'MSDeploy', buildPath);
 util.cp('-r', 'node_modules', buildPath);
 util.cp('-r', 'Strings', buildPath);

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -385,12 +385,25 @@
                 "@types/node": "*"
             }
         },
+        "@types/events": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.2.tgz",
+            "integrity": "sha512-v4Mr60wJuF069iZZCdY5DKhfj0l6eXNJtbSM/oMDNdRLoBEUsktmKnswkz0X3OAic5W8Qy/YU6owKE4A66Y46A=="
+        },
         "@types/form-data": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
             "integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
             "requires": {
                 "@types/node": "*"
+            }
+        },
+        "@types/ltx": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/ltx/-/ltx-3.0.6.tgz",
+            "integrity": "sha512-ZdHUgFEaBVUHI0si050pQkuGzHQC5UU46JsljUUJkGWbsjKeV3RUspJvvdV80Inrnhx8d3JqXw4qCDRX4A/BdA==",
+            "requires": {
+                "@types/events": "*"
             }
         },
         "@types/mocha": {

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.230.1",
+    "version": "4.230.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -4,6 +4,379 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@ampproject/remapping": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+            "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/gen-mapping": "^0.3.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            }
+        },
+        "@babel/code-frame": {
+            "version": "7.22.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.22.13",
+                "chalk": "^2.4.2"
+            }
+        },
+        "@babel/compat-data": {
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
+            "integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
+            "dev": true
+        },
+        "@babel/core": {
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
+            "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+            "dev": true,
+            "requires": {
+                "@ampproject/remapping": "^2.2.0",
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-compilation-targets": "^7.22.15",
+                "@babel/helper-module-transforms": "^7.23.0",
+                "@babel/helpers": "^7.23.2",
+                "@babel/parser": "^7.23.0",
+                "@babel/template": "^7.22.15",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.23.0",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "dependencies": {
+                "convert-source-map": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+                    "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+            "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.23.0",
+                "@jridgewell/gen-mapping": "^0.3.2",
+                "@jridgewell/trace-mapping": "^0.3.17",
+                "jsesc": "^2.5.1"
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+            "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.22.9",
+                "@babel/helper-validator-option": "^7.22.15",
+                "browserslist": "^4.21.9",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-environment-visitor": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+            "dev": true
+        },
+        "@babel/helper-function-name": {
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.22.5"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+            "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.22.15"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+            "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-module-imports": "^7.22.15",
+                "@babel/helper-simple-access": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/helper-validator-identifier": "^7.22.20"
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+            "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.22.5"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.22.5"
+            }
+        },
+        "@babel/helper-string-parser": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "dev": true
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+            "dev": true
+        },
+        "@babel/helper-validator-option": {
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+            "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+            "dev": true
+        },
+        "@babel/helpers": {
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
+            "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.22.15",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.23.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+            "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "chalk": "^2.4.2",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+            "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+            "dev": true
+        },
+        "@babel/template": {
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.22.13",
+                "@babel/parser": "^7.22.15",
+                "@babel/types": "^7.22.15"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+            "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-string-parser": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@istanbuljs/load-nyc-config": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.3.1",
+                "find-up": "^4.1.0",
+                "get-package-type": "^0.1.0",
+                "js-yaml": "^3.13.1",
+                "resolve-from": "^5.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                }
+            }
+        },
+        "@istanbuljs/schema": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "dev": true
+        },
+        "@jridgewell/gen-mapping": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            }
+        },
+        "@jridgewell/resolve-uri": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "dev": true
+        },
+        "@jridgewell/set-array": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true
+        },
+        "@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "dev": true
+        },
+        "@jridgewell/trace-mapping": {
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
         "@types/concat-stream": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.1.tgz",
@@ -44,6 +417,46 @@
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
+        "aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "dev": true,
+            "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            }
+        },
+        "ansi-colors": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+            "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+            "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "append-transform": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+            "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+            "dev": true,
+            "requires": {
+                "default-require-extensions": "^3.0.0"
+            }
+        },
         "archiver": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.2.0.tgz",
@@ -72,6 +485,73 @@
                 "readable-stream": "^2.0.0"
             }
         },
+        "archy": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+            "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "array-buffer-byte-length": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+            "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "is-array-buffer": "^3.0.1"
+            }
+        },
+        "array.prototype.reduce": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.6.tgz",
+            "integrity": "sha512-UW+Mz8LG/sPSU8jRDCjVr6J/ZKAGpHfwrZ6kWTG5qCxIEiXdVshqGnu5vEZA8S1y6X4aCSbQZ0/EEsfvEvBiSg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1",
+                "es-array-method-boxes-properly": "^1.0.0",
+                "is-string": "^1.0.7"
+            }
+        },
+        "arraybuffer.prototype.slice": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
+            "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
+            "dev": true,
+            "requires": {
+                "array-buffer-byte-length": "^1.0.0",
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1",
+                "get-intrinsic": "^1.2.1",
+                "is-array-buffer": "^3.0.2",
+                "is-shared-array-buffer": "^1.0.2"
+            },
+            "dependencies": {
+                "get-intrinsic": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+                    "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-proto": "^1.0.1",
+                        "has-symbols": "^1.0.3"
+                    }
+                }
+            }
+        },
         "asap": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -89,6 +569,12 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "available-typed-arrays": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+            "dev": true
         },
         "azure-pipelines-task-lib": {
             "version": "4.2.0",
@@ -156,6 +642,24 @@
                 "concat-map": "0.0.1"
             }
         },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
+        },
+        "browserslist": {
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+            "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+            "dev": true,
+            "requires": {
+                "caniuse-lite": "^1.0.30001541",
+                "electron-to-chromium": "^1.4.535",
+                "node-releases": "^2.0.13",
+                "update-browserslist-db": "^1.0.13"
+            }
+        },
         "buffer": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -199,6 +703,18 @@
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
             "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="
         },
+        "caching-transform": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+            "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+            "dev": true,
+            "requires": {
+                "hasha": "^5.0.0",
+                "make-dir": "^3.0.0",
+                "package-hash": "^4.0.0",
+                "write-file-atomic": "^3.0.0"
+            }
+        },
         "call-bind": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -207,6 +723,18 @@
                 "function-bind": "^1.1.1",
                 "get-intrinsic": "^1.0.2"
             }
+        },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true
+        },
+        "caniuse-lite": {
+            "version": "1.0.30001550",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001550.tgz",
+            "integrity": "sha512-p82WjBYIypO0ukTsd/FG3Xxs+4tFeaY9pfT4amQL8KWtYH7H9nYwReGAbMTJ0hsmRO8IfDtsS6p3ZWj8+1c2RQ==",
+            "dev": true
         },
         "caseless": {
             "version": "0.12.0",
@@ -221,6 +749,88 @@
                 "traverse": ">=0.3.0 <0.4"
             }
         },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true
+        },
+        "cliui": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+            "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+            "dev": true,
+            "requires": {
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+                    "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
+        },
         "combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -228,6 +838,12 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+            "dev": true
         },
         "compress-commons": {
             "version": "1.2.2",
@@ -256,6 +872,12 @@
                 "typedarray": "^0.0.6"
             }
         },
+        "convert-source-map": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "dev": true
+        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -277,6 +899,43 @@
                 "crc": "^3.4.4",
                 "readable-stream": "^2.0.0"
             }
+        },
+        "cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
+            "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "debug": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+            "dev": true,
+            "requires": {
+                "ms": "^2.1.1"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+            "dev": true
         },
         "decompress-zip": {
             "version": "0.3.3",
@@ -315,10 +974,73 @@
                 }
             }
         },
+        "default-require-extensions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+            "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
+            "dev": true,
+            "requires": {
+                "strip-bom": "^4.0.0"
+            }
+        },
+        "define-data-property": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "dependencies": {
+                "get-intrinsic": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+                    "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-proto": "^1.0.1",
+                        "has-symbols": "^1.0.3"
+                    }
+                }
+            }
+        },
+        "define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
+            "requires": {
+                "define-data-property": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            }
+        },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
+        },
+        "electron-to-chromium": {
+            "version": "1.4.557",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.557.tgz",
+            "integrity": "sha512-6x0zsxyMXpnMJnHrondrD3SuAeKcwij9S+83j2qHAQPXbGTDDfgImzzwgGlzrIcXbHQ42tkG4qA6U860cImNhw==",
+            "dev": true
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+            "dev": true
         },
         "end-of-stream": {
             "version": "1.4.4",
@@ -326,6 +1048,179 @@
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "requires": {
                 "once": "^1.4.0"
+            }
+        },
+        "es-abstract": {
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.2.tgz",
+            "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
+            "dev": true,
+            "requires": {
+                "array-buffer-byte-length": "^1.0.0",
+                "arraybuffer.prototype.slice": "^1.0.2",
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "es-set-tostringtag": "^2.0.1",
+                "es-to-primitive": "^1.2.1",
+                "function.prototype.name": "^1.1.6",
+                "get-intrinsic": "^1.2.1",
+                "get-symbol-description": "^1.0.0",
+                "globalthis": "^1.0.3",
+                "gopd": "^1.0.1",
+                "has": "^1.0.3",
+                "has-property-descriptors": "^1.0.0",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "internal-slot": "^1.0.5",
+                "is-array-buffer": "^3.0.2",
+                "is-callable": "^1.2.7",
+                "is-negative-zero": "^2.0.2",
+                "is-regex": "^1.1.4",
+                "is-shared-array-buffer": "^1.0.2",
+                "is-string": "^1.0.7",
+                "is-typed-array": "^1.1.12",
+                "is-weakref": "^1.0.2",
+                "object-inspect": "^1.12.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.4",
+                "regexp.prototype.flags": "^1.5.1",
+                "safe-array-concat": "^1.0.1",
+                "safe-regex-test": "^1.0.0",
+                "string.prototype.trim": "^1.2.8",
+                "string.prototype.trimend": "^1.0.7",
+                "string.prototype.trimstart": "^1.0.7",
+                "typed-array-buffer": "^1.0.0",
+                "typed-array-byte-length": "^1.0.0",
+                "typed-array-byte-offset": "^1.0.0",
+                "typed-array-length": "^1.0.4",
+                "unbox-primitive": "^1.0.2",
+                "which-typed-array": "^1.1.11"
+            },
+            "dependencies": {
+                "get-intrinsic": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+                    "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-proto": "^1.0.1",
+                        "has-symbols": "^1.0.3"
+                    }
+                },
+                "object.assign": {
+                    "version": "4.1.4",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+                    "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "has-symbols": "^1.0.3",
+                        "object-keys": "^1.1.1"
+                    }
+                }
+            }
+        },
+        "es-array-method-boxes-properly": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+            "dev": true
+        },
+        "es-set-tostringtag": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+            "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.3",
+                "has": "^1.0.3",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+            "dev": true
+        },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "find-cache-dir": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+            "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^3.0.2",
+                "pkg-dir": "^4.1.0"
+            }
+        },
+        "find-up": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+            "dev": true,
+            "requires": {
+                "locate-path": "^3.0.0"
+            }
+        },
+        "flat": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+            "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "~2.0.3"
+            }
+        },
+        "for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.3"
+            }
+        },
+        "foreground-child": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+            "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "form-data": {
@@ -337,6 +1232,12 @@
                 "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
             }
+        },
+        "fromentries": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+            "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+            "dev": true
         },
         "fs-constants": {
             "version": "1.0.0",
@@ -353,6 +1254,36 @@
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
+        "function.prototype.name": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+            "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1",
+                "functions-have-names": "^1.2.3"
+            }
+        },
+        "functions-have-names": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+            "dev": true
+        },
+        "gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
+        },
         "get-intrinsic": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
@@ -363,10 +1294,26 @@
                 "has-symbols": "^1.0.3"
             }
         },
+        "get-package-type": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+            "dev": true
+        },
         "get-port": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
             "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg=="
+        },
+        "get-symbol-description": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+            "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.1"
+            }
         },
         "glob": {
             "version": "7.1.6",
@@ -381,10 +1328,40 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
+        },
+        "globalthis": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+            "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3"
+            }
+        },
+        "gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.3"
+            }
+        },
         "graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+        },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+            "dev": true
         },
         "has": {
             "version": "1.0.3",
@@ -394,10 +1371,68 @@
                 "function-bind": "^1.1.1"
             }
         },
+        "has-bigints": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+            "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+            "dev": true
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true
+        },
+        "has-property-descriptors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.1"
+            }
+        },
+        "has-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "dev": true
+        },
         "has-symbols": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
             "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+        },
+        "has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "hasha": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+            "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+            "dev": true,
+            "requires": {
+                "is-stream": "^2.0.0",
+                "type-fest": "^0.8.0"
+            }
+        },
+        "he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true
+        },
+        "html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true
         },
         "http-basic": {
             "version": "8.1.3",
@@ -423,6 +1458,18 @@
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true
+        },
+        "indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -437,10 +1484,63 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
+        "internal-slot": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+            "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.2.0",
+                "has": "^1.0.3",
+                "side-channel": "^1.0.4"
+            }
+        },
         "interpret": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+        },
+        "is-array-buffer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+            "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.0",
+                "is-typed-array": "^1.1.10"
+            }
+        },
+        "is-bigint": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+            "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+            "dev": true,
+            "requires": {
+                "has-bigints": "^1.0.1"
+            }
+        },
+        "is-boolean-object": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+            "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-buffer": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+            "dev": true
+        },
+        "is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "dev": true
         },
         "is-core-module": {
             "version": "2.11.0",
@@ -450,10 +1550,303 @@
                 "has": "^1.0.3"
             }
         },
+        "is-date-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+            "dev": true
+        },
+        "is-negative-zero": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+            "dev": true
+        },
+        "is-number-object": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+            "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-regex": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-shared-array-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+            "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
+        },
+        "is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true
+        },
+        "is-string": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+            "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "is-typed-array": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+            "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+            "dev": true,
+            "requires": {
+                "which-typed-array": "^1.1.11"
+            }
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+            "dev": true
+        },
+        "is-weakref": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+            "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
+        },
+        "istanbul-lib-coverage": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+            "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+            "dev": true
+        },
+        "istanbul-lib-hook": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+            "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+            "dev": true,
+            "requires": {
+                "append-transform": "^2.0.0"
+            }
+        },
+        "istanbul-lib-instrument": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+            "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.7.5",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.0.0",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-processinfo": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+            "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
+            "dev": true,
+            "requires": {
+                "archy": "^1.0.0",
+                "cross-spawn": "^7.0.3",
+                "istanbul-lib-coverage": "^3.2.0",
+                "p-map": "^3.0.0",
+                "rimraf": "^3.0.0",
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "make-dir": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+                    "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^7.5.3"
+                    }
+                },
+                "semver": {
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+            "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-reports": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+            "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+            "dev": true,
+            "requires": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            }
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
+        },
+        "json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true
         },
         "lazystream": {
             "version": "1.0.1",
@@ -463,10 +1856,44 @@
                 "readable-stream": "^2.0.5"
             }
         },
+        "locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "dev": true,
+            "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "lodash.flattendeep": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+            "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+            "dev": true
+        },
+        "log-symbols": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1"
+            }
+        },
+        "lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "requires": {
+                "yallist": "^3.0.2"
+            }
         },
         "ltx": {
             "version": "2.8.0",
@@ -474,6 +1901,23 @@
             "integrity": "sha512-SJJUrmDgXP0gkUzgErfkaeD+pugM8GYxerTALQa1gTUb5W1wrC4k07GZU+QNZd7MpFqJSYWXTQSUy8Ps03hx5Q==",
             "requires": {
                 "inherits": "^2.0.1"
+            }
+        },
+        "make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "requires": {
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+                    "dev": true
+                }
             }
         },
         "mime-db": {
@@ -497,15 +1941,117 @@
                 "brace-expansion": "^1.1.7"
             }
         },
+        "minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+            "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5"
+            }
+        },
         "mkpath": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
             "integrity": "sha512-bauHShmaxVQiEvlrAPWxSPn8spSL8gDVRl11r8vLT4r/KdnknLqtqwQbToZ2Oa8sJkExYY1z6/d+X7pNiqo4yg=="
         },
+        "mocha": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
+            "integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "3.2.3",
+                "browser-stdout": "1.3.1",
+                "debug": "3.2.6",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "find-up": "3.0.0",
+                "glob": "7.1.3",
+                "growl": "1.10.5",
+                "he": "1.2.0",
+                "js-yaml": "3.13.1",
+                "log-symbols": "2.2.0",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.4",
+                "ms": "2.1.1",
+                "node-environment-flags": "1.0.5",
+                "object.assign": "4.1.0",
+                "strip-json-comments": "2.0.1",
+                "supports-color": "6.0.0",
+                "which": "1.3.1",
+                "wide-align": "1.1.3",
+                "yargs": "13.3.2",
+                "yargs-parser": "13.1.2",
+                "yargs-unparser": "1.6.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
+            }
+        },
         "mockery": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
             "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
+        },
+        "ms": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+            "dev": true
+        },
+        "node-environment-flags": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+            "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+            "dev": true,
+            "requires": {
+                "object.getownpropertydescriptors": "^2.0.3",
+                "semver": "^5.7.0"
+            }
+        },
+        "node-preload": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+            "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+            "dev": true,
+            "requires": {
+                "process-on-spawn": "^1.0.0"
+            }
+        },
+        "node-releases": {
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+            "dev": true
         },
         "node-stream-zip": {
             "version": "1.15.0",
@@ -528,10 +2074,225 @@
                 "remove-trailing-separator": "^1.0.1"
             }
         },
+        "nyc": {
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+            "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+            "dev": true,
+            "requires": {
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.2",
+                "caching-transform": "^4.0.0",
+                "convert-source-map": "^1.7.0",
+                "decamelize": "^1.2.0",
+                "find-cache-dir": "^3.2.0",
+                "find-up": "^4.1.0",
+                "foreground-child": "^2.0.0",
+                "get-package-type": "^0.1.0",
+                "glob": "^7.1.6",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-hook": "^3.0.0",
+                "istanbul-lib-instrument": "^4.0.0",
+                "istanbul-lib-processinfo": "^2.0.2",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.0.2",
+                "make-dir": "^3.0.0",
+                "node-preload": "^0.2.1",
+                "p-map": "^3.0.0",
+                "process-on-spawn": "^1.0.0",
+                "resolve-from": "^5.0.0",
+                "rimraf": "^3.0.0",
+                "signal-exit": "^3.0.2",
+                "spawn-wrap": "^2.0.0",
+                "test-exclude": "^6.0.0",
+                "yargs": "^15.0.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "cliui": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+                    "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^6.2.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.1"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "15.4.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+                    "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^6.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^4.1.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^4.2.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^18.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
         "object-inspect": {
             "version": "1.12.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
             "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.7.tgz",
+            "integrity": "sha512-PrJz0C2xJ58FNn11XV2lr4Jt5Gzl94qpy9Lu0JlfEj14z88sqbSBJCBEzdlNUCzY2gburhbrwOZ5BHCmuNUy0g==",
+            "dev": true,
+            "requires": {
+                "array.prototype.reduce": "^1.0.6",
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1",
+                "safe-array-concat": "^1.0.0"
+            }
         },
         "once": {
             "version": "1.4.0",
@@ -541,25 +2302,142 @@
                 "wrappy": "1"
             }
         },
+        "p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.0.0"
+            }
+        },
+        "p-map": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+            "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+            "dev": true,
+            "requires": {
+                "aggregate-error": "^3.0.0"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true
+        },
+        "package-hash": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+            "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.15",
+                "hasha": "^5.0.0",
+                "lodash.flattendeep": "^4.4.0",
+                "release-zalgo": "^1.0.0"
+            }
+        },
         "parse-cache-control": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
             "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+            "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
+        "path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true
+        },
         "path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
+        "picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
+        },
+        "pkg-dir": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+            "dev": true,
+            "requires": {
+                "find-up": "^4.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                }
+            }
+        },
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "process-on-spawn": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+            "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+            "dev": true,
+            "requires": {
+                "fromentries": "^1.2.0"
+            }
         },
         "promise": {
             "version": "8.3.0",
@@ -604,10 +2482,42 @@
                 "resolve": "^1.1.6"
             }
         },
+        "regexp.prototype.flags": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+            "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "set-function-name": "^2.0.0"
+            }
+        },
+        "release-zalgo": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+            "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
+            "dev": true,
+            "requires": {
+                "es6-error": "^4.0.1"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw=="
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true
         },
         "resolve": {
             "version": "1.22.1",
@@ -619,10 +2529,68 @@
                 "supports-preserve-symlinks-flag": "^1.0.0"
             }
         },
+        "resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "safe-array-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
+            "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.1",
+                "has-symbols": "^1.0.3",
+                "isarray": "^2.0.5"
+            },
+            "dependencies": {
+                "get-intrinsic": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+                    "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-proto": "^1.0.1",
+                        "has-symbols": "^1.0.3"
+                    }
+                },
+                "isarray": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+                    "dev": true
+                }
+            }
+        },
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "safe-regex-test": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+            "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.3",
+                "is-regex": "^1.1.4"
+            }
         },
         "sax": {
             "version": "1.2.4",
@@ -633,6 +2601,38 @@
             "version": "5.7.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
             "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+            "dev": true
+        },
+        "set-function-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+            "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+            "dev": true,
+            "requires": {
+                "define-data-property": "^1.0.1",
+                "functions-have-names": "^1.2.3",
+                "has-property-descriptors": "^1.0.0"
+            }
+        },
+        "shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^3.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true
         },
         "shelljs": {
             "version": "0.8.5",
@@ -654,12 +2654,128 @@
                 "object-inspect": "^1.9.0"
             }
         },
+        "signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
+        },
+        "spawn-wrap": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+            "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+            "dev": true,
+            "requires": {
+                "foreground-child": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "make-dir": "^3.0.0",
+                "rimraf": "^3.0.0",
+                "signal-exit": "^3.0.2",
+                "which": "^2.0.1"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            }
+        },
+        "string.prototype.trim": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+            "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+            "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+            "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
+            }
+        },
         "string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
                 "safe-buffer": "~5.1.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^3.0.0"
+            }
+        },
+        "strip-bom": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+            "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
             }
         },
         "supports-preserve-symlinks-flag": {
@@ -699,6 +2815,17 @@
                 "xtend": "^4.0.0"
             }
         },
+        "test-exclude": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+            "dev": true,
+            "requires": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^7.1.4",
+                "minimatch": "^3.0.4"
+            }
+        },
         "then-request": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
@@ -729,6 +2856,12 @@
             "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
             "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
         },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+            "dev": true
+        },
         "touch": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
@@ -752,16 +2885,114 @@
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
             "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ=="
         },
+        "type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true
+        },
+        "typed-array-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+            "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.1",
+                "is-typed-array": "^1.1.10"
+            },
+            "dependencies": {
+                "get-intrinsic": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+                    "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-proto": "^1.0.1",
+                        "has-symbols": "^1.0.3"
+                    }
+                }
+            }
+        },
+        "typed-array-byte-length": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+            "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "has-proto": "^1.0.1",
+                "is-typed-array": "^1.1.10"
+            }
+        },
+        "typed-array-byte-offset": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
+            "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+            "dev": true,
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "has-proto": "^1.0.1",
+                "is-typed-array": "^1.1.10"
+            }
+        },
+        "typed-array-length": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+            "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "is-typed-array": "^1.1.9"
+            }
+        },
         "typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+        },
+        "typedarray-to-buffer": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
+            "requires": {
+                "is-typedarray": "^1.0.0"
+            }
         },
         "typescript": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
             "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
             "dev": true
+        },
+        "unbox-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+            "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-bigints": "^1.0.2",
+                "has-symbols": "^1.0.3",
+                "which-boxed-primitive": "^1.0.2"
+            }
+        },
+        "update-browserslist-db": {
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+            "dev": true,
+            "requires": {
+                "escalade": "^3.1.1",
+                "picocolors": "^1.0.0"
+            }
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -773,15 +3004,116 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dev": true,
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            }
+        },
+        "which-module": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+            "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+            "dev": true
+        },
+        "which-typed-array": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+            "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+            "dev": true,
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "wide-align": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.2 || 2"
+            }
+        },
         "winreg": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.2.tgz",
             "integrity": "sha1-hQmvo7ccW70RCm18YkfsZ3NsWY8="
         },
+        "wrap-ansi": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+            "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+                    "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "write-file-atomic": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+            "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+            "dev": true,
+            "requires": {
+                "imurmurhash": "^0.1.4",
+                "is-typedarray": "^1.0.0",
+                "signal-exit": "^3.0.2",
+                "typedarray-to-buffer": "^3.1.5"
+            }
         },
         "xml2js": {
             "version": "0.6.2",
@@ -801,6 +3133,85 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        },
+        "y18n": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+            "dev": true
+        },
+        "yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true
+        },
+        "yargs": {
+            "version": "13.3.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+            "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+            "dev": true,
+            "requires": {
+                "cliui": "^5.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+                    "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "13.1.2",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+            "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            }
+        },
+        "yargs-unparser": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+            "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+            "dev": true,
+            "requires": {
+                "flat": "^4.1.0",
+                "lodash": "^4.17.15",
+                "yargs": "^13.3.0"
+            }
         },
         "zip-stream": {
             "version": "1.2.0",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -20,6 +20,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
         "@xmldom/xmldom": "git+https://github.com/xmldom/xmldom.git#0.8.6",
+        "@types/ltx": "3.0.6",
         "archiver": "1.2.0",
         "azure-pipelines-task-lib": "^4.2.0",
         "decompress-zip": "^0.3.3",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.230.1",
+    "version": "4.230.2",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -7,7 +7,8 @@
         "url": "git+ssh://git@github.com/Microsoft/azure-pipelines-tasks.git"
     },
     "scripts": {
-        "build": "pwsh build.ps1"
+        "build": "pwsh build.ps1",
+        "test": "nyc --all --src ./_build mocha ./_build/Tests/L0.js"
     },
     "author": "Microsoft Corporation",
     "license": "MIT",
@@ -29,6 +30,8 @@
         "xml2js": "0.6.2"
     },
     "devDependencies": {
-        "typescript": "4.0.2"
+        "typescript": "4.0.2",
+        "mocha": "^6.2.3",
+        "nyc": "^15.1.0"
     }
 }

--- a/common-npm-packages/webdeployment-common/packageUtility.ts
+++ b/common-npm-packages/webdeployment-common/packageUtility.ts
@@ -66,6 +66,15 @@ export class Package {
     }
 
     public async isMSBuildPackage(): Promise<boolean> {
+  if (this._isMSBuildPackage !== undefined) return this._isMSBuildPackage;
+
+  const shouldCheckFiles = this.getPackageType() !== PackageType.folder;
+  this._isMSBuildPackage = shouldCheckFiles && await checkIfFilesExistsInZip(this._path, ["parameters.xml", "systeminfo.xml"]);
+
+  tl.debug(`Is the package an msdeploy package : ${this._isMSBuildPackage}`);
+
+  return this._isMSBuildPackage;
+}
         if(this._isMSBuildPackage == undefined) {
             this._isMSBuildPackage = this.getPackageType() != PackageType.folder && await checkIfFilesExistsInZip(this._path, ["parameters.xml", "systeminfo.xml"]);
             tl.debug("Is the package an msdeploy package : " + this._isMSBuildPackage);

--- a/common-npm-packages/webdeployment-common/packageUtility.ts
+++ b/common-npm-packages/webdeployment-common/packageUtility.ts
@@ -66,19 +66,10 @@ export class Package {
     }
 
     public async isMSBuildPackage(): Promise<boolean> {
-  if (this._isMSBuildPackage !== undefined) return this._isMSBuildPackage;
-
-  const shouldCheckFiles = this.getPackageType() !== PackageType.folder;
-  this._isMSBuildPackage = shouldCheckFiles && await checkIfFilesExistsInZip(this._path, ["parameters.xml", "systeminfo.xml"]);
-
-  tl.debug(`Is the package an msdeploy package : ${this._isMSBuildPackage}`);
-
-  return this._isMSBuildPackage;
-}
-        if(this._isMSBuildPackage == undefined) {
-            this._isMSBuildPackage = this.getPackageType() != PackageType.folder && await checkIfFilesExistsInZip(this._path, ["parameters.xml", "systeminfo.xml"]);
-            tl.debug("Is the package an msdeploy package : " + this._isMSBuildPackage);
-        }
+        if (this._isMSBuildPackage !== undefined) return this._isMSBuildPackage;
+        const shouldCheckFiles = this.getPackageType() !== PackageType.folder;
+        this._isMSBuildPackage = shouldCheckFiles && await checkIfFilesExistsInZip(this._path, ["parameters.xml", "systeminfo.xml"]);
+        tl.debug(`Is the package an msdeploy package : ${this._isMSBuildPackage}`);
         return this._isMSBuildPackage;
     }
 

--- a/common-npm-packages/webdeployment-common/packageUtility.ts
+++ b/common-npm-packages/webdeployment-common/packageUtility.ts
@@ -1,6 +1,6 @@
 import tl = require('azure-pipelines-task-lib/task');
 import utility = require('./utility');
-var zipUtility = require('azure-pipelines-tasks-webdeployment-common/ziputility.js');
+import { checkIfFilesExistsInZip } from './ziputility';
 import path = require('path');
 
 export enum PackageType {
@@ -67,7 +67,7 @@ export class Package {
 
     public async isMSBuildPackage(): Promise<boolean> {
         if(this._isMSBuildPackage == undefined) {
-            this._isMSBuildPackage = this.getPackageType() != PackageType.folder && await zipUtility.checkIfFilesExistsInZip(this._path, ["parameters.xml", "systeminfo.xml"]);
+            this._isMSBuildPackage = this.getPackageType() != PackageType.folder && await checkIfFilesExistsInZip(this._path, ["parameters.xml", "systeminfo.xml"]);
             tl.debug("Is the package an msdeploy package : " + this._isMSBuildPackage);
         }
         return this._isMSBuildPackage;

--- a/common-npm-packages/webdeployment-common/utility.ts
+++ b/common-npm-packages/webdeployment-common/utility.ts
@@ -1,10 +1,8 @@
 import path = require('path');
-import fs = require('fs');
 import * as os from "os";
 import tl = require('azure-pipelines-task-lib/task');
-import { PackageUtility, PackageType } from './packageUtility';
-
-var zipUtility = require('azure-pipelines-tasks-webdeployment-common/ziputility.js');
+import {  PackageType } from './packageUtility';
+import zipUtility = require('./ziputility');
 /**
  * Validates the input package and finds out input type
  *

--- a/common-npm-packages/webdeployment-common/utility.ts
+++ b/common-npm-packages/webdeployment-common/utility.ts
@@ -1,7 +1,7 @@
 import path = require('path');
 import * as os from "os";
 import tl = require('azure-pipelines-task-lib/task');
-import {  PackageType } from './packageUtility';
+import { PackageType } from './packageUtility';
 import zipUtility = require('./ziputility');
 /**
  * Validates the input package and finds out input type

--- a/common-npm-packages/webdeployment-common/webconfigutil.ts
+++ b/common-npm-packages/webdeployment-common/webconfigutil.ts
@@ -3,7 +3,7 @@ import fs = require('fs');
 import path = require('path');
 import util = require('util');
 
-export function generateWebConfigFile(webConfigTargetPath: string, appType: string, substitutionParameters: any) {
+export function generateWebConfigFile(webConfigTargetPath: string, appType: string, substitutionParameters: { [key: string]: string }) {
     // Get the template path for the given appType
     var webConfigTemplatePath = path.join(__dirname, 'WebConfigTemplates', appType.toLowerCase());
     var webConfigContent: string = fs.readFileSync(webConfigTemplatePath, 'utf8');
@@ -11,7 +11,7 @@ export function generateWebConfigFile(webConfigTargetPath: string, appType: stri
     tl.writeFile(webConfigTargetPath, webConfigContent, { encoding: "utf8" });
 }
 
-function replaceMultiple(text: string, substitutions: any): string {
+function replaceMultiple(text: string, substitutions: { [key: string]: string }): string {
     for(var key in substitutions) {
         tl.debug('Replacing: ' + '{' + key + '} with: ' + substitutions[key]);
         text = text.replace(new RegExp('{' + key + '}', 'g'), substitutions[key]);

--- a/common-npm-packages/webdeployment-common/xdttransformationutility.ts
+++ b/common-npm-packages/webdeployment-common/xdttransformationutility.ts
@@ -1,5 +1,4 @@
 import tl = require('azure-pipelines-task-lib/task');
-import trm = require('azure-pipelines-task-lib/toolrunner');
 import path = require('path');
 
 export function expandWildcardPattern(folderPath: string, wildcardPattern : string) {
@@ -22,7 +21,7 @@ export function expandWildcardPattern(folderPath: string, wildcardPattern : stri
 */
 export function applyXdtTransformation(sourceFile: string, transformFile: string, destinationFile?: string) {
 
-    var cttPath = path.join(__dirname, "..", "..", "ctt", "ctt.exe"); 
+    var cttPath = path.join(__dirname, "ctt", "ctt", "ctt.exe"); 
     var cttArgsArray= [
         "s:" + sourceFile,
         "t:" + transformFile,


### PR DESCRIPTION
Until now tests from `webdeployment-common` were not run during package build process. Instead of that pipeline tasks that are using this package were running JavaScript files from `webdeployment-common\Tests` folder. Also there were missing real test suites (`describe`) with particular tests (`it`). This PR introduces new `L0.ts` file that contains calls to all existing tests. All tests were wrapped into test suites and additional fixes were applied where it was necessary.