### PR TITLE
To hardcode supported API versions for MsDeploy installation

### DIFF
--- a/common-npm-packages/azure-arm-rest/azure-arm-app-service.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-app-service.ts
@@ -890,11 +890,16 @@ export class AzureAppService {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'GET';
             var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+
+            const isAzureStack = this._client.getCredentials().isAzureStackEnvironment;
+            const apiVersion = isAzureStack ? '2020-12-01' : '2022-03-01';
+
             httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/basicPublishingCredentialsPolicies/scm`,
             {
                 '{resourceGroupName}': this._resourceGroup,
                 '{name}': this._name,
-            }, null, '2022-03-01');
+            }, null, apiVersion);
+
             let requestOptions = new webClient.WebRequestOptions();
             requestOptions.retryCount = 1;
 

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.246.0",
+  "version": "3.246.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-tasks-azure-arm-rest",
-      "version": "3.246.0",
+      "version": "3.246.2",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.246.0",
+  "version": "3.246.2",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Azure Stack [Azure Stack](https://azure.microsoft.com/en-us/products/azure-stack/) which works a bit differently from public Azure cloud.
When the user is using [AzureRmWebAppDeploymentV4](https://github.com/microsoft/azure-pipelines-tasks/tree/master/Tasks/AzureRmWebAppDeploymentV4) task, it has to install MsDeploy to deploy some service to Azure.
But Azure Stack has different supported versions of MsDeploy than public Azure cloud.

So, as a temporary solution we need to hardcode supported API versions for MsDeploy download 