### PR TITLE
2208911 Create PR for the Azure-arm-rest Common lib and update related task

### DIFF
--- a/common-npm-packages/azure-arm-rest/Tests/L0-azure-arm-aks-service-tests.d.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-azure-arm-aks-service-tests.d.ts
@@ -1,0 +1,1 @@
+export declare function AksServiceTests(): void;

--- a/common-npm-packages/azure-arm-rest/Tests/L0-azure-arm-aks-service-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-azure-arm-aks-service-tests.ts
@@ -1,0 +1,25 @@
+import assert = require("assert");
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import tl = require('azure-pipelines-task-lib');
+import * as path from 'path';
+
+export function AksServiceTests() {
+    it('azure-arm-aks-service AksService', (done: Mocha.Done) => {
+        let tp = path.join(__dirname, 'azure-arm-aks-service-tests.js');
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        let passed: boolean = true;
+
+        tr.runAsync().then(() => {
+            assert(tr.stdOutContained("Aks Cluster Credential Found: clusterAdmin"), "Should have printed: Aks Cluster Credential Found: clusterAdmin");
+            assert(tr.stdOutContained("Aks Cluster Credential Found: clusterUser"), "Should have printed: Aks Cluster Credential Found: clusterUser");
+            assert(tr.stdOutContained("Aks Cluster Credential Found: customUser"), "Should have printed: Aks Cluster Credential Found: customUser");
+            done();
+        })
+        .catch((error) => {
+            passed = false;
+            console.log(tr.stdout);
+            console.log(tr.stderr);
+            done(error);
+        });
+    });
+}

--- a/common-npm-packages/azure-arm-rest/Tests/L0.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0.ts
@@ -3,6 +3,7 @@ import { KuduServiceTests } from "./L0-azure-arm-app-service-kudu-tests";
 import { ApplicationInsightsTests } from "./L0-azure-arm-appinsights-tests";
 import { ApplicationInsightsTests as ApplicationInsightsTestsWebTests } from "./L0-azure-arm-appinsights-webtests-tests";
 import { ResourcesTests } from "./L0-azure-arm-resource-tests";
+import { AksServiceTests } from "./L0-azure-arm-aks-service-tests";
 const DEFAULT_TIMEOUT = 1000 * 20;
 
 describe("AzureARMRestTests", function () {
@@ -12,4 +13,5 @@ describe("AzureARMRestTests", function () {
     describe("ApplicationInsightsTests", ApplicationInsightsTests.bind(ApplicationInsightsTests, DEFAULT_TIMEOUT))
     describe("ApplicationInsightsWeb tests", ApplicationInsightsTestsWebTests.bind(ApplicationInsightsTestsWebTests, DEFAULT_TIMEOUT))
     describe("Resources Tests", ResourcesTests.bind(ResourcesTests, DEFAULT_TIMEOUT));
+    describe("AKS Tests", AksServiceTests.bind(AksServiceTests, DEFAULT_TIMEOUT));
 });

--- a/common-npm-packages/azure-arm-rest/Tests/azure-arm-aks-service-tests.d.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/azure-arm-aks-service-tests.d.ts
@@ -1,0 +1,5 @@
+export declare class AksServiceTests {
+    static credentialsByClusterAdmin(): Promise<void>;
+    static credentialsByClusterUser(): Promise<void>;
+    static credentialsByCustomClusterUser(): Promise<void>;
+}

--- a/common-npm-packages/azure-arm-rest/Tests/azure-arm-aks-service-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/azure-arm-aks-service-tests.ts
@@ -1,0 +1,54 @@
+import { getMockEndpoint, nock, mockAzureAksServiceTests } from './mock_utils';
+import tl = require('azure-pipelines-task-lib');
+import { AzureAksService } from '../azure-arm-aks-service';
+
+var endpoint = getMockEndpoint();
+
+// Mock all calls for Azure AKS Service
+mockAzureAksServiceTests();
+
+export class AksServiceTests {
+    public static async credentialsByClusterAdmin() {
+        let aksService: AzureAksService = new AzureAksService(endpoint);
+        try {
+            let result = await aksService.getClusterCredential("MOCK_RESOURCE_GROUP_NAME", "MOCK_CLUSTER", true);
+            console.log(`Aks Cluster Credential Found: ${result.name}`);
+        }
+        catch(error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'AksServiceTests.credentialsByClusterAdmin() should have passed but failed');
+        }
+    }
+
+    public static async credentialsByClusterUser() {
+        let aksService: AzureAksService = new AzureAksService(endpoint);
+        try {
+            let result = await aksService.getClusterCredential("MOCK_RESOURCE_GROUP_NAME", "MOCK_CLUSTER", false);
+            console.log(`Aks Cluster Credential Found: ${result.name}`);
+        }
+        catch(error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'AksServiceTests.credentialsByClusterUser() should have passed but failed');
+        }
+    }
+
+    public static async credentialsByCustomClusterUser() {
+        let aksService: AzureAksService = new AzureAksService(endpoint);
+        try {
+            let result = await aksService.getClusterCredential("MOCK_RESOURCE_GROUP_NAME", "MOCK_CLUSTER", false, 'customUser');
+            console.log(`Aks Cluster Credential Found: ${result.name}`);
+        }
+        catch(error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'AksServiceTests.credentialsByCustomClusterUser() should have passed but failed');
+        }
+    }
+}
+
+async function RUNTESTS() {
+    await AksServiceTests.credentialsByClusterAdmin();
+    await AksServiceTests.credentialsByClusterUser();
+    await AksServiceTests.credentialsByCustomClusterUser();
+}
+
+RUNTESTS();

--- a/common-npm-packages/azure-arm-rest/Tests/mock_utils.d.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/mock_utils.d.ts
@@ -6,3 +6,4 @@ export declare function mockAzureApplicationInsightsTests(): void;
 export declare function mockAzureAppServiceTests(): void;
 export declare function mockKuduServiceTests(): void;
 export declare function mockAzureARMResourcesTests(): void;
+export declare function mockAzureAksServiceTests(): void;

--- a/common-npm-packages/azure-arm-rest/Tests/mock_utils.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/mock_utils.ts
@@ -726,7 +726,7 @@ export function mockAzureAksServiceTests() {
             "authorization": "Bearer DUMMY_ACCESS_TOKEN",
             "content-type": "application/json; charset=utf-8"
         }
-    }).get("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/Microsoft.ContainerService/managedClusters/MOCK_CLUSTER/listClusterUserCredential?api-version=2024-05-01")
+    }).post("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/Microsoft.ContainerService/managedClusters/MOCK_CLUSTER/listClusterUserCredential?api-version=2024-05-01")
     .reply(200, {
         kubeconfigs: [{ 
             name: "clusterUser",
@@ -743,7 +743,7 @@ export function mockAzureAksServiceTests() {
             "authorization": "Bearer DUMMY_ACCESS_TOKEN",
             "content-type": "application/json; charset=utf-8"
         }
-    }).get("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/Microsoft.ContainerService/managedClusters/MOCK_CLUSTER/listClusterAdminCredential?api-version=2024-05-01")
+    }).post("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/Microsoft.ContainerService/managedClusters/MOCK_CLUSTER/listClusterAdminCredential?api-version=2024-05-01")
     .reply(200, {
         kubeconfigs: [{ 
             name: "clusterAdmin",

--- a/common-npm-packages/azure-arm-rest/Tests/mock_utils.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/mock_utils.ts
@@ -719,3 +719,36 @@ export function mockAzureARMResourcesTests() {
         }]
      }).persist();
 }
+
+export function mockAzureAksServiceTests() {
+    nock('https://management.azure.com', {
+        reqheaders: {
+            "authorization": "Bearer DUMMY_ACCESS_TOKEN",
+            "content-type": "application/json; charset=utf-8"
+        }
+    }).get("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/Microsoft.ContainerService/managedClusters/MOCK_CLUSTER/listClusterUserCredential?api-version=2024-05-01")
+    .reply(200, {
+        kubeconfigs: [{ 
+            name: "clusterUser",
+            value: "base46kubeconfig"
+        },
+        { 
+            name: "customUser",
+            value: "base46kubeconfig"
+        }]
+     }).persist();
+
+     nock('https://management.azure.com', {
+        reqheaders: {
+            "authorization": "Bearer DUMMY_ACCESS_TOKEN",
+            "content-type": "application/json; charset=utf-8"
+        }
+    }).get("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/Microsoft.ContainerService/managedClusters/MOCK_CLUSTER/listClusterAdminCredential?api-version=2024-05-01")
+    .reply(200, {
+        kubeconfigs: [{ 
+            name: "clusterAdmin",
+            value: "base46kubeconfig"
+        }]
+     }).persist();
+
+}

--- a/common-npm-packages/azure-arm-rest/azure-arm-aks-service.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-aks-service.ts
@@ -28,10 +28,10 @@ export class AzureAksService {
         this._client = new ServiceClient(endpoint.applicationTokenCredentials, endpoint.subscriptionID, 30);
     }
 
-    public beginRequest(uri: string,  parameters: {}) : Promise<webClient.WebResponse> {
+    public beginRequest(uri: string,  parameters: {}, apiVersion: string, method: string) : Promise<webClient.WebResponse> {
          var webRequest = new webClient.WebRequest();
-         webRequest.method = 'GET';
-         webRequest.uri = this._client.getRequestUri(uri, parameters, null,'2017-08-31');
+         webRequest.method = method || 'GET';
+         webRequest.uri = this._client.getRequestUri(uri, parameters, null, apiVersion);
         return this._client.beginRequestExpBackoff(webRequest, 3).then((response)=>{
             if(response.statusCode >= 200 && response.statusCode < 300) {
                 return response;
@@ -48,10 +48,36 @@ export class AzureAksService {
             '{ResourceGroupName}': resourceGroup,
             '{ClusterName}': clusterName,
             '{AccessProfileName}': accessProfileName
-        }).then((response) => {
+        }, '2017-08-31', "GET").then((response) => {
             return  response.body;
         }, (reason) => {
             throw Error(tl.loc('CantDownloadAccessProfile',clusterName,  this._client.getFormattedError(reason)));
         });
+    }
+
+    public getClusterCredentials(resourceGroup : string , clusterName : string, useClusterAdmin?: boolean): Promise<Model.AKSCredentialResults> {
+        var credentialAction = !!useClusterAdmin ? 'listClusterAdminCredential' : 'listClusterUserCredential';
+        return this.beginRequest(`//subscriptions/{subscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{ClusterName}/{CredentialAction}`,
+        {
+            '{ResourceGroupName}': resourceGroup,
+            '{ClusterName}': clusterName,
+            '{CredentialAction}': credentialAction
+        }, '2024-05-01', "POST").then((response) => {
+            return  response.body;
+        }, (reason) => {
+            throw Error(tl.loc('CantDownloadClusterCredentials',clusterName,  this._client.getFormattedError(reason)));
+        });
+    }
+
+    public getClusterCredential(resourceGroup : string , clusterName : string, useClusterAdmin?: boolean, credentialName?: string): Promise<Model.AKSCredentialResult> {
+        var credentialName = !!credentialName ? credentialName : !!useClusterAdmin ? 'clusterAdmin' : 'clusterUser';
+        var clusterCredentials = this.getClusterCredentials(resourceGroup, clusterName, useClusterAdmin)
+        return clusterCredentials.then((credentials) => {
+           var credential = credentials.kubeconfigs.find(credential => credential.name == credentialName)
+            if (credential === undefined) {
+                throw Error(tl.loc('CantDownloadClusterCredentials', clusterName, `${credentialName} not found in the list of cluster credentials.`));
+            }
+            return credential;
+        })
     }
 }

--- a/common-npm-packages/azure-arm-rest/azureModels.ts
+++ b/common-npm-packages/azure-arm-rest/azureModels.ts
@@ -305,6 +305,15 @@ export interface AKSClusterAccessProfile extends AzureBaseObject {
     properties: AKSClusterAccessProfileProperties
 }
 
+export interface AKSCredentialResult {
+    name: string;
+    value: string;
+}
+
+export interface AKSCredentialResults extends AzureBaseObject {
+    kubeconfigs: Array<AKSCredentialResult>
+}
+
 export interface IThresholdRuleConditionDataSource {
 	"odata.type": string;
 	resourceUri: string;

--- a/common-npm-packages/azure-arm-rest/module.json
+++ b/common-npm-packages/azure-arm-rest/module.json
@@ -185,6 +185,7 @@
         "UpdatedAppServiceConfigurationSettings": "Updated App Service Configuration settings.",
         "UpdatingAppServiceApplicationSettings": "Updating App Service Application settings. Data: %s",
         "UpdatingAppServiceConfigurationSettings": "Trying to update App Service Configuration settings. Data: %s",
-        "VirtualApplicationDoesNotExist": "Virtual application doesn't exists : %s"
+        "VirtualApplicationDoesNotExist": "Virtual application doesn't exists : %s",
+        "CantDownloadClusterCredentials": "Cannot fetch the credentials for the cluster %s. Reason %s."
     }
 }

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.246.4",
+  "version": "3.246.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-tasks-azure-arm-rest",
-      "version": "3.246.4",
+      "version": "3.246.5",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.246.4",
+  "version": "3.246.5",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
For AKS cluster currently we are using access profile API to fetch credentials but this endpoint is going to be deprecated. so we have introduced new function to fetch the credentials from AkS cluster