### PR TITLE
securefiles-common.ts now uses the name by default

### DIFF
--- a/common-npm-packages/securefiles-common/Tests/L0.ts
+++ b/common-npm-packages/securefiles-common/Tests/L0.ts
@@ -11,8 +11,9 @@ import {
     enable
 } from "mockery";
 
+export const secureFileName = "securefilename";
 export const secureFileId = Math.random().toString(36).slice(2, 7);
-process.env['SECUREFILE_NAME_' + secureFileId] = 'securefilename';
+process.env['SECUREFILE_NAME_' + secureFileId] = secureFileName;
 
 const tmAnswers = {
     'exist': {
@@ -30,6 +31,11 @@ class AgentAPI {
         rs.push('data');
         rs.push(null);
         return rs;
+    }
+    getSecureFilesByNames() {
+        return new Promise((resolve) => {
+            resolve([{ id: secureFileId }]);
+        });
     }
 }
 
@@ -109,22 +115,22 @@ describe("securefiles-common package suites", function() {
         registerMock("fs", fsMock);
         const secureFiles = require("../securefiles-common");
         const secureFileHelpers = new secureFiles.SecureFileHelpers();
-        const secureFilePath = await secureFileHelpers.downloadSecureFile(secureFileId);
-        const pseudoResolvedPath = await secureFileHelpers.getSecureFileTempDownloadPath(secureFileId);
+        const secureFilePath = await secureFileHelpers.downloadSecureFile(secureFileName);
+        const pseudoResolvedPath = await secureFileHelpers.getSecureFileTempDownloadPath(secureFileName);
         strictEqual(secureFilePath, pseudoResolvedPath, `Result should be equal to ${pseudoResolvedPath}`);
     });
 
     it("Check deleteSecureFile", async() => {
         const secureFiles = require("../securefiles-common");
         const secureFileHelpers = new secureFiles.SecureFileHelpers();
-        secureFileHelpers.deleteSecureFile(secureFileId);
+        secureFileHelpers.deleteSecureFile(secureFileName);
     });
 
     it("Check getSecureFileTempDownloadPath", async() => {
         const secureFiles = require("../securefiles-common");
         const secureFileHelpers = new secureFiles.SecureFileHelpers();
-        const resolvedPath = secureFileHelpers.getSecureFileTempDownloadPath(secureFileId);
-        const pseudoResolvedPath = tlClone.resolve(tlClone.getVariable("Agent.TempDirectory"), tlClone.getSecureFileName(secureFileId));
+        const resolvedPath = secureFileHelpers.getSecureFileTempDownloadPath(secureFileName);
+        const pseudoResolvedPath = tlClone.resolve(tlClone.getVariable("Agent.TempDirectory"), secureFileName);
         strictEqual(resolvedPath, pseudoResolvedPath, `Resolved path "${resolvedPath}" should be equal to "${pseudoResolvedPath}"`);
     });
 });

--- a/common-npm-packages/securefiles-common/Tests/utils.ts
+++ b/common-npm-packages/securefiles-common/Tests/utils.ts
@@ -14,7 +14,7 @@ tlClone.getVariable = variable => {
     return variable;
 };
 tlClone.getEndpointAuthorizationParameter = (id: string, key: string, optional: boolean) => `${id}_${key}_${optional}`;
-tlClone.getSecureFileName = (secureFileId: number) => secureFileId;
+//tlClone.getSecureFileName = (secureFileId: number) => secureFileId;
 tlClone.getSecureFileTicket = () => {
     return true;
 };

--- a/common-npm-packages/securefiles-common/securefiles-common-mock.ts
+++ b/common-npm-packages/securefiles-common/securefiles-common-mock.ts
@@ -1,4 +1,5 @@
 import * as tl from "azure-pipelines-task-lib/task";
+import {randomUUID} from "node:crypto";
 
 export class SecureFileHelpers {
     private static fileExtension: string = ".filename";
@@ -13,15 +14,15 @@ export class SecureFileHelpers {
         }
     }
 
-    async downloadSecureFile(secureFileId: string) {
-        tl.debug('Mock downloadSecureFile with id = ' + secureFileId);
-        const fileName: string = `${secureFileId}${SecureFileHelpers.fileExtension}`;
+    async downloadSecureFile(secureFileName: string) {
+        tl.debug('Mock downloadSecureFile with name = ' + secureFileName);
+        const fileName: string = `${secureFileName}${SecureFileHelpers.fileExtension}`;
         const tempDownloadPath: string = `/build/temp/${fileName}`;
         return tempDownloadPath;
     }
 
-    deleteSecureFile(secureFileId: string) {
-        tl.debug('Mock deleteSecureFile with id = ' + secureFileId);
+    deleteSecureFile(secureFileName: string) {
+        tl.debug('Mock deleteSecureFile with name = ' + secureFileName);
     }
 
     static setFileExtension(extension: string): void {


### PR DESCRIPTION
# This pull request is supposed to fix the following issue: https://github.com/microsoft/azure-pipelines-tasks/issues/6885

First of all I'm sorry if I broke any etiquette with this contribution.

In the classic pipelines the secure file reference was stored by the GUID of the secure file which was generated upon upload. The flow in this design was that the secure file has no option to update it's content.

When for example a config file has to be changed because of infrastructural changes then every classic pipeline using that secure file breaks because the newly uploaded secure file has a different GUID.

In the context of yaml pipelines this does not cause any issue because we store the secure file by name.