### PR TITLE
Bump webdeployment-common version

### DIFF
--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.236.0",
+    "version": "4.242.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.236.0",
+    "version": "4.242.0",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Bumped the webdeployment-common package version as a follow-up to https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/334
