### PR TITLE
fix(docker): improve retrieval of layer id during inspect

### DIFF
--- a/common-npm-packages/docker-common/dockercommandutils.ts
+++ b/common-npm-packages/docker-common/dockercommandutils.ts
@@ -13,7 +13,7 @@ const buildString = "build";
 const hostType = tl.getVariable("System.HostType");
 const isBuild = hostType && hostType.toLowerCase() === buildString;
 const matchPatternForDigest = new RegExp(/sha256\:(.+)/);
-const matchPatternForLayerId = new RegExp(/layerId:(?:(?<algorithm>[^:]+):)?(?<layerId>[^\s]+)/);
+const matchPatternForLayerId = new RegExp(/layerId:(?:([^:]+):)?([^\s]+)/);
 
 export function build(connection: ContainerConnection, dockerFile: string, commandArguments: string, labelArguments: string[], tagArguments: string[], onCommandOut: (output) => any): any {
     var command = connection.createCommand();
@@ -225,7 +225,7 @@ export function getImageFingerPrintV1Name(history: string): string {
 
     const match = matchPatternForLayerId.exec(history);
     if (match) {
-        v1Name = match.groups.layerId;
+        v1Name = match[2];
     }
 
     return v1Name;


### PR DESCRIPTION
Should fix https://github.com/microsoft/azure-pipelines-tasks/issues/20506

Accounts for the change from https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/373 where layerId may or may not include an algorithm.

It appears that when a Dockerfile has a multiline RUN command, `docker history` outputs the `createdBy` property as-is, with newlines. This breaks retrieval of the layerId from the history, as the existing code splits the history by newline and attempts to find the layerId in the first line.

This change uses regex to find the first layerId mentioned in the history, regardless of newlines.
