### PR TITLE
Do not add any labels to Docker images if addPipelineData is false

### DIFF
--- a/common-npm-packages/docker-common/pipelineutils.ts
+++ b/common-npm-packages/docker-common/pipelineutils.ts
@@ -27,16 +27,16 @@ function addLabelWithValue(labelName: string, labelValue: string, labels: string
 }
 
 function addCommonLabels(hostName: string, labels: string[], addPipelineData?: boolean): void {
-    addLabel(hostName, "system.teamfoundationcollectionuri", "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", labels);
     if (addPipelineData) {
+        addLabel(hostName, "system.teamfoundationcollectionuri", "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", labels);
         addLabel(hostName, "system.teamproject", "SYSTEM_TEAMPROJECT", labels);
         addLabel(hostName, "build.repository.name", "BUILD_REPOSITORY_NAME", labels);
     }
 }
 
 function addBuildLabels(hostName: string, labels: string[], addPipelineData?: boolean): void {
-    addLabel(hostName, "build.sourceversion", "BUILD_SOURCEVERSION", labels);
     if (addPipelineData) {
+        addLabel(hostName, "build.sourceversion", "BUILD_SOURCEVERSION", labels);
         addLabel(hostName, "build.repository.uri", "BUILD_REPOSITORY_URI", labels);
         addLabel(hostName, "build.sourcebranchname", "BUILD_SOURCEBRANCHNAME", labels);
         addLabel(hostName, "build.definitionname", "BUILD_DEFINITIONNAME", labels);
@@ -46,8 +46,8 @@ function addBuildLabels(hostName: string, labels: string[], addPipelineData?: bo
 }
 
 function addReleaseLabels(hostName: string, labels: string[], addPipelineData?: boolean): void {
-    addLabel(hostName, "release.releaseid", "RELEASE_RELEASEID", labels);
     if (addPipelineData) {
+        addLabel(hostName, "release.releaseid", "RELEASE_RELEASEID", labels);
         addLabel(hostName, "release.definitionname", "RELEASE_DEFINITIONNAME", labels);
         addLabel(hostName, "release.releaseweburl", "RELEASE_RELEASEWEBURL", labels);
     }


### PR DESCRIPTION
First of all, many thanks to @Parsa2820 for the PR on the original repository: https://github.com/microsoft/azure-pipelines-tasks/pull/16604. All I'm doing here is making sure these changes can go ahead and be merged even after it was closed on the original repo.

Currently, even when setting both the `addPipelineData` and `addBaseImageData` to `false` in the `Docker@2` task, the resulting docker command still includes 2 default labels:

```log
--label com.azure.dev.image.system.teamfoundationcollectionuri=https://dev.azure.com/<my-org>/ 
--label com.azure.dev.image.build.sourceversion=<source version id>
```

When running the task inside a release it also includes the label `release.releaseid`.

This PR changes the behavior of the `Docker@2` task so that adding labels with the values of `system.teamfoundationcollectionuri` and `build.sourceversion` can be enabled/disabled with the `addPipelineData` boolean variable, which can be set in the pipeline.

Task name: `DockerV2`

Description: Control the mentioned docker image labels. Previously these labels were always added, and there was no option to remove them. This behavior caused the private repository URI to be exposed in the docker image.

Documentation changes required: (Y/N) N

Added unit tests: (Y/N) N

Attached related issue: (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/13268 (Not sure if the issues on the old repository are still relevant, I'd gladly open one in here if necessary).

Checklist:

- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipe-[lines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected