### PR TITLE
Fix casing inconsistency in UniversalPackagesV0 tool cache location

### DIFF
--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.236.0",
+    "version": "3.239.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -844,7 +844,7 @@
         "semver-compare": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+            "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
         },
         "serialize-javascript": {
             "version": "5.0.1",

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.236.0",
+    "version": "3.239.0",
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "mocha _build/Tests/L0.js",

--- a/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
+++ b/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
@@ -11,7 +11,7 @@ import * as toollib from "azure-pipelines-tool-lib/tool";
 export function getArtifactToolLocation(dirName: string): string {
     let toolPath: string = path.join(dirName, "ArtifactTool.exe");
     if (tl.osType() !== "Windows_NT"){
-        toolPath = path.join(dirName, "artifacttool");
+        toolPath = path.join(dirName, "Artifacttool");
     }
     return toolPath;
 }
@@ -19,7 +19,7 @@ export function getArtifactToolLocation(dirName: string): string {
 function _createExtractFolder(dest?: string): string {
     if (!dest) {
         // create a temp dir
-        dest = path.join(tl.getVariable("Agent.TempDirectory"), "artifactTool");
+        dest = path.join(tl.getVariable("Agent.TempDirectory"), "ArtifactTool");
     }
     tl.mkdirP(dest);
     return dest;


### PR DESCRIPTION
Old PR that didn't get merged: https://github.com/microsoft/azure-pipelines-tasks/pull/18143