### PR TITLE
[artifacs-common] add keep-alive option

### DIFF
--- a/common-npm-packages/artifacts-common/package-lock.json
+++ b/common-npm-packages/artifacts-common/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "azure-pipelines-tasks-artifacts-common",
-    "version": "2.243.1",
+    "version": "2.244.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-artifacts-common",
-            "version": "2.243.1",
+            "version": "2.244.0",
             "license": "MIT",
             "dependencies": {
                 "@types/fs-extra": "8.0.0",
                 "@types/mocha": "^5.2.6",
                 "@types/node": "^16.11.39",
-                "azure-devops-node-api": "14.0.1",
+                "azure-devops-node-api": "^14.0.2",
                 "azure-pipelines-task-lib": "^4.13.0",
                 "fs-extra": "8.1.0",
                 "node-fetch": "^2.7.0",
@@ -77,9 +77,9 @@
             "dev": true
         },
         "node_modules/azure-devops-node-api": {
-            "version": "14.0.1",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-14.0.1.tgz",
-            "integrity": "sha512-oVnFfTNmergd3JU852EpGY64d1nAxW8lCyzZqFDPhfQVZkdApBeK/ZMN7yoFiq/C50Ru304X1L/+BFblh2SRJw==",
+            "version": "14.0.2",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-14.0.2.tgz",
+            "integrity": "sha512-TwjAEnWnOSZ2oypkDyqppgvJw43qArEfPiJtEWLL3NBgdvAuOuB0xgFz/Eiz4H6Dk0Yv52wCodZxtZvAMhJXwQ==",
             "dependencies": {
                 "tunnel": "0.0.6",
                 "typed-rest-client": "^2.0.1"

--- a/common-npm-packages/artifacts-common/package.json
+++ b/common-npm-packages/artifacts-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-artifacts-common",
-    "version": "2.243.1",
+    "version": "2.244.0",
     "description": "Azure Artifacts common code (for new authentication tasks)",
     "scripts": {
         "build": "cd ../build-scripts && npm install && cd ../artifacts-common && node make.js"
@@ -15,7 +15,7 @@
         "@types/fs-extra": "8.0.0",
         "@types/mocha": "^5.2.6",
         "@types/node": "^16.11.39",
-        "azure-devops-node-api": "14.0.1",
+        "azure-devops-node-api": "^14.0.2",
         "azure-pipelines-task-lib": "^4.13.0",
         "fs-extra": "8.1.0",
         "node-fetch": "^2.7.0",

--- a/common-npm-packages/artifacts-common/webapi.ts
+++ b/common-npm-packages/artifacts-common/webapi.ts
@@ -10,7 +10,8 @@ export function getWebApiWithProxy(serviceUri: string, accessToken: string, opti
     const defaultOptions: IRequestOptions = {
         proxy: tl.getHttpProxyConfiguration(serviceUri),
         allowRetries: true,
-        maxRetries: 5
+        maxRetries: 5,
+        keepAlive: true
     };
 
     return new api.WebApi(serviceUri, credentialHandler, {...defaultOptions, ...options});


### PR DESCRIPTION
**Description**
- Since node19 [http.GlobalAgent](https://nodejs.org/docs/latest/api/http.html#httpglobalagent) has 5 sec timeout which might be too short for Azure REST API.
 By adding keppAlive request option we assign to request [own agent](https://github.com/microsoft/typed-rest-client/blob/master/lib/HttpClient.ts#L524) with null timeout(as it was previously) instead of [global one](https://github.com/microsoft/typed-rest-client/blob/master/lib/HttpClient.ts#L532) with 5sec timeout.
In case if proxy will be specified, the specific agent will be created as well without [timeout option.](https://github.com/microsoft/typed-rest-client/blob/master/lib/HttpClient.ts#L501)

**Related WI**: [AB#2194177](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2194177)

**Testing**: Tested locally with AzuerCLI task