### PR TITLE
Rename ExpiredServicePrincipal message to unique

### DIFF
--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/de-DE/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/de-DE/resources.resjson
@@ -163,7 +163,7 @@
   "loc.messages.ResponseNotValid": "Das Format der Antwort ist ungültig.",
   "loc.messages.NotAbleToCreateFirewallRule": "Fehler beim Hinzufügen der Firewallregel zum Azure MySQL-Server. Fehler: %s",
   "loc.messages.MethodNotImplementedError": "Die Methode \"%s\" ist nicht implementiert.",
-  "loc.messages.ExpiredServicePrincipal": "Das Zugriffstoken für Azure konnte nicht abgerufen werden. Stellen Sie sicher, dass der verwendete Dienstprinzipal gültig und nicht abgelaufen ist. Weitere Informationen finden Sie unter https://aka.ms/azureappservicedeploytsg.",
+  "loc.messages.ExpiredServicePrincipalMessageWithLink": "Das Zugriffstoken für Azure konnte nicht abgerufen werden. Stellen Sie sicher, dass der verwendete Dienstprinzipal gültig und nicht abgelaufen ist. Weitere Informationen finden Sie unter https://aka.ms/azureappservicedeploytsg.",
   "loc.messages.CorrelationIdForARM": "Korrelations-ID aus ARM-API-Aufrufantwort: %s",
   "loc.messages.CantDownloadAccessProfile": "Zugriffsprofil/Kube-Konfigurationsdatei für den Cluster \"%s\" kann nicht heruntergeladen werden. Ursache: %s.",
   "loc.messages.FailedToPatchAppServiceConfiguration": "Fehler beim Patchen der Konfiguration für App Service „%s“. Fehler: %s",

--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
@@ -163,7 +163,7 @@
   "loc.messages.ResponseNotValid": "Response is not in a valid format",
   "loc.messages.NotAbleToCreateFirewallRule": "Getting error during adding firewall rule to Azure mysql server. Error: %s",
   "loc.messages.MethodNotImplementedError": "Method '%s' is not implemented.",
-  "loc.messages.ExpiredServicePrincipal": "Secret expired, update service connection at %s See https://aka.ms/azdo-rm-workload-identity-conversion to learn more about conversion to secret-less service connections.",
+  "loc.messages.ExpiredServicePrincipalMessageWithLink": "Secret expired, update service connection at %s See https://aka.ms/azdo-rm-workload-identity-conversion to learn more about conversion to secret-less service connections.",
   "loc.messages.CorrelationIdForARM": "Correlation ID from ARM api call response : %s",
   "loc.messages.CantDownloadAccessProfile": "Cannot download access profile/kube config file for the cluster %s. Reason %s.",
   "loc.messages.FailedToPatchAppServiceConfiguration": "Failed to patch App Service '%s' configuration. Error: %s",

--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/es-ES/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/es-ES/resources.resjson
@@ -163,7 +163,7 @@
   "loc.messages.ResponseNotValid": "El formato de la respuesta no es válido.",
   "loc.messages.NotAbleToCreateFirewallRule": "Error al agregar la regla de firewall al servidor MySQL de Azure: %s",
   "loc.messages.MethodNotImplementedError": "El método \"%s\" no está implementado.",
-  "loc.messages.ExpiredServicePrincipal": "Se produjo un error al capturar el token de acceso de Azure. Compruebe que la entidad de servicio que se usa es válida y no ha expirado. Para obtener más información, consulte https://aka.ms/azureappservicedeploytsg",
+  "loc.messages.ExpiredServicePrincipalMessageWithLink": "Se produjo un error al capturar el token de acceso de Azure. Compruebe que la entidad de servicio que se usa es válida y no ha expirado. Para obtener más información, consulte https://aka.ms/azureappservicedeploytsg",
   "loc.messages.CorrelationIdForARM": "Identificador de correlación de la respuesta de llamada API de ARM: %s",
   "loc.messages.CantDownloadAccessProfile": "No se puede descargar el archivo de configuración del perfil de acceso o kube para el clúster %s. Motivo %s.",
   "loc.messages.FailedToPatchAppServiceConfiguration": "Se produjo un error al aplicar una revisión a la configuración de App Service \"%s\". Error: %s",

--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/fr-FR/resources.resjson
@@ -163,7 +163,7 @@
   "loc.messages.ResponseNotValid": "La réponse n’est pas dans un format valide",
   "loc.messages.NotAbleToCreateFirewallRule": "Obtention d’une erreur durant l’ajout d’une règle de pare-feu au serveur Azure MySQL. Erreur : %s",
   "loc.messages.MethodNotImplementedError": "La méthode '%s' n'est pas implémentée.",
-  "loc.messages.ExpiredServicePrincipal": "Impossible de récupérer (fetch) le jeton d'accès pour Azure. Vérifiez si le principal de service utilisé est valide et s'il n'a pas expiré. Pour plus d'informations, consultez https://aka.ms/azureappservicedeploytsg",
+  "loc.messages.ExpiredServicePrincipalMessageWithLink": "Impossible de récupérer (fetch) le jeton d'accès pour Azure. Vérifiez si le principal de service utilisé est valide et s'il n'a pas expiré. Pour plus d'informations, consultez https://aka.ms/azureappservicedeploytsg",
   "loc.messages.CorrelationIdForARM": "ID de corrélation de la réponse à l'appel d'API ARM : %s",
   "loc.messages.CantDownloadAccessProfile": "Impossible de télécharger le fichier config de profil d'accès/kube pour le cluster %s. Raison : %s.",
   "loc.messages.FailedToPatchAppServiceConfiguration": "Nous n’avons pas pu patcher l’application du correctif à la configuration de l’App Service '%s'. Erreur : %s",

--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/it-IT/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/it-IT/resources.resjson
@@ -163,7 +163,7 @@
   "loc.messages.ResponseNotValid": "Il formato della risposta non è valido",
   "loc.messages.NotAbleToCreateFirewallRule": "Si è verificato un errore durante l'aggiunta della regola del firewall al server MySQL di Azure. Errore: %s",
   "loc.messages.MethodNotImplementedError": "Il metodo '%s' non è implementato.",
-  "loc.messages.ExpiredServicePrincipal": "Non è stato possibile recuperare il token di accesso per Azure. Verificare che l'entità servizio usata sia valida e non sia scaduta. Per altre informazioni, vedere https://aka.ms/azureappservicedeploytsg",
+  "loc.messages.ExpiredServicePrincipalMessageWithLink": "Non è stato possibile recuperare il token di accesso per Azure. Verificare che l'entità servizio usata sia valida e non sia scaduta. Per altre informazioni, vedere https://aka.ms/azureappservicedeploytsg",
   "loc.messages.CorrelationIdForARM": "ID correlazione della risposta alla chiamata API ARM: %s",
   "loc.messages.CantDownloadAccessProfile": "Non è possibile scaricare il profilo di accesso o il file di configurazione kube per il cluster %s. Motivo: %s.",
   "loc.messages.FailedToPatchAppServiceConfiguration": "Non è stato possibile correggere la configurazione del servizio app '%s'. Errore: %s",

--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/ja-JP/resources.resjson
@@ -163,7 +163,7 @@
   "loc.messages.ResponseNotValid": "応答が有効な形式ではありません",
   "loc.messages.NotAbleToCreateFirewallRule": "ファイアウォール規則を Azure MySql サーバーに追加する際にエラーが発生しました。エラー: %s",
   "loc.messages.MethodNotImplementedError": "メソッド '%s' は実装されていません。",
-  "loc.messages.ExpiredServicePrincipal": "Azure のアクセス トークンをフェッチできませんでした。使用されているサービス プリンシパルが有効であり、有効期限が切れていないことをご確認ください。詳細については、https://aka.ms/azureappservicedeploytsg をご覧ください",
+  "loc.messages.ExpiredServicePrincipalMessageWithLink": "Azure のアクセス トークンをフェッチできませんでした。使用されているサービス プリンシパルが有効であり、有効期限が切れていないことをご確認ください。詳細については、https://aka.ms/azureappservicedeploytsg をご覧ください",
   "loc.messages.CorrelationIdForARM": "ARM API 呼び出しの応答からの関連付け ID: %s",
   "loc.messages.CantDownloadAccessProfile": "クラスター %s のアクセス プロファイルまたは kube 構成ファイルをダウンロードできません。理由 %s。",
   "loc.messages.FailedToPatchAppServiceConfiguration": "App Service '%s' の構成を修正できませんでした。エラー: %s",

--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/ko-KR/resources.resjson
@@ -163,7 +163,7 @@
   "loc.messages.ResponseNotValid": "응답의 형식이 유효하지지 않습니다.",
   "loc.messages.NotAbleToCreateFirewallRule": "Azure MySQL 서버에 방화벽 규칙을 추가하는 중 오류가 발생했습니다. 오류: %s",
   "loc.messages.MethodNotImplementedError": "메서드 '%s'이(가) 구현되지 않았습니다.",
-  "loc.messages.ExpiredServicePrincipal": "Azure의 액세스 토큰을 가져올 수 없습니다. 사용한 서비스 주체가 유효하고 만료되지 않았는지 확인하세요. 자세한 내용은 https://aka.ms/azureappservicedeploytsg를 참조하세요.",
+  "loc.messages.ExpiredServicePrincipalMessageWithLink": "Azure의 액세스 토큰을 가져올 수 없습니다. 사용한 서비스 주체가 유효하고 만료되지 않았는지 확인하세요. 자세한 내용은 https://aka.ms/azureappservicedeploytsg를 참조하세요.",
   "loc.messages.CorrelationIdForARM": "ARM API 호출 응답의 상관 관계 ID: %s",
   "loc.messages.CantDownloadAccessProfile": "%s 클러스터의 액세스 프로필/kube 구성 파일을 다운로드할 수 없습니다. 이유: %s.",
   "loc.messages.FailedToPatchAppServiceConfiguration": "App Service '%s' 구성을 패치하지 못했습니다. 오류: %s",

--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/ru-RU/resources.resjson
@@ -163,7 +163,7 @@
   "loc.messages.ResponseNotValid": "Недопустимый формат ответа",
   "loc.messages.NotAbleToCreateFirewallRule": "Сбой при добавлении правила брандмауэра на сервере MySQL Azure. Ошибка: %s",
   "loc.messages.MethodNotImplementedError": "Метод \"%s\" не реализован.",
-  "loc.messages.ExpiredServicePrincipal": "Не удалось получить маркер доступа для Azure. Убедитесь, что используемый субъект-служба является допустимым, а срок его действия не истек. Дополнительные сведения: https://aka.ms/azureappservicedeploytsg",
+  "loc.messages.ExpiredServicePrincipalMessageWithLink": "Не удалось получить маркер доступа для Azure. Убедитесь, что используемый субъект-служба является допустимым, а срок его действия не истек. Дополнительные сведения: https://aka.ms/azureappservicedeploytsg",
   "loc.messages.CorrelationIdForARM": "Идентификатор корреляции из ответа на вызов API ARM: %s",
   "loc.messages.CantDownloadAccessProfile": "Невозможно скачать профиль доступа и файл kube config для кластера %s. Причина: %s.",
   "loc.messages.FailedToPatchAppServiceConfiguration": "Не удалось изменить конфигурацию службы приложений \"%s\". Ошибка: %s",

--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/zh-CN/resources.resjson
@@ -163,7 +163,7 @@
   "loc.messages.ResponseNotValid": "响应的格式无效。",
   "loc.messages.NotAbleToCreateFirewallRule": "将防火墙规则添加到 Azure MySQL 服务器时出现错误。错误: %s",
   "loc.messages.MethodNotImplementedError": "方法 \"%s\" 未实现。",
-  "loc.messages.ExpiredServicePrincipal": "无法提取 Azure 的访问令牌。请确保使用的服务主体有效且未过期。有关详细信息，请参阅 https://aka.ms/azureappservicedeploytsg",
+  "loc.messages.ExpiredServicePrincipalMessageWithLink": "无法提取 Azure 的访问令牌。请确保使用的服务主体有效且未过期。有关详细信息，请参阅 https://aka.ms/azureappservicedeploytsg",
   "loc.messages.CorrelationIdForARM": "来自 ARM API 调用响应的相关 ID: %s",
   "loc.messages.CantDownloadAccessProfile": "无法下载群集 %s 的访问配置文件/kube 配置文件。原因为 %s。",
   "loc.messages.FailedToPatchAppServiceConfiguration": "未能修补应用服务“%s”配置。错误: %s",

--- a/common-npm-packages/azure-arm-rest/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/common-npm-packages/azure-arm-rest/Strings/resources.resjson/zh-TW/resources.resjson
@@ -163,7 +163,7 @@
   "loc.messages.ResponseNotValid": "回應的格式無效",
   "loc.messages.NotAbleToCreateFirewallRule": "將防火牆規則新增至 Azure mysql 伺服器時取得錯誤。錯誤: %s",
   "loc.messages.MethodNotImplementedError": "未實作方法 '%s'。",
-  "loc.messages.ExpiredServicePrincipal": "無法擷取 Azure 的存取權杖。請確認使用的服務主體有效而且未到期。如需詳細資訊，請參閱 https://aka.ms/azureappservicedeploytsg",
+  "loc.messages.ExpiredServicePrincipalMessageWithLink": "無法擷取 Azure 的存取權杖。請確認使用的服務主體有效而且未到期。如需詳細資訊，請參閱 https://aka.ms/azureappservicedeploytsg",
   "loc.messages.CorrelationIdForARM": "來自 ARM API 呼叫回應的相互關聯識別碼: %s",
   "loc.messages.CantDownloadAccessProfile": "無法下載叢集 %s 的存取設定檔/Kube 組態檔。原因 %s。",
   "loc.messages.FailedToPatchAppServiceConfiguration": "無法修補 App Service '%s' 組態。錯誤: %s",

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -497,7 +497,7 @@ export class ApplicationTokenCredentials {
                 const projectName = tl.getVariable('System.TeamProject');
                 const serviceConnectionLink = encodeURI(`${organizationURL}${projectName}/_settings/adminservices?resourceId=${this.connectedServiceName}`);
 
-                throw new Error(tl.loc('ExpiredServicePrincipal', serviceConnectionLink));
+                throw new Error(tl.loc('ExpiredServicePrincipalMessageWithLink', serviceConnectionLink));
             } else {
                 throw new Error(tl.loc('CouldNotFetchAccessTokenforAzureStatusCode', error.errorCode, error.errorMessage));
             }

--- a/common-npm-packages/azure-arm-rest/module.json
+++ b/common-npm-packages/azure-arm-rest/module.json
@@ -163,7 +163,7 @@
         "ResponseNotValid": "Response is not in a valid format",
         "NotAbleToCreateFirewallRule": "Getting error during adding firewall rule to Azure mysql server. Error: %s",
         "MethodNotImplementedError": "Method '%s' is not implemented.",
-        "ExpiredServicePrincipal": "Secret expired, update service connection at %s See https://aka.ms/azdo-rm-workload-identity-conversion to learn more about conversion to secret-less service connections.",
+        "ExpiredServicePrincipalMessageWithLink": "Secret expired, update service connection at %s See https://aka.ms/azdo-rm-workload-identity-conversion to learn more about conversion to secret-less service connections.",
         "CorrelationIdForARM" : "Correlation ID from ARM api call response : %s",
         "Successfullyupdateddeploymenthistory": "Successfully updated deployment History at %s",
         "Failedtoupdatedeploymenthistory": "Failed to update deployment history. Error: %s",

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.236.0",
+  "version": "3.237.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.236.0",
+  "version": "3.237.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I found an issue, that some tasks are already have `ExpiredServicePrincipal` as a message key, so I renamed it to `ExpiredServicePrincipalMessageWithLink` for uniqueness purpuse.