### PR TITLE
Added checksum header to kudu deployment request conditionally

### DIFF
--- a/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
@@ -6,6 +6,7 @@ import Q = require('q');
 import { WebJob, SiteExtension } from './azureModels';
 import { KUDU_DEPLOYMENT_CONSTANTS } from './constants';
 import path = require('path');
+import crypto = require("crypto");
 
 tl.setResourcePath(path.join(__dirname, 'module.json'), true);
 
@@ -456,14 +457,25 @@ export class Kudu {
         }
     }
 
-    public async zipDeploy(webPackage: string, queryParameters?: Array<string>): Promise<any> {
+    public async zipDeploy(webPackage: string, queryParameters?: Array<string>, addChecksumHeader?: boolean): Promise<any> {
         let httpRequest = new webClient.WebRequest();
         httpRequest.method = 'POST';
         httpRequest.uri = this.client.getRequestUri(`/api/zipdeploy`, queryParameters);
-        httpRequest.body = fs.createReadStream(webPackage);
+
+        var rs = fs.createReadStream(webPackage);
+        var checksum: string = undefined;
+
+        httpRequest.body = rs;
         httpRequest.headers = {
             'Content-Type': 'application/octet-stream'
         };
+
+        if (addChecksumHeader !== undefined && addChecksumHeader) {
+            checksum = await this._computeFileChecksum(rs);
+            if (checksum !== undefined){
+                httpRequest.headers["x-ms-artifact-checksum"] = checksum;
+            }
+        }
 
         try {
             let response = await this.client.beginRequest(httpRequest);
@@ -528,11 +540,24 @@ export class Kudu {
         }
     }
 
-    public async oneDeploy(webPackage: string, queryParameters?: Array<string>): Promise<any> {
+    public async oneDeploy(webPackage: string, queryParameters?: Array<string>, addChecksumHeader?: boolean): Promise<any> {
         let httpRequest = new webClient.WebRequest();
         httpRequest.method = 'POST';
         httpRequest.uri = this.client.getRequestUri(`/api/publish`, queryParameters);
-        httpRequest.body = fs.createReadStream(webPackage);
+
+        var rs = fs.createReadStream(webPackage);
+        var checksum: string = undefined;
+
+        httpRequest.body = rs;
+        httpRequest.headers = httpRequest.headers || {};
+
+        if (addChecksumHeader !== undefined && addChecksumHeader) {
+            checksum = await this._computeFileChecksum(rs);
+            if (checksum !== undefined){
+                httpRequest.headers["x-ms-artifact-checksum"] = checksum;
+            }
+        }
+
         let requestOptions = new webClient.WebRequestOptions();
         //Bydefault webclient.sendRequest retries for  [500, 502, 503, 504]
         requestOptions.retriableStatusCodes = [500, 502, 503, 504];
@@ -689,5 +714,23 @@ export class Kudu {
         }
 
         return error;
+    }
+
+    private _computeFileChecksum(stream: fs.ReadStream) :Promise<string> {
+        return new Promise((resolve, reject) => {
+            const hash = crypto.createHash('sha256');
+            stream.on('data', (data) => {
+                hash.update(data);
+            });
+        
+            stream.on('end', () => {
+                const result = hash.digest('hex');
+                resolve(result);
+            });
+        
+            stream.on('error', (error) => {
+                resolve(undefined);
+            });
+        });
     }
 }

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.250.0",
+  "version": "3.251.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-tasks-azure-arm-rest",
-      "version": "3.250.0",
+      "version": "3.251.0",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.249.1",
+  "version": "3.250.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-tasks-azure-arm-rest",
-      "version": "3.249.1",
+      "version": "3.250.0",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.249.0",
+  "version": "3.250.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.250.0",
+  "version": "3.251.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In file azure-arm-rest/azure-arm-app-service-kudu.ts, for methods zipDeploy and oneDeploy, 
- based on optional header `addChecksumHeader`, we compute the sha-256 checksum of the zip file attached with the deployment request and add it as a request header `x-ms-artifact-checksum`. 
- This step is skipped if the parameter value is undefined or false. So, there is essentially no change in behaviour if this parameter is not specified or false.
- Any error in computing the checksum is ignored.

This value would be used by the kudu service to validate the integrity of the received file.

Testing done: Validated the changes by deploying update task AzureRmWebAppDeploymentV4