### PR TITLE
[docker-common] bump azure-arm-rest version

### DIFF
--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.241.0",
+    "version": "2.241.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -154,9 +154,9 @@
             }
         },
         "azure-pipelines-tasks-azure-arm-rest": {
-            "version": "3.241.1",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.241.1.tgz",
-            "integrity": "sha512-Ws8BKzgIIDyW6y4LcumnpiTK2HCS3S+PBvzvI/OL6tC05OxniWsndjAPcmFIC55kvIRtqMTLXiaDQoFWOVvCGw==",
+            "version": "3.241.2",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.241.2.tgz",
+            "integrity": "sha512-mYTj2UwoIhgzMTR1Y144pk4hCsVwzglFV/AcfV60YrxYOdyDF5ZqTZjJrq1mcen2ND12F304TUKNvBU0TyP7Kg==",
             "requires": {
                 "@azure/msal-node": "^2.7.0",
                 "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.241.0",
+    "version": "2.241.1",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",
@@ -18,7 +18,7 @@
         "@types/q": "1.5.4",
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.241.1",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.241.2",
         "del": "2.2.0",
         "q": "1.4.1"
     },


### PR DESCRIPTION
**Description:**

- bumped azure-arm-rest version because of https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/322

**Related WI**: IcM 492723897

**Testing**: Tested in canary org([run](https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=86900&view=results)) with directly injected packages([commit](https://github.com/microsoft/azure-pipelines-tasks/commit/ac35f8f7d87bceb3e53ba6128b7c6247172b2371))