### PR TITLE
ApplicationTokenCredentials.initOIDCToken: Extend retry mechanism for exceptions

### DIFF
--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.232.0",
+  "version": "3.235.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.232.0",
+  "version": "3.235.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In several mseng release pipelines we are experiencing flaky issues when trying to fetch OIDC token for AzureKeyVault tasks (see the bug [here](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2125804)). OIDC token is provided by OIDC token API (see [controller](https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps?path=%2FDistributedTask%2FSdk%2FServer%2FControllers%2FTaskHubOidcTokenController.cs&_a=contents&version=GBmaster) and [API specification](https://learn.microsoft.com/en-us/rest/api/azure/devops/distributedtask/oidctoken/create?view=azure-devops-rest-7.1)). It turned out that in some cases request does not reach the server (`ECONNRESET` or similar) which leads to the exception on the build agent side, but retry mechanism is missing for these cases. This PR introduces such logic and refactors `ApplicationTokenCredentials.initOIDCToken` to `async`/`await` style function.