### PR TITLE
Changing NuGet cred provider functions when using WIF SC

### DIFF
--- a/common-npm-packages/artifacts-common/credentialProviderUtils.d.ts
+++ b/common-npm-packages/artifacts-common/credentialProviderUtils.d.ts
@@ -15,13 +15,15 @@ export declare function getUserProfileNuGetPluginsDir(): string;
  */
 export declare function configureCredProvider(protocol: ProtocolType, serviceConnections: ServiceConnection[]): Promise<void>;
 /**
- * Configure the credential provider to provide credentials for feeds within the pipeline's organization,
- * as well as for a single Entra backed service connection.
+ * Configure credentials for the given feed using the provided 'Azure Devops' service connection.
+ * Only external feeds are supported, will throw if the feed provided is internal.
  */
-export declare function configureEntraCredProvider(protocol: ProtocolType, serviceConnections: ServiceConnection[]): Promise<void>;
+export declare function configureEntraCredProvider(protocol: ProtocolType, entraWifServiceConnectionName: string, feedUrl: string | undefined): Promise<void>;
 /**
  * Configure the credential provider to provide credentials for feeds within the pipeline's organization,
  * using VSS_NUGET_URI_PREFIXES and VSS_NUGET_ACCESSTOKEN variables to do so.
+ * If an AzureDevops Service Connection is provided, it will be used to aquire an access token.
+ * Otherwise, the system access token will be used.
  */
 export declare function configureCredProviderForSameOrganizationFeeds(protocol: ProtocolType): Promise<void>;
 /**

--- a/common-npm-packages/artifacts-common/credentialProviderUtils.ts
+++ b/common-npm-packages/artifacts-common/credentialProviderUtils.ts
@@ -122,7 +122,7 @@ export async function configureCredProvider(protocol: ProtocolType, serviceConne
  * Configure credentials for the given feed using the provided 'Azure Devops' service connection.
  * Only external feeds are supported, will throw if the feed provided is internal.
  */
-export async function configureEntraCredProvider(protocol: ProtocolType, entraWifServiceConnectionName: string, feedUrl: string | undefined) : Promise<boolean> {
+export async function configureEntraCredProvider(protocol: ProtocolType, entraWifServiceConnectionName: string, feedUrl: string | undefined) {
     const connectionData = await getConnectionDataForProtocol(protocol);
     const packagingAccessMappings = getPackagingAccessMappings(connectionData.locationServiceData)
     const allPrefixes: string[] = [...new Set(packagingAccessMappings.map(prefix => prefix.uri))];
@@ -136,7 +136,6 @@ export async function configureEntraCredProvider(protocol: ProtocolType, entraWi
     let token = await getFederatedWorkloadIdentityCredentials(entraWifServiceConnectionName, feedTenant);
     if (token) {
         configureCredProviderForServiceConnectionFeeds([new EntraServiceConnection({uri:feedUrl}, entraWifServiceConnectionName, token)]);
-        return true;
     } else {
         throw new Error(tl.loc("FailedToGetServiceConnectionAuth", entraWifServiceConnectionName)); 
     }

--- a/common-npm-packages/artifacts-common/module.json
+++ b/common-npm-packages/artifacts-common/module.json
@@ -16,6 +16,7 @@
         "ErrorInSettingUpSubscription": "Error in setting up subscription",
         "Error_FederatedTokenAquisitionFailed": "Failed to aquire federated token.",
         "Error_GetFeedTenantIdFailed": "Failed to find tenantId for feedUrl. %s",
+        "Error_InternalFeedsNotSupported": "Internal feeds are not supported for use with 'Azure Devops' Service Connections. To use an Azure Devops Service Connection, feedUrl must belong to an external organization.",
         "LoginFailed": "Azure login failed",
         "MSILoginFailed": "Azure login failed using Managed Service Identity",
         "ServiceConnections_Error_FailedToParseServiceEndpoint_MissingParameter": "Failed to parse the service endpoint '%s' because it was missing the parameter '%s'",

--- a/common-npm-packages/artifacts-common/module.json
+++ b/common-npm-packages/artifacts-common/module.json
@@ -16,7 +16,7 @@
         "ErrorInSettingUpSubscription": "Error in setting up subscription",
         "Error_FederatedTokenAquisitionFailed": "Failed to aquire federated token.",
         "Error_GetFeedTenantIdFailed": "Failed to find tenantId for feedUrl. %s",
-        "Error_InternalFeedsNotSupported": "Internal feeds are not supported for use with 'Azure Devops' Service Connections. To use an Azure Devops Service Connection, feedUrl must belong to an external organization.",
+        "Error_InternalFeedsNotSupported": "FeedUrl must belong to an external organization. To authenticate to a feed in your organization with a 'Azure DevOps' service connection type, remove the `feedUrl` input.",
         "LoginFailed": "Azure login failed",
         "MSILoginFailed": "Azure login failed using Managed Service Identity",
         "ServiceConnections_Error_FailedToParseServiceEndpoint_MissingParameter": "Failed to parse the service endpoint '%s' because it was missing the parameter '%s'",

--- a/common-npm-packages/artifacts-common/package-lock.json
+++ b/common-npm-packages/artifacts-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-artifacts-common",
-    "version": "2.245.1",
+    "version": "2.247.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/common-npm-packages/artifacts-common/package-lock.json
+++ b/common-npm-packages/artifacts-common/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-artifacts-common",
-            "version": "2.245.1",
+            "version": "2.247.0",
             "license": "MIT",
             "dependencies": {
                 "@types/fs-extra": "8.0.0",

--- a/common-npm-packages/artifacts-common/package.json
+++ b/common-npm-packages/artifacts-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-artifacts-common",
-    "version": "2.245.1",
+    "version": "2.247.0",
     "description": "Azure Artifacts common code (for new authentication tasks)",
     "scripts": {
         "build": "cd ../build-scripts && npm install && cd ../artifacts-common && node make.js"


### PR DESCRIPTION
When using a WIF Service connection, we now:
- Verify the feed is external (internal feeds not supported with feedUrl param)
- Don't configure auth for all internal feeds if using an external feed in the same run
- Allow configuration of auth for internal feeds with a WIF Service connection if feed URL is not present