### PR TITLE
Update the check of the msdeploy version

### DIFF
--- a/common-npm-packages/webdeployment-common/msdeployutility.ts
+++ b/common-npm-packages/webdeployment-common/msdeployutility.ts
@@ -286,14 +286,21 @@ export async function getInstalledMSDeployVersion(): Promise<string> {
 }
 
 export async function installedMSDeployVersionSupportsTokenAuth(): Promise<boolean | undefined> {
-    // MSDeploy 9.0.7225 is the first product version to support token auth
-    const minimalMSDeployVersion = "9.0.7225";
-    const msDeployVersion = await getInstalledMSDeployVersion();
-    if (!msDeployVersion) {
+    const msDeployVersionString = await getInstalledMSDeployVersion();
+    if (!msDeployVersionString) {
         tl.debug('Could not determine MSDeploy version. Assuming it is not installed.');
         return undefined;
     }
-    return semver.gte(semver.coerce(msDeployVersion), semver.coerce(minimalMSDeployVersion));
+
+    const msDeployVersion = semver.coerce(msDeployVersionString);
+    // MSDeploy 9.0.7225 is the first product version to support token auth
+    if (semver.gte(msDeployVersion, semver.coerce("9.0.7225"))) {
+        return true;
+    }
+
+    // MDeploy shipped with Web Deploy has different versioning scheme
+    // Versions between 9.0.2000 and 9.0.2999 are considered to be similar to 9.0.7225
+    return semver.gte(msDeployVersion, semver.coerce("9.0.2000")) && semver.lte(msDeployVersion, semver.coerce("9.0.2999"));
 }
 
 function getMSDeployLatestRegKey(): Promise<winreg.Registry> {

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.243.0",
+    "version": "4.243.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-webdeployment-common",
-            "version": "4.243.0",
+            "version": "4.243.1",
             "license": "MIT",
             "dependencies": {
                 "@types/ltx": "3.0.6",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.243.0",
+    "version": "4.243.1",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This PR extends the list msdeploy versions that officially supports token authentication with the interval from 9.0.2000 to 9.0.2999. These versions are used for the msedploy that comes with Web Deploy package. The binaries should be identical with the ones that comes with VS build tools.   