### PR TITLE
[az-blobstorage-provider] Fixed AzureBlobProvider Init - AB#2218195

### DIFF
--- a/common-npm-packages/az-blobstorage-provider/blobservice.ts
+++ b/common-npm-packages/az-blobstorage-provider/blobservice.ts
@@ -20,13 +20,13 @@ export class BlobService {
 
     public async uploadBlobs(source: string, container: string, prefixFolderPath?: string, itemPattern?: string): Promise<string[]> {
         var fileProvider = new artifactProviders.FilesystemProvider(source);
-        var azureProvider = new azureBlobProvider.AzureBlobProvider(this._storageAccountName, container, this._storageAccessKey, prefixFolderPath, this._host,false,this._useCredential,this._endpoint);
+        var azureProvider = new azureBlobProvider.AzureBlobProvider(this._storageAccountName, container, this._storageAccessKey, prefixFolderPath, this._host, false, this._useCredential, this._endpoint);
         var processor = new artifactProcessor.ArtifactEngine();
         var processorOptions = new artifactProcessor.ArtifactEngineOptions();
         if (itemPattern) {
             processorOptions.itemPattern = itemPattern;
         }
-        
+
         var uploadedItemTickets = await processor.processItems(fileProvider, azureProvider);
         var uploadedUrls: string[] = [];
         uploadedItemTickets.forEach((ticket: models.ArtifactDownloadTicket) => {
@@ -40,7 +40,7 @@ export class BlobService {
 
     public async downloadBlobs(destination: string, container: string, prefixFolderPath?: string, itemPattern?: string, addPrefixToDownloadedItems?: boolean): Promise<void> {
         var fileProvider = new artifactProviders.FilesystemProvider(destination);
-        var azureProvider = new azureBlobProvider.AzureBlobProvider(this._storageAccountName, container, this._storageAccessKey, prefixFolderPath, this._host, !!addPrefixToDownloadedItems,this._useCredential);
+        var azureProvider = new azureBlobProvider.AzureBlobProvider(this._storageAccountName, container, this._storageAccessKey, prefixFolderPath, this._host, !!addPrefixToDownloadedItems, this._useCredential, this._endpoint);
         var processor = new artifactProcessor.ArtifactEngine();
         var processorOptions = new artifactProcessor.ArtifactEngineOptions();
         if (itemPattern) {

--- a/common-npm-packages/az-blobstorage-provider/package-lock.json
+++ b/common-npm-packages/az-blobstorage-provider/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azp-tasks-az-blobstorage-provider",
-    "version": "3.245.2",
+    "version": "3.246.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azp-tasks-az-blobstorage-provider",
-            "version": "3.245.2",
+            "version": "3.246.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^3.4.2",

--- a/common-npm-packages/az-blobstorage-provider/package.json
+++ b/common-npm-packages/az-blobstorage-provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azp-tasks-az-blobstorage-provider",
-    "version": "3.245.2",
+    "version": "3.246.2",
     "description": "Common Library to download blobs from azure storage",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Why this change?

Initialization of the `AzureBlobProvider`in the `downloadBlobs` method in `BlobService` class was incorrect. The `_endpoint` object was not being passed which resulted in a runtime error.

### What was changed?

1. Passed the `_endpoint` object to the `AzureBlobProvider` constructor in the `downloadBlobs` method.
2. Corrected the formatting of the `BlobService` class.
3. Incremented the package version.