### PR TITLE
[MSBuildHelpers] Bump package to 3.231.0

### DIFF
--- a/common-npm-packages/msbuildhelpers/package-lock.json
+++ b/common-npm-packages/msbuildhelpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-msbuildhelpers",
-  "version": "3.219.1",
+  "version": "3.231.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/msbuildhelpers/package.json
+++ b/common-npm-packages/msbuildhelpers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-msbuildhelpers",
-    "version": "3.219.1",
+    "version": "3.231.0",
     "description": "Azure Pipelines tasks MSBuild helpers",
     "main": "msbuildhelpers.js",
     "scripts": {


### PR DESCRIPTION
Bumped azure-pipelines-msbuildhelpers to 3.231.0 which was missed in previous PR: https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/233