### PR TITLE
Don't throw Error_ProcessorArchitectureNotSupported on Darwin/amd64

### DIFF
--- a/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
+++ b/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
@@ -60,7 +60,8 @@ export async function getArtifactToolFromService(serviceUri: string, accessToken
         }
     }
 
-    if (arch.toLowerCase() !== "amd64") {
+    // If architecture is amd64 & Darwin the Artifact Tool can run using Rosetta.
+    if (arch.toLowerCase() !== "amd64" && osName.toLowerCase() !== "darwin") {
         throw new Error(tl.loc("Error_ProcessorArchitectureNotSupported"));
     }
 


### PR DESCRIPTION
This change addresses #247 and allows the Typescript to run on arm64 on MacOS.