### PR TITLE
Bump dependency versions for azure-pipelines-tasks-azure-arm-rest package to fix vulnerability issues

### DIFF
--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.241.2",
+  "version": "3.242.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -93,12 +93,26 @@
       }
     },
     "azure-devops-node-api": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.0.0.tgz",
-      "integrity": "sha512-S6Il++7dQeMlZDokBDWw7YVoPeb90tWF10pYxnoauRMnkuL91jq9M7SOYRVhtO3FUC5URPkB/qzGa7jTLft0Xw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-14.0.1.tgz",
+      "integrity": "sha512-oVnFfTNmergd3JU852EpGY64d1nAxW8lCyzZqFDPhfQVZkdApBeK/ZMN7yoFiq/C50Ru304X1L/+BFblh2SRJw==",
       "requires": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.4"
+        "typed-rest-client": "^2.0.1"
+      },
+      "dependencies": {
+        "typed-rest-client": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.0.1.tgz",
+          "integrity": "sha512-LSfgVu+jKUbkceVBGJ6bdIMzzpvjhw6A+aKsVnGa2S7bT82QCALh/RAtq/fdV3aLXxHqsChuClrQ93fXMrIckA==",
+          "requires": {
+            "des.js": "^1.1.0",
+            "js-md4": "^0.3.2",
+            "qs": "^6.10.3",
+            "tunnel": "0.0.6",
+            "underscore": "^1.12.1"
+          }
+        }
       }
     },
     "azure-pipelines-task-lib": {
@@ -199,6 +213,15 @@
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "gopd": "^1.0.1"
+      }
+    },
+    "des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -369,10 +392,15 @@
         "has": "^1.0.3"
       }
     },
+    "js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="
+    },
     "jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
       "requires": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -383,7 +411,14 @@
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
-        "semver": "^5.6.0"
+        "semver": "^7.5.4"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+        }
       }
     },
     "jwa": {
@@ -460,6 +495,11 @@
       "requires": {
         "mime-db": "1.52.0"
       }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
       "version": "3.0.5",
@@ -664,11 +704,13 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
-      "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.0.1.tgz",
+      "integrity": "sha512-LSfgVu+jKUbkceVBGJ6bdIMzzpvjhw6A+aKsVnGa2S7bT82QCALh/RAtq/fdV3aLXxHqsChuClrQ93fXMrIckA==",
       "requires": {
-        "qs": "^6.9.1",
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
       }

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.241.2",
+  "version": "3.242.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",
@@ -19,13 +19,13 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.5.4",
     "async-mutex": "^0.4.0",
-    "azure-devops-node-api": "^12.0.0",
+    "azure-devops-node-api": "^14.0.1",
     "azure-pipelines-task-lib": "^4.11.0",
     "https-proxy-agent": "^4.0.0",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "node-fetch": "^2.6.7",
     "q": "1.5.1",
-    "typed-rest-client": "^1.8.6",
+    "typed-rest-client": "^2.0.1",
     "xml2js": "0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
In this PR I updated dependecies for **azure-pipelines-tasks-azure-arm-rest** package:
1) _typed-rest-client_ and _azure-devops-node-api_ packages to fix https://nvd.nist.gov/vuln/detail/CVE-2022-24999
See related PRs:
https://github.com/microsoft/azure-devops-node-api/pull/602
https://github.com/microsoft/typed-rest-client/pull/371

2) _jsonwebtoken_ package since there may be security issues associated with key encryption https://nvd.nist.gov/vuln/detail/CVE-2022-23541

_azure-pipelines-tasks-azure-arm-rest_ version was bumped to 3.242.0
