### PR TITLE
Move ParameterParserUtility tests from AzureRmWebAppDeploymentV4

### DIFF
--- a/common-npm-packages/webdeployment-common/Tests/L0.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0.ts
@@ -7,6 +7,7 @@ import { runL1JSONVarSubWithCommentsTests } from "./L1JSONVarSubWithComments";
 import { runL1JsonVarSubTests } from "./L1JsonVarSub";
 import { runL1JsonVarSubV2Tests } from "./L1JsonVarSubV2";
 import { runL1ValidateFileEncodingTests } from "./L1ValidateFileEncoding";
+import { runParameterParserUtilityTests } from "./L0ParameterParserUtility";
 
 describe('Web deployment common tests', () => {
     describe('GetMSDeployCmdArgs tests', runGetMSDeployCmdArgsTests);
@@ -19,4 +20,5 @@ describe('Web deployment common tests', () => {
     describe("L1JsonVarSub tests", runL1JsonVarSubTests);
     describe("L1JsonVarSubV2 tests", runL1JsonVarSubV2Tests);
     describe("L1ValidateFileEncoding tests", runL1ValidateFileEncodingTests);
+    describe("ParameterParserUtility tests", runParameterParserUtilityTests);
 });

--- a/common-npm-packages/webdeployment-common/Tests/L0MSDeployUtility.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0MSDeployUtility.ts
@@ -1,8 +1,6 @@
 import assert = require("assert");
 import { getMSDeployCmdArgs, getWebDeployErrorCode } from "../msdeployutility";
 
-
-
 export function runGetMSDeployCmdArgsTests() {
 
     it('Should produce default valid args', () => {

--- a/common-npm-packages/webdeployment-common/Tests/L0ParameterParserUtility.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0ParameterParserUtility.ts
@@ -1,0 +1,65 @@
+import assert = require('assert');
+import { parse } from '../ParameterParserUtility';
+
+export function runParameterParserUtilityTests(): void {
+
+    it("Should parse parameters", () => {
+        const paramString = "-port 8080 -Release.ReleaseName Release-1173";
+        const expectedJSON = {
+            "port": {
+                value: "8080"
+            },
+            "Release.ReleaseName": {
+                value: "Release-1173"
+            }
+        };
+
+        const result = parse(paramString);
+
+        assert.deepStrictEqual(result, expectedJSON);
+    });
+
+    it("Should parse parameters with empty values", () => {
+        const paramString = "-port 8080 -ErrorCode -ErrorMessage -Release.ReleaseName Release-1173";
+        const expectedJSON = {
+            "port": {
+                value: "8080"
+            },
+            "ErrorCode": {
+                value: ""
+            },
+            "ErrorMessage": {
+                value: ""
+            },
+            "Release.ReleaseName": {
+                value: "Release-1173"
+            }
+        };
+
+        const result = parse(paramString);
+
+        assert.deepStrictEqual(result, expectedJSON);
+    });
+
+    it("Should parse parameters with extra spaces", () => {
+        const paramString = "-port         8080    -ErrorCode    -ErrorMessage     -Release.ReleaseName         Release-1173";
+        const expectedJSON = {
+            "port": {
+                value: "8080"
+            },
+            "ErrorCode": {
+                value: ""
+            },
+            "ErrorMessage": {
+                value: ""
+            },
+            "Release.ReleaseName": {
+                value: "Release-1173"
+            }
+        };
+
+        const result = parse(paramString);
+
+        assert.deepStrictEqual(result, expectedJSON);
+    });
+}

--- a/common-npm-packages/webdeployment-common/Tests/L1JSONVarSubWithComments.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L1JSONVarSubWithComments.ts
@@ -33,7 +33,6 @@ export function runL1JSONVarSubWithCommentsTests(): void {
     it("Should throw exception for invalid JSON with comments", (done: Mocha.Done) => {
         const fileContent = fs.readFileSync(path.join(__dirname, 'L1JSONVarSub', 'InvalidJSONWithComments.json'), 'utf-8');
         const jsonContent = stripJsonComments(fileContent);
-        console.log(jsonContent);
         assert.throws(() => JSON.parse(jsonContent), "Parse is expected to throw an error");
         done();
     });

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.230.2",
+    "version": "4.230.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.230.2",
+    "version": "4.230.3",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Adding L0 tests for `parse` function from `ParameterParserUtility` module. These tests were originally [placed](https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/AzureRmWebAppDeploymentV4/Tests/L0ParameterParserUtility.ts) inside `AzureRmWebAppDeploymentV4` pipeline task.