### PR TITLE
Use trace level for MSAL logs

### DIFF
--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -310,11 +310,11 @@ export class ApplicationTokenCredentials {
             },
             system: {
                 loggerOptions: {
-                    loggerCallback(loglevel, message, containsPii) {
-                        loglevel == msal.LogLevel.Error ? tl.error(message) : tl.debug(message);
+                    loggerCallback(loglevel, message, _) {
+                        loglevel === msal.LogLevel.Error ? tl.error(message) : tl.debug(message);
                     },
                     piiLoggingEnabled: isDebug,
-                    logLevel: isDebug ? msal.LogLevel.Verbose : msal.LogLevel.Info,
+                    logLevel: isDebug ? msal.LogLevel.Trace : msal.LogLevel.Info,
                 }
             }
         };

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.248.0",
+  "version": "3.248.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-tasks-azure-arm-rest",
-      "version": "3.248.0",
+      "version": "3.248.1",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.248.0",
+  "version": "3.248.1",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Change the log level for MSAL logs from `Verbose` to `Trace` when `system.debug` is enabled.