### PR TITLE
Expose function to get version of installed MSDeploy

### DIFF
--- a/common-npm-packages/webdeployment-common/Strings/resources.resjson/en-US/resources.resjson
+++ b/common-npm-packages/webdeployment-common/Strings/resources.resjson/en-US/resources.resjson
@@ -31,5 +31,6 @@
   "loc.messages.SkippedUpdatingFile": "Skipped Updating file: %s",
   "loc.messages.PwshNotAvailable": "##WARNING##:PowerShell Core (pwsh.exe) is not available on agent machine. Falling back to using Windows PowerShell (powershell.exe). This can cause reduced performance. Please install the newer version of PowerShell for improved performance.",
   "loc.messages.UnabletofindthelocationofMSDeployfromregistryonmachineError": "Unable to find the location of MSDeploy from registry. Error: %s",
-  "loc.messages.MissingMSDeployInstallPathRegistryKey": "Missing MSDeploy InstallPath registry key."
+  "loc.messages.MissingMSDeployInstallPathRegistryKey": "Missing MSDeploy InstallPath registry key.",
+  "loc.messages.UnsupportedinstalledversionfoundforMSDeployversionshouldbeatleast3orabove": "Unsupported installed version: %s found for MSDeploy. Version should be at least 3 or above."
 }

--- a/common-npm-packages/webdeployment-common/Strings/resources.resjson/en-US/resources.resjson
+++ b/common-npm-packages/webdeployment-common/Strings/resources.resjson/en-US/resources.resjson
@@ -29,5 +29,7 @@
   "loc.messages.VariableSubstitutionInitiated": "Initiated variable substitution in config file : %s",
   "loc.messages.ConfigFileUpdated": "Config file : %s updated.",
   "loc.messages.SkippedUpdatingFile": "Skipped Updating file: %s",
-  "loc.messages.PwshNotAvailable": "##WARNING##:PowerShell Core (pwsh.exe) is not available on agent machine. Falling back to using Windows PowerShell (powershell.exe). This can cause reduced performance. Please install the newer version of PowerShell for improved performance."
+  "loc.messages.PwshNotAvailable": "##WARNING##:PowerShell Core (pwsh.exe) is not available on agent machine. Falling back to using Windows PowerShell (powershell.exe). This can cause reduced performance. Please install the newer version of PowerShell for improved performance.",
+  "loc.messages.UnabletofindthelocationofMSDeployfromregistryonmachineError": "Unable to find the location of MSDeploy from registry. Error: %s",
+  "loc.messages.MissingMSDeployInstallPathRegistryKey": "Missing MSDeploy InstallPath registry key."
 }

--- a/common-npm-packages/webdeployment-common/module.json
+++ b/common-npm-packages/webdeployment-common/module.json
@@ -32,6 +32,7 @@
         "SkippedUpdatingFile" : "Skipped Updating file: %s",
         "PwshNotAvailable": "##WARNING##:PowerShell Core (pwsh.exe) is not available on agent machine. Falling back to using Windows PowerShell (powershell.exe). This can cause reduced performance. Please install the newer version of PowerShell for improved performance.",
         "UnabletofindthelocationofMSDeployfromregistryonmachineError": "Unable to find the location of MSDeploy from registry. Error: %s",
-        "MissingMSDeployInstallPathRegistryKey": "Missing MSDeploy InstallPath registry key."
+        "MissingMSDeployInstallPathRegistryKey": "Missing MSDeploy InstallPath registry key.",
+        "UnsupportedinstalledversionfoundforMSDeployversionshouldbeatleast3orabove": "Unsupported installed version: %s found for MSDeploy. Version should be at least 3 or above."
    }
 }

--- a/common-npm-packages/webdeployment-common/module.json
+++ b/common-npm-packages/webdeployment-common/module.json
@@ -32,8 +32,6 @@
         "SkippedUpdatingFile" : "Skipped Updating file: %s",
         "PwshNotAvailable": "##WARNING##:PowerShell Core (pwsh.exe) is not available on agent machine. Falling back to using Windows PowerShell (powershell.exe). This can cause reduced performance. Please install the newer version of PowerShell for improved performance.",
         "UnabletofindthelocationofMSDeployfromregistryonmachineError": "Unable to find the location of MSDeploy from registry. Error: %s",
-        "MissingMSDeployVersionRegistryKey": "Missing MSDeploy Version registry key.",
-        "UnsupportedMSDeployVersion": "MSDeploy %s does not support token base authentication. Please upgrade to MSDeploy 9.0.7225.0 or higher.",
         "MissingMSDeployInstallPathRegistryKey": "Missing MSDeploy InstallPath registry key."
-    }
+   }
 }

--- a/common-npm-packages/webdeployment-common/msdeployutility.ts
+++ b/common-npm-packages/webdeployment-common/msdeployutility.ts
@@ -298,7 +298,7 @@ export async function installedMSDeployVersionSupportsTokenAuth(): Promise<boole
 
 function getMSDeployLatestRegKey(): Promise<winreg.Registry> {
     return new Promise<winreg.Registry>((resolve, reject) => {
-
+        const minimalSupportedMSDeployVersion = 3;
         const msdeployRegistryPath = "\\SOFTWARE\\Microsoft\\IIS Extensions\\MSDeploy";
         const regKey = new winreg({
             hive: winreg.HKLM,
@@ -326,7 +326,8 @@ function getMSDeployLatestRegKey(): Promise<winreg.Registry> {
                     latestSubKey = subRegKeys[index];
                 }
             }
-            if (latestKeyVersion < 3) {
+            if (latestKeyVersion < minimalSupportedMSDeployVersion) {
+                // previous versions are not compatible either with app services or web deployment tasks
                 reject(tl.loc("UnsupportedinstalledversionfoundforMSDeployversionshouldbeatleast3orabove", latestKeyVersion));
                 return;
             }

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.230.3",
+    "version": "4.230.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -421,6 +421,18 @@
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
             "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
         },
+        "@types/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
+            "dev": true
+        },
+        "@types/winreg": {
+            "version": "1.2.34",
+            "resolved": "https://registry.npmjs.org/@types/winreg/-/winreg-1.2.34.tgz",
+            "integrity": "sha512-XmJ8urhMkVnaKj6SqUz0jdStxi/kYio8v5N8zZujL2uG/jAs4fq1qhJLAssbfc4ObInibB0XvDAYgHXBQlMcxw==",
+            "dev": true
+        },
         "@xmldom/xmldom": {
             "version": "git+https://github.com/xmldom/xmldom.git#238b1ea8431fae8817812c68d55b4933248af07e",
             "from": "git+https://github.com/xmldom/xmldom.git#0.8.6"
@@ -615,6 +627,11 @@
                     "version": "1.5.1",
                     "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
                     "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
+                },
+                "semver": {
+                    "version": "5.7.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+                    "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
                 }
             }
         },
@@ -2049,6 +2066,14 @@
             "requires": {
                 "object.getownpropertydescriptors": "^2.0.3",
                 "semver": "^5.7.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+                    "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+                    "dev": true
+                }
             }
         },
         "node-preload": {
@@ -2611,9 +2636,27 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "requires": {
+                "lru-cache": "^6.0.0"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+                }
+            }
         },
         "set-blocking": {
             "version": "2.0.0",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.230.3",
+    "version": "4.230.4",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",
@@ -17,22 +17,25 @@
     },
     "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
     "dependencies": {
+        "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
         "@xmldom/xmldom": "git+https://github.com/xmldom/xmldom.git#0.8.6",
-        "@types/ltx": "3.0.6",
         "archiver": "1.2.0",
         "azure-pipelines-task-lib": "^4.2.0",
         "decompress-zip": "^0.3.3",
         "ltx": "2.8.0",
         "node-stream-zip": "^1.15.0",
         "q": "1.4.1",
+        "semver": "^7.5.4",
         "winreg": "1.2.2",
         "xml2js": "0.6.2"
     },
     "devDependencies": {
-        "typescript": "4.0.2",
+        "@types/semver": "^7.5.4",
+        "@types/winreg": "^1.2.34",
         "mocha": "^6.2.3",
-        "nyc": "^15.1.0"
+        "nyc": "^15.1.0",
+        "typescript": "4.0.2"
     }
 }


### PR DESCRIPTION
Web deployment tasks need to detect if there is a MSDeploy that supports token authentication installed on the agent machine. In opposite the task should not start the deployment at all and fail instantly. In order to do so this PR introduces `installedMSDeployVersionSupportsTokenAuth` that provides such information. More details in [work item](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2118491).