### PR TITLE
Add OneDeploy endpoint for AzureRmWebAppDeployment-Copy

### DIFF
--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.236.0",
+  "version": "3.237.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.236.0",
+  "version": "3.237.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",

--- a/common-npm-packages/azurermdeploycommon/azure-arm-rest/azure-arm-app-service-kudu.ts
+++ b/common-npm-packages/azurermdeploycommon/azure-arm-rest/azure-arm-app-service-kudu.ts
@@ -522,6 +522,41 @@ export class Kudu {
         }
     }
 
+        public async oneDeploy(webPackage: string, queryParameters?: Array<string>): Promise<any> {
+        let httpRequest = new webClient.WebRequest();
+        httpRequest.method = 'POST';
+        httpRequest.uri = this._client.getRequestUri(`/api/publish`, queryParameters);
+        httpRequest.body = fs.createReadStream(webPackage);
+        let requestOptions = new webClient.WebRequestOptions();
+        //Bydefault webclient.sendRequest retries for  [500, 502, 503, 504]
+        requestOptions.retriableStatusCodes = [500, 502, 503, 504];
+        requestOptions.retryIntervalInSeconds = 5;
+        try {
+            let response = await this._client.beginRequest(httpRequest, requestOptions, 'application/octet-stream');
+            tl.debug(`OneDeploy response: ${JSON.stringify(response)}`);
+            if (response.statusCode == 200) {
+                tl.debug('Deployment passed');
+                return null;
+            }
+            else if (response.statusCode == 202) {
+                let pollableURL: string = response.headers.location;
+                if (!!pollableURL) {
+                    tl.debug(`Polling for OneDeploy URL: ${pollableURL}`);
+                    return await this._getDeploymentDetailsFromPollURL(pollableURL);
+                }
+                else {
+                    tl.debug('OneDeploy returned 202 without pollable URL.');
+                    return null;
+                }
+            }
+            else {
+                throw response;
+            }
+        }
+        catch (error) {
+            throw new Error(tl.loc('PackageDeploymentFailed', this._getFormattedError(error)));
+        }
+    }
 
     public async getDeploymentDetails(deploymentID: string): Promise<any> {
         try {

--- a/common-npm-packages/azurermdeploycommon/operations/KuduServiceUtility.ts
+++ b/common-npm-packages/azurermdeploycommon/operations/KuduServiceUtility.ts
@@ -14,6 +14,7 @@ const physicalRootPath: string = '/site/wwwroot';
 const deploymentFolder: string = 'site/deployments';
 const manifestFileName: string = 'manifest';
 const VSTS_ZIP_DEPLOY: string = 'VSTS_ZIP_DEPLOY';
+const VSTS_ONE_DEPLOY: string = 'VSTS_ONE_DEPLOY';
 const VSTS_DEPLOY: string = 'VSTS';
 
 export class KuduServiceUtility {
@@ -193,6 +194,45 @@ export class KuduServiceUtility {
         }
         catch(error) {
             tl.debug('Failed to warm-up Kudu: ' + error.toString());
+        }
+    }
+
+    public async deployUsingOneDeploy(packagePath: string, customMessage?: any, targetPath?: any, type?: any, clean?: any, restart?: any): Promise<string> {
+        try {
+            console.log(tl.loc('Package deployment using OneDeploy initiated.'));
+            let queryParameters: Array<string> = [
+                'async=true',
+                'deployer=' + VSTS_ONE_DEPLOY
+            ];
+
+            if (type) {
+                queryParameters.push('type=' + encodeURIComponent(type));
+            }
+
+            if (targetPath) {
+                queryParameters.push('path=' + encodeURIComponent(targetPath));
+            }
+
+            if (clean) {
+                queryParameters.push('clean=' + encodeURIComponent(clean));
+            }
+
+            if (restart) {
+                queryParameters.push('restart=' + encodeURIComponent(restart));
+            }
+
+            var deploymentMessage = this._getUpdateHistoryRequest(null, null, customMessage).message;
+            queryParameters.push('message=' + encodeURIComponent(deploymentMessage));
+            let deploymentDetails = await this._appServiceKuduService.oneDeploy(packagePath, queryParameters);
+            console.log(tl.loc(deploymentDetails));
+            await this._processDeploymentResponse(deploymentDetails);
+            console.log(tl.loc('Successfully deployed web package to App Service.'));
+
+            return deploymentDetails.id;
+        }
+        catch (error) {
+            tl.error(tl.loc('PackageDeploymentFailed'));
+            throw error;
         }
     }
 

--- a/common-npm-packages/azurermdeploycommon/package-lock.json
+++ b/common-npm-packages/azurermdeploycommon/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azurermdeploycommon",
-  "version": "3.236.0",
+  "version": "3.237.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azurermdeploycommon/package.json
+++ b/common-npm-packages/azurermdeploycommon/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azurermdeploycommon",
-    "version": "3.236.0",
+    "version": "3.237.0",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Add the logic to send deployment requests to the OneDeploy API for AzureRmWebAppDeployment to consume.
clone of: https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/279