### PR TITLE
Fix issue where an incorrect amount of named arguments cause an error in the FileTransformationsUtility

### DIFF
--- a/common-npm-packages/webdeployment-common/fileTransformationsUtility.ts
+++ b/common-npm-packages/webdeployment-common/fileTransformationsUtility.ts
@@ -61,10 +61,10 @@ export function advancedFileTransformations(isFolderBasedDeployment: boolean, ta
             if(transformationRules.length > 0) {
                 transformationRules.forEach(function(rule) {
                     var args = ParameterParser.parse(rule);
-                    if(Object.keys(args).length < 2 || !args["transform"] || !args["xml"]) {
+                    if(!args["transform"] || !args["xml"]) {
                         tl.error(tl.loc("MissingArgumentsforXMLTransformation"));
                     }
-                    else if(Object.keys(args).length > 2) {
+                    else if(args["transform"] && args["xml"] && args["result"]) {
                         isTransformationApplied = xdtTransformationUtility.specialXdtTransformation(folderPath, args["transform"].value, args["xml"].value, args["result"].value) && isTransformationApplied;
                     }
                     else {


### PR DESCRIPTION
This function returns an error when an (incorrect) transformation rule is passed in trough the FileTransformV2 task.

Working rules:
```
-transform MyTransform.xdt -xml MyConfig.xml
-transform MyTransform.xdt -xml MyConfig.xml -result MyConfig.xml
```

Broken rule
```
-transform MyTransform.xdt -xml MyConfig.xml -whateverparam test
```

The code assumes that when there are 3 arguments, that the argument named result is always passed, which in the above case isn't so. It should just use the arguments based on the names intsead of the count.
