### PR TITLE
Update error message on expired secrets

### DIFF
--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
@@ -163,7 +163,7 @@
   "loc.messages.ResponseNotValid": "Response is not in a valid format",
   "loc.messages.NotAbleToCreateFirewallRule": "Getting error during adding firewall rule to Azure mysql server. Error: %s",
   "loc.messages.MethodNotImplementedError": "Method '%s' is not implemented.",
-  "loc.messages.ExpiredServicePrincipal": "Could not fetch access token for Azure. Verify if the Service Principal used is valid and not expired. For more information refer https://aka.ms/azureappservicedeploytsg",
+  "loc.messages.ExpiredServicePrincipal": "Secret expired, update service connection at %s See https://aka.ms/azdo-rm-workload-identity-conversion to learn more about conversion to secret-less service connections.",
   "loc.messages.CorrelationIdForARM": "Correlation ID from ARM api call response : %s",
   "loc.messages.CantDownloadAccessProfile": "Cannot download access profile/kube config file for the cluster %s. Reason %s.",
   "loc.messages.FailedToPatchAppServiceConfiguration": "Failed to patch App Service '%s' configuration. Error: %s",

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -492,11 +492,15 @@ export class ApplicationTokenCredentials {
             }
 
             if (error.errorMessage && error.errorMessage.toString().startsWith("7000222")) {
-                // additional error message when clientSecret has been expired
-                tl.error(tl.loc('ExpiredServicePrincipal'));
-            }
+                // Additional error message when clientSecret has been expired
+                const organizationURL = tl.getVariable('System.CollectionUri');
+                const projectName = tl.getVariable('System.TeamProject');
+                const serviceConnectionLink = encodeURI(`${organizationURL}${projectName}/_settings/adminservices?resourceId=${this.connectedServiceName}`);
 
-            throw new Error(tl.loc('CouldNotFetchAccessTokenforAzureStatusCode', error.errorCode, error.errorMessage));
+                throw new Error(tl.loc('ExpiredServicePrincipal', serviceConnectionLink));
+            } else {
+                throw new Error(tl.loc('CouldNotFetchAccessTokenforAzureStatusCode', error.errorCode, error.errorMessage));
+            }
         }
     }
 

--- a/common-npm-packages/azure-arm-rest/module.json
+++ b/common-npm-packages/azure-arm-rest/module.json
@@ -163,7 +163,7 @@
         "ResponseNotValid": "Response is not in a valid format",
         "NotAbleToCreateFirewallRule": "Getting error during adding firewall rule to Azure mysql server. Error: %s",
         "MethodNotImplementedError": "Method '%s' is not implemented.",
-        "ExpiredServicePrincipal": "Could not fetch access token for Azure. Verify if the Service Principal used is valid and not expired. For more information refer https://aka.ms/azureappservicedeploytsg",
+        "ExpiredServicePrincipal": "Secret expired, update service connection at %s See https://aka.ms/azdo-rm-workload-identity-conversion to learn more about conversion to secret-less service connections.",
         "CorrelationIdForARM" : "Correlation ID from ARM api call response : %s",
         "Successfullyupdateddeploymenthistory": "Successfully updated deployment History at %s",
         "Failedtoupdatedeploymenthistory": "Failed to update deployment history. Error: %s",

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.235.0",
+  "version": "3.236.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.235.0",
+  "version": "3.236.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR introduces an updated error message when the Service Connection secret has expired.
It includes a clear message and a link to expired Service Connection.
Also, in case of secret is expired we're showing only one appropriate message not to confuse the users.

Before:
![image](https://github.com/microsoft/azure-pipelines-tasks-common-packages/assets/50652041/a97866d1-cf53-4e0a-a320-c664515d3a0c)

After:
![image](https://github.com/microsoft/azure-pipelines-tasks-common-packages/assets/50652041/faf29601-9562-48a4-82c7-90f006978f2f)
