### PR TITLE
Add dynamic MSAL loading to azure-arm-rest package to fix compatibility issue with Node 10 execution handler

### DIFF
--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -7,7 +7,6 @@ import constants = require('./constants');
 import path = require('path');
 import fs = require('fs');
 import jwt = require('jsonwebtoken');
-import msal = require('@azure/msal-node');
 import crypto = require("crypto");
 import { Mutex } from 'async-mutex';
 import HttpsProxyAgent = require('https-proxy-agent');
@@ -15,6 +14,17 @@ import fetch = require('node-fetch');
 import { getHandlerFromToken, WebApi } from "azure-devops-node-api";
 import { ITaskApi } from "azure-devops-node-api/TaskApi";
 import TaskAgentInterfaces = require("azure-devops-node-api/interfaces/TaskAgentInterfaces");
+
+// Important note! Since the msal v2.** doesn't work with Node 10, and we still need to support Node 10 tasks, a dynamic msal loading was implemented.
+// Dynamic loading imposes restrictions on type validation when compiling TypeScript and we can't use it in this case.
+// For this reason, all msal types were temporarily replaced with 'any' type.
+// When the support for Node 10 is dropped, the types should be restored and the dynamic loading should be removed.
+
+/// Dynamic msal loading based on the node version
+const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
+const msalVer = nodeVersion < 16 ? "msal1": "msal2";
+const msal = require(msalVer);
+///
 
 tl.setResourcePath(path.join(__dirname, 'module.json'), true);
 
@@ -36,7 +46,7 @@ export class ApplicationTokenCredentials {
     private isADFSEnabled?: boolean;
     private token_deferred: Q.Promise<string>;
     private useMSAL: boolean;
-    private msalInstance: msal.ConfidentialClientApplication;
+    private msalInstance: any; //msal.ConfidentialClientApplication
 
     private readonly tokenMutex: Mutex;
 
@@ -232,7 +242,7 @@ export class ApplicationTokenCredentials {
         }
     }
 
-    private async getMSAL(): Promise<msal.ConfidentialClientApplication> {
+    private async getMSAL(): Promise<any> /*Promise<msal.ConfidentialClientApplication>*/ {
         // use same instance if it already exists
         if (!this.msalInstance) {
             this.msalInstance = await this.buildMSAL();
@@ -241,7 +251,7 @@ export class ApplicationTokenCredentials {
         return this.msalInstance;
     }
 
-    private getProxyClient(agentProxyURL: URL): msal.INetworkModule {
+    private getProxyClient(agentProxyURL: URL): any /*msal.INetworkModule*/ {
         let proxyURL = `${agentProxyURL.protocol}//${agentProxyURL.host}`;
 
         const agentProxyUsername: string = tl.getVariable("agent.proxyusername");
@@ -262,7 +272,7 @@ export class ApplicationTokenCredentials {
         // direct usage of msalConfig.system.proxyUrl is not available at the moment due to the fact that Object.fromEntries requires >=Node12
         const proxyAgent = new HttpsProxyAgent(proxyURL);
 
-        const proxyNetworkClient: msal.INetworkModule = {
+        const proxyNetworkClient: any /*msal.INetworkModule*/ = {
             async sendGetRequestAsync(url, options) {
                 const customOptions = { ...options, ...{ method: "GET", agent: proxyAgent } }
                 const response = await fetch(url, customOptions);
@@ -286,11 +296,11 @@ export class ApplicationTokenCredentials {
         return proxyNetworkClient;
     }
 
-    private async buildMSAL(): Promise<msal.ConfidentialClientApplication> {
+    private async buildMSAL(): Promise<any> /*Promise<msal.ConfidentialClientApplication>*/ {
         // default configuration
         const authorityURL = (new URL(this.tenantId, this.authorityUrl)).toString();
 
-        const msalConfig: msal.Configuration = {
+        const msalConfig: any /*msal.Configuration*/ = {
             auth: {
                 clientId: this.clientId,
                 authority: authorityURL
@@ -325,7 +335,7 @@ export class ApplicationTokenCredentials {
             }
         }
 
-        let msalInstance: msal.ConfidentialClientApplication;
+        let msalInstance: any; //msal.ConfidentialClientApplication
 
         // setup msal according to parameters
         switch (this.scheme) {
@@ -344,13 +354,13 @@ export class ApplicationTokenCredentials {
         return msalInstance;
     }
 
-    private configureMSALWithMSI(msalConfig: msal.Configuration): msal.ConfidentialClientApplication {
+    private configureMSALWithMSI(msalConfig: any /*msal.Configuration*/): any /*msal.ConfidentialClientApplication*/ {
         let resourceId = this.activeDirectoryResourceId;
-        let accessTokenProvider: msal.IAppTokenProvider = (appTokenProviderParameters: msal.AppTokenProviderParameters): Promise<msal.AppTokenProviderResult> => {
+        let accessTokenProvider: any /*msal.IAppTokenProvider*/ = (appTokenProviderParameters: any /*msal.AppTokenProviderParameters*/): Promise<any> /*Promise<msal.AppTokenProviderResult>*/ => {
 
             tl.debug("MSAL - ManagedIdentity is used.");
 
-            let providerResultPromise = new Promise<msal.AppTokenProviderResult>(function (resolve, reject) {
+            let providerResultPromise = new Promise<any>/*Promise<msal.AppTokenProviderResult>*/(function (resolve, reject) {
                 // same for MSAL
                 let webRequest = new webClient.WebRequest();
                 webRequest.method = "GET";
@@ -363,7 +373,7 @@ export class ApplicationTokenCredentials {
                 webClient.sendRequest(webRequest).then(
                     (response: webClient.WebResponse) => {
                         if (response.statusCode == 200) {
-                            let providerResult: msal.AppTokenProviderResult = {
+                            let providerResult: any /*msal.AppTokenProviderResult*/ = {
                                 accessToken: response.body.access_token,
                                 expiresInSeconds: response.body.expires_in
                             }
@@ -388,7 +398,7 @@ export class ApplicationTokenCredentials {
         return msalInstance;
     }
 
-    private configureMSALWithSP(msalConfig: msal.Configuration): msal.ConfidentialClientApplication {
+    private configureMSALWithSP(msalConfig: any /*msal.Configuration*/): any /*msal.ConfidentialClientApplication*/ {
         switch (this.authType) {
             case constants.AzureServicePrinicipalAuthentications.servicePrincipalKey:
                 tl.debug("MSAL - ServicePrincipal - clientSecret is used.");
@@ -459,7 +469,7 @@ export class ApplicationTokenCredentials {
         return oidc_token;
     }
 
-    private async configureMSALWithOIDC(msalConfig: msal.Configuration): Promise<msal.ConfidentialClientApplication> {
+    private async configureMSALWithOIDC(msalConfig: any /*msal.Configuration*/): Promise<any> /*Promise<msal.ConfidentialClientApplication>*/ {
         tl.debug("MSAL - FederatedAccess - OIDC is used.");
 
         msalConfig.auth.clientAssertion = await this.getFederatedToken();
@@ -470,13 +480,13 @@ export class ApplicationTokenCredentials {
 
     private async getMSALToken(force?: boolean, retryCount: number = 3, retryWaitMS: number = 2000): Promise<string> {
         tl.debug(`MSAL - getMSALToken called. force=${force}`);
-        const msalApp: msal.ConfidentialClientApplication = await this.getMSAL();
+        const msalApp: any /*msal.ConfidentialClientApplication*/ = await this.getMSAL();
         if (force) {
             msalApp.clearCache();
         }
 
         try {
-            const request: msal.ClientCredentialRequest = {
+            const request: any /*msal.ClientCredentialRequest*/ = {
                 scopes: [this.activeDirectoryResourceId + "/.default"]
             };
             const response = await msalApp.acquireTokenByClientCredential(request);

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -15,7 +15,7 @@ import { getHandlerFromToken, WebApi } from "azure-devops-node-api";
 import { ITaskApi } from "azure-devops-node-api/TaskApi";
 import TaskAgentInterfaces = require("azure-devops-node-api/interfaces/TaskAgentInterfaces");
 
-// Important note! Since the msal v2.** doesn't work with Node 10, and we still need to support Node 10 tasks, a dynamic msal loading was implemented.
+// Important note! Since the msal v2.** doesn't work with Node 10, and we still need to support Node 10 execution handler, a dynamic msal loading was implemented.
 // Dynamic loading imposes restrictions on type validation when compiling TypeScript and we can't use it in this case.
 // For this reason, all msal types were temporarily replaced with 'any' type.
 // When the support for Node 10 is dropped, the types should be restored and the dynamic loading should be removed.

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -22,7 +22,7 @@ import TaskAgentInterfaces = require("azure-devops-node-api/interfaces/TaskAgent
 
 /// Dynamic msal loading based on the node version
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
-const msalVer = nodeVersion < 16 ? "msal1": "msal2";
+const msalVer = nodeVersion < 16 ? "msalv1": "msalv2";
 
 tl.debug('Using ' + msalVer);
 const msal = require(msalVer);

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -24,6 +24,7 @@ import TaskAgentInterfaces = require("azure-devops-node-api/interfaces/TaskAgent
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
 const msalVer = nodeVersion < 16 ? "msal1": "msal2";
 const msal = require(msalVer);
+tl.debug('Using ' + msalVer);
 ///
 
 tl.setResourcePath(path.join(__dirname, 'module.json'), true);

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -23,8 +23,9 @@ import TaskAgentInterfaces = require("azure-devops-node-api/interfaces/TaskAgent
 /// Dynamic msal loading based on the node version
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
 const msalVer = nodeVersion < 16 ? "msal1": "msal2";
-const msal = require(msalVer);
+
 tl.debug('Using ' + msalVer);
+const msal = require(msalVer);
 ///
 
 tl.setResourcePath(path.join(__dirname, 'module.json'), true);

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.242.1",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-node": "^2.7.0",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -19,6 +18,8 @@
         "azure-pipelines-task-lib": "^4.11.0",
         "https-proxy-agent": "^4.0.0",
         "jsonwebtoken": "^9.0.0",
+        "msal1": "npm:@azure/msal-node@^1.18.4",
+        "msal2": "npm:@azure/msal-node@^2.7.0",
         "node-fetch": "^2.6.7",
         "q": "1.5.1",
         "typed-rest-client": "^2.0.1",
@@ -30,67 +31,11 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "14.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.9.0.tgz",
-      "integrity": "sha512-yzBPRlWPnTBeixxLNI3BBIgF5/bHpbhoRVuuDBnYjCyWRavaPUsKAHUDYLqpGkBLDciA6TCc6GOxN4/S3WiSxg==",
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.3.1.tgz",
+      "integrity": "sha512-Lrk1ozoAtaP/cp53May3v6HtcFSVxdFrg2Pa/1xu5oIvsIwhxW6zSPibKefCOVgd5osgykMi5jjcZHv8XkzZEQ==",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@azure/msal-node": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.7.0.tgz",
-      "integrity": "sha512-wXD8LkUvHICeSWZydqg6o8Yvv+grlBEcmLGu+QEI4FcwFendbTEZrlSygnAXXSOCVaGAirWLchca35qrgpO6Jw==",
-      "dependencies": {
-        "@azure/msal-common": "14.9.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@types/jsonwebtoken": {
@@ -628,17 +573,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -678,6 +612,59 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/msal1": {
+      "name": "@azure/msal-node",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.18.4.tgz",
+      "integrity": "sha512-Kc/dRvhZ9Q4+1FSfsTFDME/v6+R2Y1fuMty/TfwqE5p9GTPw08BPbKgeWinE8JRHRp+LemjQbUZsn4Q4l6Lszg==",
+      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
+      "dependencies": {
+        "@azure/msal-common": "13.3.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": "10 || 12 || 14 || 16 || 18"
+      }
+    },
+    "node_modules/msal1/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/msal2": {
+      "name": "@azure/msal-node",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.10.0.tgz",
+      "integrity": "sha512-JxsSE0464a8IA/+q5EHKmchwNyUFJHtCH00tSXsLaOddwLjG6yVvTH6lGgPcWMhO7YWUXj/XVgVgeE9kZtsPUQ==",
+      "dependencies": {
+        "@azure/msal-common": "14.13.0",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/msal2/node_modules/@azure/msal-common": {
+      "version": "14.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.13.0.tgz",
+      "integrity": "sha512-b4M/tqRzJ4jGU91BiwCsLTqChveUEyFK3qY2wGfZ0zBswIBZjAxopx5CYt5wzZFKuN15HqRDYXQbztttuIC3nA==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/msal2/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "1.7.2",
@@ -1022,60 +1009,13 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
     "@azure/msal-common": {
-      "version": "14.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.9.0.tgz",
-      "integrity": "sha512-yzBPRlWPnTBeixxLNI3BBIgF5/bHpbhoRVuuDBnYjCyWRavaPUsKAHUDYLqpGkBLDciA6TCc6GOxN4/S3WiSxg=="
-    },
-    "@azure/msal-node": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.7.0.tgz",
-      "integrity": "sha512-wXD8LkUvHICeSWZydqg6o8Yvv+grlBEcmLGu+QEI4FcwFendbTEZrlSygnAXXSOCVaGAirWLchca35qrgpO6Jw==",
-      "requires": {
-        "@azure/msal-common": "14.9.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-          "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash.includes": "^4.3.0",
-            "lodash.isboolean": "^3.0.3",
-            "lodash.isinteger": "^4.0.4",
-            "lodash.isnumber": "^3.0.3",
-            "lodash.isplainobject": "^4.0.6",
-            "lodash.isstring": "^4.0.1",
-            "lodash.once": "^4.0.0",
-            "ms": "^2.1.1",
-            "semver": "^7.5.4"
-          }
-        },
-        "semver": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
-      }
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.3.1.tgz",
+      "integrity": "sha512-Lrk1ozoAtaP/cp53May3v6HtcFSVxdFrg2Pa/1xu5oIvsIwhxW6zSPibKefCOVgd5osgykMi5jjcZHv8XkzZEQ=="
     },
     "@types/jsonwebtoken": {
       "version": "8.5.8",
@@ -1501,14 +1441,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -1539,6 +1471,45 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "msal1": {
+      "version": "npm:@azure/msal-node@1.18.4",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.18.4.tgz",
+      "integrity": "sha512-Kc/dRvhZ9Q4+1FSfsTFDME/v6+R2Y1fuMty/TfwqE5p9GTPw08BPbKgeWinE8JRHRp+LemjQbUZsn4Q4l6Lszg==",
+      "requires": {
+        "@azure/msal-common": "13.3.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "msal2": {
+      "version": "npm:@azure/msal-node@2.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.10.0.tgz",
+      "integrity": "sha512-JxsSE0464a8IA/+q5EHKmchwNyUFJHtCH00tSXsLaOddwLjG6yVvTH6lGgPcWMhO7YWUXj/XVgVgeE9kZtsPUQ==",
+      "requires": {
+        "@azure/msal-common": "14.13.0",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "@azure/msal-common": {
+          "version": "14.13.0",
+          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.13.0.tgz",
+          "integrity": "sha512-b4M/tqRzJ4jGU91BiwCsLTqChveUEyFK3qY2wGfZ0zBswIBZjAxopx5CYt5wzZFKuN15HqRDYXQbztttuIC3nA=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
     },
     "node-addon-api": {
       "version": "1.7.2",
@@ -1794,11 +1765,6 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -18,8 +18,8 @@
         "azure-pipelines-task-lib": "^4.11.0",
         "https-proxy-agent": "^4.0.0",
         "jsonwebtoken": "^9.0.0",
-        "msal1": "npm:@azure/msal-node@^1.18.4",
-        "msal2": "npm:@azure/msal-node@^2.7.0",
+        "msalv1": "npm:@azure/msal-node@^1.18.4",
+        "msalv2": "npm:@azure/msal-node@^2.7.0",
         "node-fetch": "^2.6.7",
         "q": "1.5.1",
         "typed-rest-client": "^2.0.1",
@@ -613,7 +613,7 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "node_modules/msal1": {
+    "node_modules/msalv1": {
       "name": "@azure/msal-node",
       "version": "1.18.4",
       "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.18.4.tgz",
@@ -628,7 +628,7 @@
         "node": "10 || 12 || 14 || 16 || 18"
       }
     },
-    "node_modules/msal1/node_modules/uuid": {
+    "node_modules/msalv1/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
@@ -636,7 +636,7 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/msal2": {
+    "node_modules/msalv2": {
       "name": "@azure/msal-node",
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.10.0.tgz",
@@ -650,7 +650,7 @@
         "node": ">=16"
       }
     },
-    "node_modules/msal2/node_modules/@azure/msal-common": {
+    "node_modules/msalv2/node_modules/@azure/msal-common": {
       "version": "14.13.0",
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.13.0.tgz",
       "integrity": "sha512-b4M/tqRzJ4jGU91BiwCsLTqChveUEyFK3qY2wGfZ0zBswIBZjAxopx5CYt5wzZFKuN15HqRDYXQbztttuIC3nA==",
@@ -658,7 +658,7 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/msal2/node_modules/uuid": {
+    "node_modules/msalv2/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
@@ -1472,7 +1472,7 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "msal1": {
+    "msalv1": {
       "version": "npm:@azure/msal-node@1.18.4",
       "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.18.4.tgz",
       "integrity": "sha512-Kc/dRvhZ9Q4+1FSfsTFDME/v6+R2Y1fuMty/TfwqE5p9GTPw08BPbKgeWinE8JRHRp+LemjQbUZsn4Q4l6Lszg==",
@@ -1489,7 +1489,7 @@
         }
       }
     },
-    "msal2": {
+    "msalv2": {
       "version": "npm:@azure/msal-node@2.10.0",
       "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.10.0.tgz",
       "integrity": "sha512-JxsSE0464a8IA/+q5EHKmchwNyUFJHtCH00tSXsLaOddwLjG6yVvTH6lGgPcWMhO7YWUXj/XVgVgeE9kZtsPUQ==",

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.242.1",
+  "version": "3.242.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-tasks-azure-arm-rest",
-      "version": "3.242.1",
+      "version": "3.242.2",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.242.1",
+  "version": "3.242.2",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -13,7 +13,8 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "@azure/msal-node": "^2.7.0",
+    "msal1": "npm:@azure/msal-node@^1.18.4",
+    "msal2": "npm:@azure/msal-node@^2.7.0",
     "@types/jsonwebtoken": "^8.5.8",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -13,8 +13,8 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "msal1": "npm:@azure/msal-node@^1.18.4",
-    "msal2": "npm:@azure/msal-node@^2.7.0",
+    "msalv1": "npm:@azure/msal-node@^1.18.4",
+    "msalv2": "npm:@azure/msal-node@^2.7.0",
     "@types/jsonwebtoken": "^8.5.8",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",


### PR DESCRIPTION
Since the MSAL v2.** Node lib doesn't work with Node 10, and we still need to support Node 10 execution handler, a dynamic MSAL loading was implemented based on the used Node version.

Thus, MSAL v1 is used to work with Node less than v16, otherwise MSAL v2 is used

Related WI: [AB#2191965](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2191965)

Testing: Manual testing with the HelmDeployV0 task