### PR TITLE
[azure-arm-rest] - move httpClient construct to method call

### DIFF
--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.241.1",
+  "version": "3.241.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.241.1",
+  "version": "3.241.2",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",

--- a/common-npm-packages/azure-arm-rest/webClient.ts
+++ b/common-npm-packages/azure-arm-rest/webClient.ts
@@ -20,7 +20,7 @@ var requestOptions: httpInterfaces.IRequestOptions = proxyUrl ? {
 let ignoreSslErrors: string = tl.getVariable("VSTS_ARM_REST_IGNORE_SSL_ERRORS");
 requestOptions.ignoreSslError = ignoreSslErrors && ignoreSslErrors.toLowerCase() == "true";
 
-var httpCallbackClient = new httpClient.HttpClient(tl.getVariable("AZURE_HTTP_USER_AGENT"), null, requestOptions);
+var azureHttpUserAgent = tl.getVariable("AZURE_HTTP_USER_AGENT");
 
 export class WebRequest {
     public method: string;
@@ -112,8 +112,13 @@ export function sleepFor(sleepDurationInSeconds): Promise<any> {
 
 async function sendRequestInternal(request: WebRequest): Promise<WebResponse> {
     tl.debug(util.format("[%s]%s", request.method, request.uri));
+    var httpCallbackClient = new httpClient.HttpClient(azureHttpUserAgent, null, requestOptions);
+    
     var response: httpClient.HttpClientResponse = await httpCallbackClient.request(request.method, request.uri, request.body, request.headers);
-    return await toWebResponse(response);
+    const weResponse = await toWebResponse(response);
+    
+    httpCallbackClient.dispose();
+    return weResponse;
 }
 
 async function toWebResponse(response: httpClient.HttpClientResponse): Promise<WebResponse> {


### PR DESCRIPTION
**Description**:
- moved HttpClient to a method call
- added dispose method to HttpClient

**Related WI** IcM 492723897

**Testing**: Tested in canary org([run](https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=86900&view=results)) with directly injected packages([commit](https://github.com/microsoft/azure-pipelines-tasks/commit/ac35f8f7d87bceb3e53ba6128b7c6247172b2371))