### PR TITLE
2202985 Docker V2 task fails to push the container images after the task version updated to 2.243.0

### DIFF
--- a/common-npm-packages/docker-common/dockercommandutils.ts
+++ b/common-npm-packages/docker-common/dockercommandutils.ts
@@ -221,14 +221,19 @@ export function getImageFingerPrintV1Name(history: string): string {
     if (!history) {
         return null;
     }
-
     const lines = history.split(/[\r?\n]/);
     if (lines && lines.length > 0) {
-        v1Name = parseHistoryForV1Name(lines[0]);
+        for (let i = 0; i < lines.length; i++) {
+            if (lines[i].indexOf("layerId") >= 0) {
+                v1Name = parseHistoryForV1Name(lines[i]);
+                break
+            }
+        }
     }
 
     return v1Name;
 }
+
 
 export function getImageSize(layers: { [key: string]: string }[]): string {
     let imageSize = 0;
@@ -346,6 +351,9 @@ export async function getHistory(connection: ContainerConnection, image: string)
 }
 
 export async function getImageRootfsLayers(connection: ContainerConnection, imageDigest: string): Promise<string[]> {
+    if (!imageDigest || imageDigest === "") {
+        return []
+    }
     var command = connection.createCommand();
     command.arg("inspect");
     command.arg(imageDigest);

--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.245.0",
+    "version": "2.247.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.245.0",
+            "version": "2.247.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.245.0",
+    "version": "2.247.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",


### PR DESCRIPTION
When a customer uses the Podman to build the docker images they used to end up with error due to different form of layerId  