### PR TITLE
Fix error related to KuduStackTraceURL

### DIFF
--- a/common-npm-packages/azurermdeploycommon/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
+++ b/common-npm-packages/azurermdeploycommon/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
@@ -96,6 +96,7 @@
   "loc.messages.FailedToGetAppServiceApplicationSettings": "Failed to get App service '%s' application settings. Error: %s",
   "loc.messages.FailedToUpdateAppServiceApplicationSettings": "Failed to update App service '%s' application settings. Error: %s",
   "loc.messages.KuduSCMDetailsAreEmpty": "KUDU SCM details are empty",
+  "loc.messages.KuduStackTraceURL": "To debug further please check Kudu stack trace URL : %s",
   "loc.messages.FailedToGetContinuousWebJobs": "Failed to get continuous WebJobs. Error: %s",
   "loc.messages.FailedToStartContinuousWebJob": "Failed to start continuous WebJob '%s'. Error: %s",
   "loc.messages.FailedToStopContinuousWebJob": "Failed to stop continuous WebJob '%s'. Error: %s",

--- a/common-npm-packages/azurermdeploycommon/package-lock.json
+++ b/common-npm-packages/azurermdeploycommon/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azurermdeploycommon",
-  "version": "3.226.0",
+  "version": "3.235.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azurermdeploycommon/package.json
+++ b/common-npm-packages/azurermdeploycommon/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azurermdeploycommon",
-    "version": "3.226.0",
+    "version": "3.235.0",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Adding back in the missing KuduStackTraceURL

This resolves this issue for the Azure Functions App Tasks.

##[warning]Can't find loc string for key: KuduStackTraceURL for the AzureFunctionsTasks.
This appears to be the only loc String issue for the Function Apps tasks.