### PR TITLE
Prevent oidc_token from being written to agent logs

### DIFF
--- a/common-npm-packages/artifacts-common/webapi.ts
+++ b/common-npm-packages/artifacts-common/webapi.ts
@@ -53,7 +53,9 @@ export async function getFederatedToken(connectedServiceName: string): Promise<s
         connectedServiceName,
         0,
         2000);
-
+    
+    tl.setSecret(oidc_token);
+    
     return oidc_token;
 }
 


### PR DESCRIPTION
A better solution to prevent accidental token leaks.

Fixes: https://github.com/microsoft/azure-pipelines-terraform/pull/194