### PR TITLE
updating the Get-MsBuildPath function

### DIFF
--- a/common-npm-packages/msbuildhelpers/PathFunctions.ps1
+++ b/common-npm-packages/msbuildhelpers/PathFunctions.ps1
@@ -30,7 +30,6 @@ function Get-MSBuildPath {
         $VersionNumber = [int]($Version.Remove(2))
 
         $specifiedStudio = Get-VisualStudio $VersionNumber
-
         if (($VersionNumber -ge 15 -or !$Version) -and # !$Version indicates "latest"
             ($specifiedStudio = Get-VisualStudio $VersionNumber) -and
             $specifiedStudio.installationPath) {
@@ -39,15 +38,15 @@ function Get-MSBuildPath {
                 if ($VersionNumber -eq 15) {
                     $MsBuildDirectory = "15.0"
                 }
-                Write-Output $MsBuildDirectory
+
                 if ($Architecture -eq 'x86') {
-                    $msBuildPath = Join-Path $specifiedStudio.installationPath MSBuild $MsBuildDirectory Bin MSBuild.exe
+                    $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\MSBuild.exe");
                     # DotNetFrameworkArchitecture.Bitness32
                 } elseif ($Architecture -eq 'x64') {
-                    $msBuildPath = Join-Path $specifiedStudio.installationPath MSBuild $MsBuildDirectory Bin amd64 MSBuild.exe
+                    $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\amd64\MSBuild.exe");
                     # DotNetFrameworkArchitecture.Bitness64
                 } else {
-                    $msBuildPath = Join-Path $specifiedStudio.installationPath MSBuild $MsBuildDirectory Bin MSBuild.exe
+                    $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\MSBuild.exe");
                     # DotNetFrameworkArchitecture.Bitness32
                 }
 

--- a/common-npm-packages/msbuildhelpers/PathFunctions.ps1
+++ b/common-npm-packages/msbuildhelpers/PathFunctions.ps1
@@ -23,36 +23,36 @@ function Get-MSBuildPath {
         [System.Reflection.Assembly]$msUtilities = $null
 
 
-		# We do not need Microsoft.Build.Utilities.Core.dll - if we have located this .dll file, we also have the location of msbuild.exe
-		# for the Bitness32 variant since it resides in the same folder.
-		# and for the Bitness64 variant since it resides in the /amd64 folders.
-		# These paths are fixed due to the way VS is installed.
-		$VersionNumber = [int]($Version.Remove(2))
+        # We do not need Microsoft.Build.Utilities.Core.dll - if we have located this .dll file, we also have the location of msbuild.exe
+        # for the Bitness32 variant since it resides in the same folder.
+        # and for the Bitness64 variant since it resides in the /amd64 folders.
+        # These paths are fixed due to the way VS is installed.
+        $VersionNumber = [int]($Version.Remove(2))
 
-		Write-Output "version: $VersionNumber"
-		$specifiedStudio = Get-VisualStudio $VersionNumber
-		Write-Output $specifiedStudio
+        Write-Output "version: $VersionNumber"
+        $specifiedStudio = Get-VisualStudio $VersionNumber
+        Write-Output $specifiedStudio
         if (($VersionNumber -ge 16 -or !$Version) -and # !$Version indicates "latest"
             ($specifiedStudio = Get-VisualStudio $VersionNumber) -and
             $specifiedStudio.installationPath) {
 
-				[object]$archValue = $null
-				if ($Architecture -eq 'x86') {
-					$msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild\Current\Bin\msbuild.exe")
-					# DotNetFrameworkArchitecture.Bitness32
-				} elseif ($Architecture -eq 'x64') {
-					$msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild\Current\Bin\amd64\msbuild.exe")
-					# DotNetFrameworkArchitecture.Bitness64
-				} else {
-					$msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild\Current\Bin\msbuild.exe")
-					# DotNetFrameworkArchitecture.Bitness32
-				}
+                [object]$archValue = $null
+                if ($Architecture -eq 'x86') {
+                    $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild\Current\Bin\msbuild.exe")
+                    # DotNetFrameworkArchitecture.Bitness32
+                } elseif ($Architecture -eq 'x64') {
+                    $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild\Current\Bin\amd64\msbuild.exe")
+                    # DotNetFrameworkArchitecture.Bitness64
+                } else {
+                    $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild\Current\Bin\msbuild.exe")
+                    # DotNetFrameworkArchitecture.Bitness32
+                }
 
-				if ($msBuildPath -and (Test-Path -LiteralPath $msBuildPath -PathType Leaf)) {
-					Write-Verbose "MSBuild: $msBuildPath"
-					return $msBuildPath
-			}
-		}
+                if ($msBuildPath -and (Test-Path -LiteralPath $msBuildPath -PathType Leaf)) {
+                    Write-Verbose "MSBuild: $msBuildPath"
+                    return $msBuildPath
+            }
+        }
 
 
         elseif (($Version -eq "15.0" -or !$Version) -and # !$Version indicates "latest"

--- a/common-npm-packages/msbuildhelpers/PathFunctions.ps1
+++ b/common-npm-packages/msbuildhelpers/PathFunctions.ps1
@@ -35,24 +35,24 @@ function Get-MSBuildPath {
             $specifiedStudio.installationPath) {
 
                 $MsBuildDirectory = "Current"
-                if ($VersionNumber -eq 15) {
-                    $MsBuildDirectory = "15.0"
-                }
+            if ($VersionNumber -eq 15) {
+                $MsBuildDirectory = "15.0"
+            }
 
-                if ($Architecture -eq 'x86') {
-                    $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\MSBuild.exe");
-                    # DotNetFrameworkArchitecture.Bitness32
-                } elseif ($Architecture -eq 'x64') {
-                    $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\amd64\MSBuild.exe");
-                    # DotNetFrameworkArchitecture.Bitness64
-                } else {
-                    $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\MSBuild.exe");
-                    # DotNetFrameworkArchitecture.Bitness32
-                }
+            if ($Architecture -eq 'x86') {
+                $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\MSBuild.exe");
+                # DotNetFrameworkArchitecture.Bitness32
+            } elseif ($Architecture -eq 'x64') {
+                $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\amd64\MSBuild.exe");
+                # DotNetFrameworkArchitecture.Bitness64
+            } else {
+                $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\MSBuild.exe");
+                # DotNetFrameworkArchitecture.Bitness32
+            }
 
-                if ($msBuildPath -and (Test-Path -LiteralPath $msBuildPath -PathType Leaf)) {
-                    Write-Verbose "MSBuild: $msBuildPath"
-                    return $msBuildPath
+            if ($msBuildPath -and (Test-Path -LiteralPath $msBuildPath -PathType Leaf)) {
+                Write-Verbose "MSBuild: $msBuildPath"
+                return $msBuildPath
             }
         }
 

--- a/common-npm-packages/msbuildhelpers/PathFunctions.ps1
+++ b/common-npm-packages/msbuildhelpers/PathFunctions.ps1
@@ -38,7 +38,7 @@ function Get-MSBuildPath {
 
                 [object]$archValue = $null
                 if ($Architecture -eq 'x86') {
-                    $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild\Current\Bin\msbuild.exe")
+                    $msBuildPath = Join-Path $specifiedStudio.installationPath MSBuild Current Bin MSBuild.exe
                     # DotNetFrameworkArchitecture.Bitness32
                 } elseif ($Architecture -eq 'x64') {
                     $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild\Current\Bin\amd64\msbuild.exe")

--- a/common-npm-packages/msbuildhelpers/PathFunctions.ps1
+++ b/common-npm-packages/msbuildhelpers/PathFunctions.ps1
@@ -204,7 +204,6 @@ function Get-VisualStudio {
         [int]$MajorVersion)
 
     Trace-VstsEnteringInvocation $MyInvocation
-    return @{ installationPath = "C:\Program Files\Microsoft Visual Studio\2022\Preview" }
     try {
         if (!$script:visualStudioCache.ContainsKey("$MajorVersion.0")) {
             try {
@@ -214,7 +213,7 @@ function Get-VisualStudio {
                 # may be something like 16.2.
                 Write-Verbose "Getting latest Visual Studio $MajorVersion setup instance."
                 $output = New-Object System.Text.StringBuilder
-                Invoke-VstsTool -FileName "$PSScriptRoot    ools\vswhere.exe" -Arguments "-version [$MajorVersion.0,$($MajorVersion+1).0) -latest -format json" -RequireExitCodeZero 2>&1 |
+                Invoke-VstsTool -FileName "$PSScriptRoot\tools\vswhere.exe" -Arguments "-version [$MajorVersion.0,$($MajorVersion+1).0) -latest -format json" -RequireExitCodeZero 2>&1 |
                     ForEach-Object {
                         if ($_ -is [System.Management.Automation.ErrorRecord]) {
                             Write-Verbose "STDERR: $($_.Exception.Message)"
@@ -233,7 +232,7 @@ function Get-VisualStudio {
                     # the same scheme. It appears to follow the 16.<UPDATE_NUMBER>.* versioning scheme.
                     Write-Verbose "Getting latest BuildTools 16 setup instance."
                     $output = New-Object System.Text.StringBuilder
-                    Invoke-VstsTool -FileName "$PSScriptRoot    ools\vswhere.exe" -Arguments "-version [$MajorVersion.0,$($MajorVersion+1).0) -products Microsoft.VisualStudio.Product.BuildTools -latest -format json" -RequireExitCodeZero 2>&1 |
+                    Invoke-VstsTool -FileName "$PSScriptRoot\tools\vswhere.exe" -Arguments "-version [$MajorVersion.0,$($MajorVersion+1).0) -products Microsoft.VisualStudio.Product.BuildTools -latest -format json" -RequireExitCodeZero 2>&1 |
                         ForEach-Object {
                             if ($_ -is [System.Management.Automation.ErrorRecord]) {
                                 Write-Verbose "STDERR: $($_.Exception.Message)"


### PR DESCRIPTION
 to avoid reflection for the new vs studio versions since it causes assembly conflict.

### [Related issue 20734](https://github.com/microsoft/azure-pipelines-tasks/issues/20734)

This portion of the Get-MsBuildPath function script first locates **Microsoft.Build.Utilities.Core.dll** and then uses it to locate the msbuild.exe. Under the current preview version of VS this fails due to an assembly conflict.
Fortunately for us, the reflection usage here is redundant, since the msbuild exe lives either in the same folder as this .dll file or in its direct subfolder.
These paths are fixed due to the way VS installation works - e.g. if we have location of the .dll file, we have the location of both of these versions of msbuild.
```
$Architecture = 'x64'

$Path = "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\Microsoft.Build.Utilities.Core.dll"
$msUtilities = [System.Reflection.Assembly]::LoadFrom($Path)

[type]$t = $msUtilities.GetType('Microsoft.Build.Utilities.ToolLocationHelper')
if ($t -ne $null) 
{
    [System.Reflection.MethodInfo] $mi = $t.GetMethod("GetPathToBuildToolsFile",[type[]]@( [string], [string], $msUtilities.GetType("Microsoft.Build.Utilities.DotNetFrameworkArchitecture") ))

$param3 = $mi.GetParameters()[2]
    $archValues = [System.Enum]::GetValues($param3. ParameterType)

[object] $archValue = $null
        if ($Architecture -eq 'x86') {
            $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
        } elseif ($Architecture -eq 'x64') {
            $archValue = $archValues.GetValue(2) # DotNetFrameworkArchitecture.Bitness64
        } else {
            $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
        }
    Write-Host "archValue = $archValue"

$msBuildPath = $mi.Invoke($null, @( 'msbuild.exe', '17.0', $archValue ))
    $msBuildPath
}
```