### PR TITLE
2202985 Docker V2 task fails to push the container images after the task version updated to 2.243.0

### DIFF
--- a/common-npm-packages/docker-common/dockercommandutils.ts
+++ b/common-npm-packages/docker-common/dockercommandutils.ts
@@ -301,13 +301,17 @@ function parseHistoryForLayers(input: string) {
 
 function parseHistoryForV1Name(topHistoryLayer: string): string {
     let v1Name = "";
-    const layerIdString = "layerId:sha256:";
-    const indexOfLayerId = topHistoryLayer.indexOf(layerIdString);
+    let layerIdString = "layerId:sha256:";
+    let indexOfLayerId = topHistoryLayer.indexOf(layerIdString);
+    if (indexOfLayerId < 0) {
+        layerIdString = "layerId:"
+        indexOfLayerId = topHistoryLayer.indexOf(layerIdString);
+    }
     if (indexOfLayerId >= 0) {
         v1Name = topHistoryLayer.substring(indexOfLayerId + layerIdString.length);
     }
 
-    return v1Name;
+    return v1Name && v1Name !== "<missing>" ? v1Name : "";
 }
 
 export async function getHistory(connection: ContainerConnection, image: string): Promise<string> {


### PR DESCRIPTION
Customer who uses the Podman to run Docker Build would end up in a error is due to difference of layerid creation. DockerCLI used to create with prefix "layerId:sha256" and podman used to create with "layerId:" So to support it we made changes to the code 

#https://github.com/microsoft/azure-pipelines-tasks/issues/20189