### PR TITLE
[packaging-common] Add ability to pass request timeouts to `node-api` and `typed-rest-client`

### DIFF
--- a/common-npm-packages/packaging-common/locationUtilities.ts
+++ b/common-npm-packages/packaging-common/locationUtilities.ts
@@ -155,8 +155,8 @@ export function getWebApiWithProxy(serviceUri: string, accessToken?: string, web
         proxy: tl.getHttpProxyConfiguration(serviceUri),
         allowRetries: true,
         maxRetries: 5,
-        socketTimeout: webApiOptions.socketTimeout,
-        globalAgentOptions: webApiOptions.globalAgentOptions
+        socketTimeout: webApiOptions && webApiOptions.socketTimeout,
+        globalAgentOptions: webApiOptions && webApiOptions.globalAgentOptions
     };
     const webApi = new vsts.WebApi(serviceUri, credentialHandler, options);
     tl.debug(`Created webApi client for ${serviceUri}; options: ${JSON.stringify(options)}`);

--- a/common-npm-packages/packaging-common/npm/npmregistry.ts
+++ b/common-npm-packages/packaging-common/npm/npmregistry.ts
@@ -100,14 +100,14 @@ export class NpmRegistry implements INpmRegistry {
             const proxy = tl.getHttpProxyConfiguration();
             options = proxy ? { 
                 proxy,
-                socketTimeout: requestOptions.socketTimeout,
-                globalAgentOptions: requestOptions.globalAgentOptions
+                socketTimeout: requestOptions && requestOptions.socketTimeout,
+                globalAgentOptions: requestOptions && requestOptions.globalAgentOptions
             } : {};
         } catch (error) {
             tl.debug('unable to determine proxy configuration: ' + error);
             options = { 
-                socketTimeout: requestOptions.socketTimeout,
-                globalAgentOptions: requestOptions.globalAgentOptions 
+                socketTimeout: requestOptions && requestOptions.socketTimeout,
+                globalAgentOptions: requestOptions && requestOptions.globalAgentOptions
             };
         }
 

--- a/common-npm-packages/packaging-common/npm/npmregistry.ts
+++ b/common-npm-packages/packaging-common/npm/npmregistry.ts
@@ -7,6 +7,7 @@ import { IHeaders, IRequestOptions } from 'typed-rest-client/Interfaces';
 import { NormalizeRegistry } from './npmrcparser';
 import * as util from '../util';
 import * as locationUtil from '../locationUtilities';
+import { RequestOptions } from '../universal/RequestUtilities';
 
 export interface INpmRegistry {
     url: string;
@@ -26,7 +27,7 @@ export class NpmRegistry implements INpmRegistry {
     }
 
     /** Return NpmRegistry with masked auth from Service Endpoint. */
-    public static async FromServiceEndpoint(endpointId: string, authOnly?: boolean): Promise<NpmRegistry> {
+    public static async FromServiceEndpoint(endpointId: string, authOnly?: boolean, requestOptions?: RequestOptions): Promise<NpmRegistry> {
         const lineEnd = os.EOL;
         let endpointAuth: tl.EndpointAuthorization;
         let url: string;
@@ -48,7 +49,7 @@ export class NpmRegistry implements INpmRegistry {
 
             // To the reader, this could be optimized here but it is broken out for readability
             if (endpointAuth.scheme === 'Token') {
-                isVstsTokenAuth = await NpmRegistry.isEndpointInternal(url);
+                isVstsTokenAuth = await NpmRegistry.isEndpointInternal(url, requestOptions);
             }
             nerfed = util.toNerfDart(url);
         } catch (exception) {
@@ -93,20 +94,27 @@ export class NpmRegistry implements INpmRegistry {
 
     // make a request to the endpoint uri, and take a look at the response header to
     // determine whether this is our service, or an external service.
-    private static async isEndpointInternal(endpointUri: string): Promise<boolean> {
-        let requestOptions: IRequestOptions;
+    private static async isEndpointInternal(endpointUri: string, requestOptions?: RequestOptions): Promise<boolean> {
+        let options: IRequestOptions;
         try {
             const proxy = tl.getHttpProxyConfiguration();
-            requestOptions = proxy ? { proxy } : {};
+            options = proxy ? { 
+                proxy,
+                socketTimeout: requestOptions.socketTimeout,
+                globalAgentOptions: requestOptions.globalAgentOptions
+            } : {};
         } catch (error) {
             tl.debug('unable to determine proxy configuration: ' + error);
-            requestOptions = {};
+            options = { 
+                socketTimeout: requestOptions.socketTimeout,
+                globalAgentOptions: requestOptions.globalAgentOptions 
+            };
         }
 
         const headers: IHeaders = {};
         headers['X-TFS-FedAuthRedirect'] = 'Suppress';
 
-        const endpointClient = new HttpClient(tl.getVariable('AZURE_HTTP_USER_AGENT'), null, requestOptions);
+        const endpointClient = new HttpClient(tl.getVariable('AZURE_HTTP_USER_AGENT'), null, options);
         try {
             const resp = await endpointClient.get(endpointUri, headers);
             

--- a/common-npm-packages/packaging-common/nuget/NuGetToolGetter.ts
+++ b/common-npm-packages/packaging-common/nuget/NuGetToolGetter.ts
@@ -245,8 +245,8 @@ async function getLatestMatchVersionInfo(versionSpec: string, requestOptions?: R
     let versionsUrl = 'https://dist.nuget.org/tools.json';
     let proxyRequestOptions = {
         proxy: taskLib.getHttpProxyConfiguration(versionsUrl),
-        socketTimeout: requestOptions.socketTimeout,
-        globalAgentOptions: requestOptions.globalAgentOptions
+        socketTimeout: requestOptions && requestOptions.socketTimeout,
+        globalAgentOptions: requestOptions && requestOptions.globalAgentOptions
     };
     let rest: restm.RestClient = new restm.RestClient('vsts-tasks/NuGetToolInstaller', undefined, undefined, proxyRequestOptions);
 

--- a/common-npm-packages/packaging-common/nuget/NuGetToolGetter.ts
+++ b/common-npm-packages/packaging-common/nuget/NuGetToolGetter.ts
@@ -9,6 +9,7 @@ import * as os from "os";
 import {VersionInfo} from "../pe-parser/VersionResource";
 import * as peParser from "../pe-parser";
 import { getVersionFallback } from './ProductVersionHelper';
+import { RequestOptions } from '../universal/RequestUtilities';
 
 interface INuGetTools {
     nugetexe: INuGetVersionInfo[]
@@ -38,7 +39,11 @@ export const DEFAULT_NUGET_VERSION: string = '4.9.6';
 export const DEFAULT_NUGET_PATH_SUFFIX: string = 'NuGet/4.9.6/';
 export const NUGET_EXE_TOOL_PATH_ENV_VAR: string = 'NuGetExeToolPath';
 
-export async function getNuGet(versionSpec: string, checkLatest?: boolean, addNuGetToPath?: boolean): Promise<string> {
+export async function getNuGet(
+    versionSpec: string, 
+    checkLatest?: boolean, 
+    addNuGetToPath?: boolean,
+    requestOptions?: RequestOptions): Promise<string> {
     if (toolLib.isExplicitVersion(versionSpec)) {
         // Check latest doesn't make sense when explicit version
         checkLatest = false;
@@ -64,7 +69,7 @@ export async function getNuGet(versionSpec: string, checkLatest?: boolean, addNu
         console.log(taskLib.loc("Info_ResolvedToolFromCache", version));
     }
     else {
-        let versionInfo: INuGetVersionInfo = await getLatestMatchVersionInfo(versionSpec);
+        let versionInfo: INuGetVersionInfo = await getLatestMatchVersionInfo(versionSpec, requestOptions);
 
         // There is a local version which matches the spec yet we found one on dist.nuget.org
         // which is different, so we're about to change the version which was used
@@ -234,12 +239,14 @@ function GetRestClientOptions(): restm.IRequestOptions
     return options;
 }
 
-async function getLatestMatchVersionInfo(versionSpec: string): Promise<INuGetVersionInfo> {
+async function getLatestMatchVersionInfo(versionSpec: string, requestOptions?: RequestOptions): Promise<INuGetVersionInfo> {
     taskLib.debug('Querying versions list');
 
     let versionsUrl = 'https://dist.nuget.org/tools.json';
     let proxyRequestOptions = {
-        proxy: taskLib.getHttpProxyConfiguration(versionsUrl)
+        proxy: taskLib.getHttpProxyConfiguration(versionsUrl),
+        socketTimeout: requestOptions.socketTimeout,
+        globalAgentOptions: requestOptions.globalAgentOptions
     };
     let rest: restm.RestClient = new restm.RestClient('vsts-tasks/NuGetToolInstaller', undefined, undefined, proxyRequestOptions);
 

--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.246.1",
+    "version": "3.246.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-packaging-common",
-            "version": "3.246.1",
+            "version": "3.246.2",
             "license": "MIT",
             "dependencies": {
                 "@types/ini": "1.3.30",
@@ -15,7 +15,7 @@
                 "@types/node": "~16.11.39",
                 "@types/q": "1.5.2",
                 "adm-zip": "^0.4.11",
-                "azure-devops-node-api": "10.2.2",
+                "azure-devops-node-api": "14.1.0",
                 "azure-pipelines-task-lib": "^4.9.0",
                 "azure-pipelines-tool-lib": "^2.0.7",
                 "ini": "^1.3.8",
@@ -24,7 +24,7 @@
                 "mocha": "^10.7.3",
                 "q": "^1.5.0",
                 "semver": "^5.7.2",
-                "typed-rest-client": "1.8.4"
+                "typed-rest-client": "2.1.0"
             },
             "devDependencies": {
                 "typescript": "4.0.2"
@@ -140,13 +140,16 @@
             "license": "Python-2.0"
         },
         "node_modules/azure-devops-node-api": {
-            "version": "10.2.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
-            "integrity": "sha1-n1V+Yi3Qe7qpvV5+hOF8dh4hUbI=",
+            "version": "14.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-14.1.0.tgz",
+            "integrity": "sha1-7FOT3p+hRjmd6qtpBOQdoD7c4YA=",
             "license": "MIT",
             "dependencies": {
                 "tunnel": "0.0.6",
-                "typed-rest-client": "^1.8.4"
+                "typed-rest-client": "2.1.0"
+            },
+            "engines": {
+                "node": ">= 16.0.0"
             }
         },
         "node_modules/azure-pipelines-task-lib": {
@@ -451,6 +454,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/des.js": {
+            "version": "1.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+            "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "node_modules/diff": {
@@ -871,6 +884,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/js-md4": {
+            "version": "0.3.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+            "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+            "license": "MIT"
+        },
         "node_modules/js-yaml": {
             "version": "4.1.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -955,6 +974,12 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+            "license": "ISC"
         },
         "node_modules/minimatch": {
             "version": "3.0.5",
@@ -1423,14 +1448,19 @@
             }
         },
         "node_modules/typed-rest-client": {
-            "version": "1.8.4",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
-            "integrity": "sha1-uj+3iOW5MiVHQGOSUz8S1mClztY=",
+            "version": "2.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+            "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
             "license": "MIT",
             "dependencies": {
-                "qs": "^6.9.1",
+                "des.js": "^1.1.0",
+                "js-md4": "^0.3.2",
+                "qs": "^6.10.3",
                 "tunnel": "0.0.6",
                 "underscore": "^1.12.1"
+            },
+            "engines": {
+                "node": ">= 16.0.0"
             }
         },
         "node_modules/typescript": {
@@ -1730,12 +1760,12 @@
             "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg="
         },
         "azure-devops-node-api": {
-            "version": "10.2.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
-            "integrity": "sha1-n1V+Yi3Qe7qpvV5+hOF8dh4hUbI=",
+            "version": "14.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-14.1.0.tgz",
+            "integrity": "sha1-7FOT3p+hRjmd6qtpBOQdoD7c4YA=",
             "requires": {
                 "tunnel": "0.0.6",
-                "typed-rest-client": "^1.8.4"
+                "typed-rest-client": "2.1.0"
             }
         },
         "azure-pipelines-task-lib": {
@@ -1947,6 +1977,15 @@
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
                 "gopd": "^1.0.1"
+            }
+        },
+        "des.js": {
+            "version": "1.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+            "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+            "requires": {
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "diff": {
@@ -2194,6 +2233,11 @@
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
             "integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc="
         },
+        "js-md4": {
+            "version": "0.3.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+            "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU="
+        },
         "js-yaml": {
             "version": "4.1.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2249,6 +2293,11 @@
             "requires": {
                 "mime-db": "1.52.0"
             }
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
         },
         "minimatch": {
             "version": "3.0.5",
@@ -2547,11 +2596,13 @@
             "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw="
         },
         "typed-rest-client": {
-            "version": "1.8.4",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
-            "integrity": "sha1-uj+3iOW5MiVHQGOSUz8S1mClztY=",
+            "version": "2.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+            "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
             "requires": {
-                "qs": "^6.9.1",
+                "des.js": "^1.1.0",
+                "js-md4": "^0.3.2",
+                "qs": "^6.10.3",
                 "tunnel": "0.0.6",
                 "underscore": "^1.12.1"
             }

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.246.1",
+    "version": "3.246.2",
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "mocha _build/Tests/L0.js",
@@ -19,7 +19,7 @@
         "@types/node": "~16.11.39",
         "@types/q": "1.5.2",
         "adm-zip": "^0.4.11",
-        "azure-devops-node-api": "10.2.2",
+        "azure-devops-node-api": "14.1.0",
         "azure-pipelines-task-lib": "^4.9.0",
         "azure-pipelines-tool-lib": "^2.0.7",
         "ini": "^1.3.8",
@@ -28,7 +28,7 @@
         "mocha": "^10.7.3",
         "q": "^1.5.0",
         "semver": "^5.7.2",
-        "typed-rest-client": "1.8.4"
+        "typed-rest-client": "2.1.0"
     },
     "devDependencies": {
         "typescript": "4.0.2"

--- a/common-npm-packages/packaging-common/universal/ClientToolUtilities.ts
+++ b/common-npm-packages/packaging-common/universal/ClientToolUtilities.ts
@@ -176,8 +176,8 @@ export function getWebApiWithProxy(serviceUri: string, accessToken?: string, web
         proxy: tl.getHttpProxyConfiguration(serviceUri),
         allowRetries: true,
         maxRetries: 5,
-        socketTimeout: webApiOptions.socketTimeout,
-        globalAgentOptions: webApiOptions.globalAgentOptions
+        socketTimeout: webApiOptions && webApiOptions.socketTimeout,
+        globalAgentOptions: webApiOptions && webApiOptions.globalAgentOptions
     };
     const webApi = new vsts.WebApi(serviceUri, credentialHandler, options);
     tl.debug(`Created webApi client for ${serviceUri}; options: ${JSON.stringify(options)}`);

--- a/common-npm-packages/packaging-common/universal/RequestUtilities.ts
+++ b/common-npm-packages/packaging-common/universal/RequestUtilities.ts
@@ -1,0 +1,7 @@
+export interface RequestOptions {
+    socketTimeout?: number;
+    globalAgentOptions?: { 
+        keepAlive?: boolean;
+        timeout?: number;
+    }
+}


### PR DESCRIPTION
**WI**'
[AB#2217825](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2217825)

**Description**

Updated `azure-devops-node-api` and `typed-rest-client` packages and added an ability to pass request timeouts to them.

Original issue: https://github.com/microsoft/azure-pipelines-tasks/issues/20396