### PR TITLE
Add Gradle Jacoco templates v2

### DIFF
--- a/common-npm-packages/codecoverage-tools/jacoco/jacoco.gradle.ccenabler.ts
+++ b/common-npm-packages/codecoverage-tools/jacoco/jacoco.gradle.ccenabler.ts
@@ -5,6 +5,7 @@ import * as ccc from "../codecoverageconstants";
 import * as cc from "../codecoverageenabler";
 import * as Q from "q";
 import * as path from "path";
+import * as semver from "semver";
 
 tl.setResourcePath(path.join(path.dirname(__dirname), 'module.json'), true);
 
@@ -25,21 +26,17 @@ export class JacocoGradleCodeCoverageEnabler extends cc.JacocoCodeCoverageEnable
         let reportDir = ccProps["reportdirectory"];
         let gradle5xOrHigher = ccProps["gradle5xOrHigher"] && ccProps["gradle5xOrHigher"] === "true";
         let codeCoveragePluginData = null;
-        let useJacocoGradleTemplateV2 = ccProps["useJacocoGradleTemplateV2"] && ccProps["useJacocoGradleTemplateV2"] === "true";
+        const gradleVersion = ccProps["gradleVersion"];
+        const useJacocoTemplateV2forSingleModule = ccProps['useJacocoTemplateV2forSingleModule'] && ccProps['useJacocoTemplateV2forSingleModule'] === 'true';
+        const useJacocoTemplateV2forMultiModule = ccProps['useJacocoTemplateV2forMultiModule'] && ccProps['useJacocoTemplateV2forMultiModule'] === 'true';
+        const useTemplateV2FFisEnabled = isMultiModule && useJacocoTemplateV2forMultiModule || !isMultiModule && useJacocoTemplateV2forSingleModule;
 
         let filter = _this.extractFilters(classFilter);
         let jacocoExclude = _this.applyFilterPattern(filter.excludeFilter);
         let jacocoInclude = _this.applyFilterPattern(filter.includeFilter);
 
-        if (isMultiModule) {
-            codeCoveragePluginData = ccc.jacocoGradleMultiModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
-        } else {
-            if (useJacocoGradleTemplateV2) {
-                codeCoveragePluginData = ccc.jacocoGradleSingleModuleEnableV2(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
-            } else {
-                codeCoveragePluginData = ccc.jacocoGradleSingleModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
-            }
-        }
+        const jacocoGradleEnabler = _this.getJacocoGradleEnablerFunction(isMultiModule, gradleVersion, useTemplateV2FFisEnabled);
+        codeCoveragePluginData = jacocoGradleEnabler(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
 
         try {
             tl.debug("Code Coverage data will be appeneded to build file: " + this.buildFile);
@@ -66,4 +63,34 @@ export class JacocoGradleCodeCoverageEnabler extends cc.JacocoCodeCoverageEnable
         tl.debug("Applying the filter pattern: " + filter + " op: " + ccfilter);
         return ccfilter;
     }
+
+    /*
+    * Returns the appropriate Jacoco Gradle enabler function based on the project's Gradle version and module type.
+    * @param isMultiModule - A boolean indicating whether the project is a multi-module project.
+    * @param gradleVersion - The version of gradle used by the project.
+    * @returns The appropriate Jacoco Gradle enabler function.
+    * @throws An error if the Gradle version or module type is not supported.
+    */
+    private getJacocoGradleEnablerFunction(isMultiModule: boolean, gradleVersion: string, useTemplateV2FFisEnabled: boolean) {
+      const modeleType = isMultiModule ? "multi" : "single";
+      const resolvedGradleVersion = semver.valid(semver.coerce(gradleVersion));
+
+      // if gradle version is 'unknown' or below 6.1.0, use V1 template
+      const templateVersion = resolvedGradleVersion && semver.gte(resolvedGradleVersion, '6.1.0') && useTemplateV2FFisEnabled ? "V2" : "V1";
+
+      tl.debug(`Gradle module type: ${modeleType}, Gradle version: ${gradleVersion}, ResolvedGradleVersion: ${resolvedGradleVersion} Template version: ${templateVersion}`)
+
+      switch (modeleType + "-" + templateVersion) {
+          case "multi-V1":
+              return ccc.jacocoGradleMultiModuleEnable;
+          case "multi-V2":
+              return ccc.jacocoGradleMultiModuleEnableV2;
+          case "single-V1":
+              return ccc.jacocoGradleSingleModuleEnable;
+          case "single-V2":
+              return ccc.jacocoGradleSingleModuleEnableV2;
+          default:
+              throw new Error("Invalid template version or module type.");
+      }
+  }
 }

--- a/common-npm-packages/codecoverage-tools/package-lock.json
+++ b/common-npm-packages/codecoverage-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "3.245.0",
+  "version": "3.245.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-tasks-codecoverage-tools",
-      "version": "3.245.0",
+      "version": "3.245.1",
       "license": "MIT",
       "dependencies": {
         "@types/cheerio": "0.22.0",
@@ -18,6 +18,7 @@
         "mocha": "^10.5.1",
         "os": "^0.1.1",
         "rewire": "^6.0.0",
+        "semver": "^7.5.4",
         "sinon": "^14.0.0",
         "strip-bom": "^3.0.0",
         "xml2js": "^0.6.2"
@@ -394,6 +395,15 @@
         "semver": "^5.7.2",
         "shelljs": "^0.8.5",
         "uuid": "^3.0.1"
+      }
+    },
+    "node_modules/azure-pipelines-task-lib/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/balanced-match": {
@@ -920,18 +930,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/eslint/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha1-mA97VVC8F1+03AlAMIVif56zMUM=",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/espree": {
@@ -2194,12 +2192,15 @@
       "license": "ISC"
     },
     "node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
+      "version": "7.6.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha1-mA97VVC8F1+03AlAMIVif56zMUM=",
       "license": "ISC",
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/serialize-javascript": {
@@ -2963,6 +2964,13 @@
         "semver": "^5.7.2",
         "shelljs": "^0.8.5",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.2",
+          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg="
+        }
       }
     },
     "balanced-match": {
@@ -3289,11 +3297,6 @@
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
           }
-        },
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha1-mA97VVC8F1+03AlAMIVif56zMUM="
         }
       }
     },
@@ -4166,9 +4169,9 @@
       "integrity": "sha1-RMyJiDd/EmME07P8EBDHM7kp7w8="
     },
     "semver": {
-      "version": "5.7.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg="
+      "version": "7.6.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha1-mA97VVC8F1+03AlAMIVif56zMUM="
     },
     "serialize-javascript": {
       "version": "6.0.2",

--- a/common-npm-packages/codecoverage-tools/package.json
+++ b/common-npm-packages/codecoverage-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "3.245.0",
+  "version": "3.245.1",
   "author": "Microsoft Corporation",
   "description": "VSTS Tasks Code Coverage Tools",
   "license": "MIT",
@@ -17,6 +17,7 @@
     "mocha": "^10.5.1",
     "os": "^0.1.1",
     "rewire": "^6.0.0",
+    "semver": "^7.5.4",
     "sinon": "^14.0.0",
     "strip-bom": "^3.0.0",
     "xml2js": "^0.6.2"


### PR DESCRIPTION
The templates we insert into the build.gradle file to enable code coverage may not work with newer versions of Gradle.
Add the ability to use different Jacoco Gradle templates based on the project's Gradle version and module type.

Fix jacocoGradleSingleModuleEnableV2 (It has been added in this PR: https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/214)
Add jacocoGradleMultiModuleEnableV2

---

FFs to enable new templates:
 -- useJacocoTemplateV2forSingleModule 
 -- useJacocoTemplateV2forMultiModule
