### PR TITLE
azure-pipelines-tasks-packaging-common External Auth Info

### DIFF
--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.242.2",
+    "version": "3.244.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-packaging-common",
-            "version": "3.242.2",
+            "version": "3.244.0",
             "license": "MIT",
             "dependencies": {
                 "@types/ini": "1.3.30",

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.242.2",
+    "version": "3.244.0",
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "mocha _build/Tests/L0.js",

--- a/common-npm-packages/packaging-common/universal/Authentication.ts
+++ b/common-npm-packages/packaging-common/universal/Authentication.ts
@@ -29,6 +29,7 @@ export class TokenExternalAuthInfo extends ExternalAuthInfo
         public token: string)
     {
         super(packageSource, ExternalAuthType.Token);
+        tl.setSecret(token);
     }
 }
 


### PR DESCRIPTION
Set the provided secret input in the TokenExternalAuthInfo constructor.