### PR TITLE
Remove extra part of blob url

### DIFF
--- a/common-npm-packages/az-blobstorage-provider/azureBlobStorageProvider.ts
+++ b/common-npm-packages/az-blobstorage-provider/azureBlobStorageProvider.ts
@@ -43,7 +43,7 @@ export class AzureBlobProvider implements models.IArtifactProvider {
         
         try {
             await blockBlobClient.uploadStream(readStream);
-            const blobUrl = blockBlobClient.url + "/" + this._containerName + "/" + blobPath;
+            const blobUrl = blockBlobClient.url;
             
             console.log(tl.loc("CreatedBlobForItem", item.path, blobUrl));
             item.metadata["destinationUrl"] = blobUrl;

--- a/common-npm-packages/az-blobstorage-provider/package-lock.json
+++ b/common-npm-packages/az-blobstorage-provider/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azp-tasks-az-blobstorage-provider",
-  "version": "3.229.0",
+  "version": "3.231.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/az-blobstorage-provider/package.json
+++ b/common-npm-packages/az-blobstorage-provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azp-tasks-az-blobstorage-provider",
-    "version": "3.229.0",
+    "version": "3.231.0",
     "description": "Common Library to download blobs from azure storage",
     "repository": {
         "type": "git",


### PR DESCRIPTION
`blockBlobClient` appears to hold the full blob url internally. 
