### PR TITLE
support cluster credentials api

### DIFF
--- a/common-npm-packages/azure-arm-rest/azure-arm-aks-service.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-aks-service.ts
@@ -28,10 +28,10 @@ export class AzureAksService {
         this._client = new ServiceClient(endpoint.applicationTokenCredentials, endpoint.subscriptionID, 30);
     }
 
-    public beginRequest(uri: string,  parameters: {}) : Promise<webClient.WebResponse> {
+    public beginRequest(uri: string,  parameters: {}, apiVersion: string) : Promise<webClient.WebResponse> {
          var webRequest = new webClient.WebRequest();
          webRequest.method = 'GET';
-         webRequest.uri = this._client.getRequestUri(uri, parameters, null,'2017-08-31');
+         webRequest.uri = this._client.getRequestUri(uri, parameters, null, apiVersion);
         return this._client.beginRequestExpBackoff(webRequest, 3).then((response)=>{
             if(response.statusCode >= 200 && response.statusCode < 300) {
                 return response;
@@ -48,10 +48,36 @@ export class AzureAksService {
             '{ResourceGroupName}': resourceGroup,
             '{ClusterName}': clusterName,
             '{AccessProfileName}': accessProfileName
-        }).then((response) => {
+        }, '2017-08-31').then((response) => {
             return  response.body;
         }, (reason) => {
             throw Error(tl.loc('CantDownloadAccessProfile',clusterName,  this._client.getFormattedError(reason)));
         });
+    }
+
+    public getClusterCredentials(resourceGroup : string , clusterName : string, useClusterAdmin?: boolean): Promise<Model.AKSCredentialResults> {
+        var credentialAction = !!useClusterAdmin ? 'listClusterAdminCredential' : 'listClusterUserCredential';
+        return this.beginRequest(`//subscriptions/{subscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{ClusterName}/{CredentialAction}`,
+        {
+            '{ResourceGroupName}': resourceGroup,
+            '{ClusterName}': clusterName,
+            '{CredentialAction}': credentialAction
+        }, '2024-05-01').then((response) => {
+            return  response.body;
+        }, (reason) => {
+            throw Error(tl.loc('CantDownloadClusterCredentials',clusterName,  this._client.getFormattedError(reason)));
+        });
+    }
+
+    public getClusterCredential(resourceGroup : string , clusterName : string, useClusterAdmin?: boolean, credentialName?: string): Promise<Model.AKSCredentialResult> {
+        var credentialName = !!credentialName ? credentialName : !!useClusterAdmin ? 'clusterAdmin' : 'clusterUser';
+        var clusterCredentials = this.getClusterCredentials(resourceGroup, clusterName, useClusterAdmin)
+        return clusterCredentials.then((credentials) => {
+           var credential = credentials.kubeconfigs.find(credential => credential.name == credentialName)
+            if (credential === undefined) {
+                throw Error(tl.loc('CantDownloadClusterCredentials', clusterName, `${credentialName} not found in the list of cluster credentials.`));
+            }
+            return credential;
+        })
     }
 }

--- a/common-npm-packages/azure-arm-rest/azureModels.ts
+++ b/common-npm-packages/azure-arm-rest/azureModels.ts
@@ -305,6 +305,15 @@ export interface AKSClusterAccessProfile extends AzureBaseObject {
     properties: AKSClusterAccessProfileProperties
 }
 
+export interface AKSCredentialResult {
+    name: string;
+    value: string;
+}
+
+export interface AKSCredentialResults extends AzureBaseObject {
+    kubeconfigs: Array<AKSCredentialResult>
+}
+
 export interface IThresholdRuleConditionDataSource {
 	"odata.type": string;
 	resourceUri: string;


### PR DESCRIPTION
The accessProfile API is going to be deprecated not to mention that there's no out of the box RBAC role that permits this API without adding Admin access to the cluster/namespace. 

The newer API differentiates between admin and user credentials and is covered by all built in AKS RBAC roles.

HelmDeployV0 and HelmDeployV1 should be migrated to use this newer API to simplify working with AKS. 