### PR TITLE
Log MSAL Node details

### DIFF
--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -301,6 +301,7 @@ export class ApplicationTokenCredentials {
     private async buildMSAL(): Promise<any> /*Promise<msal.ConfidentialClientApplication>*/ {
         // default configuration
         const authorityURL = (new URL(this.tenantId, this.authorityUrl)).toString();
+        const isDebug = tl.getVariable("system.debug") && tl.getVariable("system.debug").toLowerCase() === "true";
 
         const msalConfig: any /*msal.Configuration*/ = {
             auth: {
@@ -312,8 +313,8 @@ export class ApplicationTokenCredentials {
                     loggerCallback(loglevel, message, containsPii) {
                         loglevel == msal.LogLevel.Error ? tl.error(message) : tl.debug(message);
                     },
-                    piiLoggingEnabled: false,
-                    logLevel: msal.LogLevel.Info,
+                    piiLoggingEnabled: isDebug,
+                    logLevel: isDebug ? msal.LogLevel.Verbose : msal.LogLevel.Info,
                 }
             }
         };

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.246.5",
+  "version": "3.248.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-tasks-azure-arm-rest",
-      "version": "3.246.5",
+      "version": "3.248.0",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.246.5",
+  "version": "3.248.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR enables verbose logging by MSAL Node library when `system.debug` variable is set to `true`.