### PR TITLE
Fix another typo in ArtifactToolsUtilities

### DIFF
--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.245.3",
+    "version": "3.246.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-packaging-common",
-            "version": "3.245.3",
+            "version": "3.246.1",
             "license": "MIT",
             "dependencies": {
                 "@types/ini": "1.3.30",

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.245.3",
+    "version": "3.246.1",
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "mocha _build/Tests/L0.js",

--- a/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
+++ b/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
@@ -8,10 +8,12 @@ import * as pkgLocationUtils from "../locationUtilities";
 import * as tl from "azure-pipelines-task-lib";
 import * as toollib from "azure-pipelines-tool-lib/tool";
 
+const toolName = "artifacttool";
+
 export function getArtifactToolLocation(dirName: string): string {
     let toolPath: string = path.join(dirName, "ArtifactTool.exe");
     if (tl.osType() !== "Windows_NT"){
-        toolPath = path.join(dirName, "artifacttool");
+        toolPath = path.join(dirName, toolName);
     }
     return toolPath;
 }
@@ -92,7 +94,7 @@ export async function getArtifactToolFromService(serviceUri: string, accessToken
         tl.debug("Downloaded zipped artifact tool to " + zippedToolsDir);
         const unzippedToolsDir = await extractZip(zippedToolsDir);
 
-        artifactToolPath = await toollib.cacheDir(unzippedToolsDir, "ArtifactTool", artifactToolUri.result['version']);
+        artifactToolPath = await toollib.cacheDir(unzippedToolsDir, toolName, artifactToolUri.result['version']);
     } else {
         tl.debug(tl.loc("Info_ResolvedToolFromCache", artifactToolPath));
     }


### PR DESCRIPTION
ArtifactTool was attempting to download from the correct location but was caching in the wrong location. Both now share the same casing.