### PR TITLE
Adding Get-MSBuildPathModified with Telemetry under Feature flags

### DIFF
--- a/common-npm-packages/msbuildhelpers/PathFunctions.ps1
+++ b/common-npm-packages/msbuildhelpers/PathFunctions.ps1
@@ -263,6 +263,7 @@ function Select-MSBuildPath {
 
     $selectMSBuildPathTelemetry = [PSCustomObject]@{
         PreferredVersion = $PreferredVersion
+        LookedUpVersion = ""
         Architecture = $Architecture
         PathFromGetMSBuildPathFunction = ""
         PathFromGetMSBuildPathFunctionV2 = ""
@@ -302,8 +303,10 @@ function Select-MSBuildPath {
             if (($path = Get-MSBuildPath -Version $PreferredVersion -Architecture $Architecture)) {
                 if($featureFlags.enableTelemetry) {
                     try {
-                        $pathFromGetMSBuildPathV2 = Get-MSBuildPathV2 -Version $PreferredVersion -Architecture $Architecture
+                        $selectMSBuildPathTelemetry.LookedUpVersion = $PreferredVersion
                         $selectMSBuildPathTelemetry.PathFromGetMSBuildPathFunction = $path
+
+                        $pathFromGetMSBuildPathV2 = Get-MSBuildPathV2 -Version $PreferredVersion -Architecture $Architecture
                         $selectMSBuildPathTelemetry.PathFromGetMSBuildPathFunctionV2 = $pathFromGetMSBuildPathV2
                         $selectMSBuildPathTelemetry.PathMatches = ($path -eq $pathFromGetMSBuildPathV2)
                     } catch {
@@ -327,8 +330,10 @@ function Select-MSBuildPath {
             if (($path = Get-MSBuildPath -Version $version -Architecture $Architecture)) {
                 if($featureFlags.enableTelemetry) {
                     try {
-                        $pathFromGetMSBuildPathV2 = Get-MSBuildPathV2 -Version $version -Architecture $Architecture
+                        $selectMSBuildPathTelemetry.LookedUpVersion = $version
                         $selectMSBuildPathTelemetry.PathFromGetMSBuildPathFunction = $path
+
+                        $pathFromGetMSBuildPathV2 = Get-MSBuildPathV2 -Version $version -Architecture $Architecture
                         $selectMSBuildPathTelemetry.PathFromGetMSBuildPathFunctionV2 = $pathFromGetMSBuildPathV2
                         $selectMSBuildPathTelemetry.PathMatches = ($path -eq $pathFromGetMSBuildPathV2)
                     } catch {
@@ -338,12 +343,10 @@ function Select-MSBuildPath {
                     EmitTelemetry -TelemetryPayload $selectMSBuildPathTelemetry -TaskName "MSBuildHelpers"
                     
                     if($featureFlags.useGetMSBuildPathV2) {
-                        
                         # Warn falling back.
                         if ($specificVersion) {
                             Write-Warning (Get-VstsLocString -Key 'MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2' -ArgumentList $PreferredVersion, $Architecture, $version)
                         }
-
                         return $pathFromGetMSBuildPathV2
                     }
                 }
@@ -352,7 +355,6 @@ function Select-MSBuildPath {
                 if ($specificVersion) {
                     Write-Warning (Get-VstsLocString -Key 'MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2' -ArgumentList $PreferredVersion, $Architecture, $version)
                 }
-               
                 return $path
             }
         }
@@ -538,4 +540,3 @@ function Get-MSBuildPathV2 {
         Trace-VstsLeavingInvocation $MyInvocation
     }
 }
-

--- a/common-npm-packages/msbuildhelpers/PathFunctions.ps1
+++ b/common-npm-packages/msbuildhelpers/PathFunctions.ps1
@@ -173,20 +173,19 @@ function Get-MSBuildPathV2 {
         [string]$Version,
         [string]$Architecture)
 
-    $VersionNumber = 0
-    try {
-        $VersionNumber = [int]($Version.Remove(2))
-    } catch {
-        Write-Debug "Exception caught while parsing VersionNumber : $_"
-    }
-
     Trace-VstsEnteringInvocation $MyInvocation
     try {
         # We do not need Microsoft.Build.Utilities.Core.dll - if we have located this .dll file, we also have the location of msbuild.exe
         # for the Bitness32 variant since it resides in the same folder.
         # and for the Bitness64 variant since it resides in the /amd64 folders.
         # These paths are fixed due to the way VS is installed.
-        $VersionNumber = [int]($Version.Remove(2))
+        
+        $VersionNumber = 0
+        try {
+            $VersionNumber = [int]($Version.Remove(2))
+        } catch {
+            Write-Debug "Exception caught while parsing VersionNumber : $_"
+        }
 
         $specifiedStudio = Get-VisualStudio $VersionNumber
         if (($VersionNumber -ge 15 -or !$Version) -and # !$Version indicates "latest"

--- a/common-npm-packages/msbuildhelpers/PathFunctions.ps1
+++ b/common-npm-packages/msbuildhelpers/PathFunctions.ps1
@@ -257,8 +257,8 @@ function Select-MSBuildPath {
     Trace-VstsEnteringInvocation $MyInvocation
 
     $featureFlags = @{
-        enableTelemetry  = [System.Convert]::ToBoolean($env:ENABLE_GETMSBUILDPATH_TELEMETRY)
-        useGetMSBuildPathModified = [System.Convert]::ToBoolean($env:USE_GETMSBUILDPATHMODIFIED_METHOD)
+        enableTelemetry  = [System.Convert]::ToBoolean($env:MSBUILDHELPERS_PATHFUCTIONS_ENABLE_TELEMETRY)
+        useGetMSBuildPathModified = [System.Convert]::ToBoolean($env:MSBUILDHELPERS_PATHFUNCTIONS_ENABLE_GETMSBUILDPATHMODIFIED)
     }
 
     $selectMSBuildPathTelemetry = [PSCustomObject]@{

--- a/common-npm-packages/msbuildhelpers/PathFunctions.ps1
+++ b/common-npm-packages/msbuildhelpers/PathFunctions.ps1
@@ -162,6 +162,177 @@ function Get-MSBuildPath {
     }
 }
 
+# This is an updated version of Get-MsBuildPath for VS version greater than equal to 15.0.
+# Get-MsBuildPath function script first locates Microsoft.Build.Utilities.Core.dll and then uses it to locate the msbuild.exe. 
+# Under the current preview version of VS 17.3.2 this fails due to an assembly conflict.
+# the reflection usage here is redundant, since the msbuild exe lives either in the same folder as this .dll file or in its direct subfolder.
+# [TODO] : Once we have enough telemetry records to be confident of the correctness of this method, replace Get-MSBuildPath with Get-MSBuildPathV2 and remove feature flags.
+function Get-MSBuildPathV2 {
+    [CmdletBinding()]
+    param(
+        [string]$Version,
+        [string]$Architecture)
+
+    $VersionNumber = [int]($Version.Remove(2))
+
+    Trace-VstsEnteringInvocation $MyInvocation
+    try {
+        # Only attempt to find Microsoft.Build.Utilities.Core.dll from a VS 15 Willow install
+        # when "15.0" or latest is specified. In 15.0, the method GetPathToBuildToolsFile(...)
+        # has regressed. When it is called for a version that is not found, the latest version
+        # found is returned instead. Same for "16.0" and "17.0"
+        [System.Reflection.Assembly]$msUtilities = $null
+
+
+        # We do not need Microsoft.Build.Utilities.Core.dll - if we have located this .dll file, we also have the location of msbuild.exe
+        # for the Bitness32 variant since it resides in the same folder.
+        # and for the Bitness64 variant since it resides in the /amd64 folders.
+        # These paths are fixed due to the way VS is installed.
+        $VersionNumber = [int]($Version.Remove(2))
+
+        $specifiedStudio = Get-VisualStudio $VersionNumber
+        if (($VersionNumber -ge 15 -or !$Version) -and # !$Version indicates "latest"
+            ($specifiedStudio = Get-VisualStudio $VersionNumber) -and
+            $specifiedStudio.installationPath) {
+
+                $MsBuildDirectory = "Current"
+            if ($VersionNumber -eq 15) {
+                $MsBuildDirectory = "15.0"
+            }
+
+            if ($Architecture -eq 'x86') {
+                $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\MSBuild.exe");
+                # DotNetFrameworkArchitecture.Bitness32
+            } elseif ($Architecture -eq 'x64') {
+                $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\amd64\MSBuild.exe");
+                # DotNetFrameworkArchitecture.Bitness64
+            } else {
+                $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\MSBuild.exe");
+                # DotNetFrameworkArchitecture.Bitness32
+            }
+
+            if ($msBuildPath -and (Test-Path -LiteralPath $msBuildPath -PathType Leaf)) {
+                Write-Verbose "MSBuild: $msBuildPath"
+                return $msBuildPath
+            }
+        }
+
+        # Fallback to searching the GAC.
+        if (!$msUtilities) {
+            $msbuildUtilitiesAssemblies = @(
+                "Microsoft.Build.Utilities.Core, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
+                "Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
+                "Microsoft.Build.Utilities.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
+                "Microsoft.Build.Utilities.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
+            )
+
+            # Attempt to load a Microsoft build utilities DLL.
+            $index = 0
+            [System.Reflection.Assembly]$msUtilities = $null
+            while (!$msUtilities -and $index -lt $msbuildUtilitiesAssemblies.Length) {
+                Write-Verbose "Loading $($msbuildUtilitiesAssemblies[$index])"
+                try {
+                    $msUtilities = [System.Reflection.Assembly]::Load((New-Object System.Reflection.AssemblyName($msbuildUtilitiesAssemblies[$index])))
+                } catch [System.IO.FileNotFoundException] {
+                    Write-Verbose "Not found."
+                }
+
+                $index++
+            }
+        }
+
+        [string]$msBuildPath = $null
+
+        # Default to x86 architecture if not specified.
+        if (!$Architecture) {
+            $Architecture = "x86"
+        }
+
+        if ($msUtilities -ne $null) {
+            [type]$t = $msUtilities.GetType('Microsoft.Build.Utilities.ToolLocationHelper')
+            if ($t -ne $null) {
+                # Attempt to load the method info for GetPathToBuildToolsFile. This method
+                # is available in the 16.0, 15.0, 14.0, and 12.0 utilities DLL. It is not available
+                # in the 4.0 utilities DLL.
+                [System.Reflection.MethodInfo]$mi = $t.GetMethod(
+                    "GetPathToBuildToolsFile",
+                    [type[]]@( [string], [string], $msUtilities.GetType("Microsoft.Build.Utilities.DotNetFrameworkArchitecture") ))
+                if ($mi -ne $null -and $mi.GetParameters().Length -eq 3) {
+                    $versions = "16.0", "15.0", "14.0", "12.0", "4.0"
+                    if ($Version) {
+                        $versions = @( $Version )
+                    }
+
+                    # Translate the architecture parameter into the corresponding value of the
+                    # DotNetFrameworkArchitecture enum. Parameter three of the target method info
+                    # takes this enum. Leverage parameter three to get to the enum's type info.
+                    $param3 = $mi.GetParameters()[2]
+                    $archValues = [System.Enum]::GetValues($param3.ParameterType)
+                    [object]$archValue = $null
+                    if ($Architecture -eq 'x86') {
+                        $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
+                    } elseif ($Architecture -eq 'x64') {
+                        $archValue = $archValues.GetValue(2) # DotNetFrameworkArchitecture.Bitness64
+                    } else {
+                        $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
+                    }
+
+                    # Attempt to resolve the path for each version.
+                    $versionIndex = 0
+                    while (!$msBuildPath -and $versionIndex -lt $versions.Length) {
+                        $msBuildPath = $mi.Invoke(
+                            $null,
+                            @( 'msbuild.exe' # string fileName
+                                $versions[$versionIndex] # string toolsVersion
+                                $archValue ))
+                        $versionIndex++
+                    }
+                } elseif (!$Version -or $Version -eq "4.0") {
+                    # Attempt to load the method info GetPathToDotNetFrameworkFile. This method
+                    # is available in the 4.0 utilities DLL.
+                    $mi = $t.GetMethod(
+                        "GetPathToDotNetFrameworkFile",
+                        [type[]]@( [string], $msUtilities.GetType("Microsoft.Build.Utilities.TargetDotNetFrameworkVersion"), $msUtilities.GetType("Microsoft.Build.Utilities.DotNetFrameworkArchitecture") ))
+                    if ($mi -ne $null -and $mi.GetParameters().Length -eq 3) {
+                        # Parameter two of the target method info takes the TargetDotNetFrameworkVersion
+                        # enum. Leverage parameter two to get the enum's type info.
+                        $param2 = $mi.GetParameters()[1];
+                        $frameworkVersionValues = [System.Enum]::GetValues($param2.ParameterType);
+
+                        # Translate the architecture parameter into the corresponding value of the
+                        # DotNetFrameworkArchitecture enum. Parameter three of the target method info
+                        # takes this enum. Leverage parameter three to get to the enum's type info.
+                        $param3 = $mi.GetParameters()[2];
+                        $archValues = [System.Enum]::GetValues($param3.ParameterType);
+                        [object]$archValue = $null
+                        if ($Architecture -eq "x86") {
+                            $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
+                        } elseif ($Architecture -eq "x64") {
+                            $archValue = $archValues.GetValue(2) # DotNetFrameworkArchitecture.Bitness64
+                        } else {
+                            $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
+                        }
+
+                        # Attempt to resolve the path.
+                        $msBuildPath = $mi.Invoke(
+                            $null,
+                            @( "msbuild.exe" # string fileName
+                                $frameworkVersionValues.GetValue($frameworkVersionValues.Length - 1) # enum TargetDotNetFrameworkVersion.VersionLatest
+                                $archValue ))
+                    }
+                }
+            }
+        }
+
+        if ($msBuildPath -and (Test-Path -LiteralPath $msBuildPath -PathType Leaf)) {
+            Write-Verbose "MSBuild: $msBuildPath"
+            $msBuildPath
+        }
+    } finally {
+        Trace-VstsLeavingInvocation $MyInvocation
+    }
+}
+
 function Get-SolutionFiles {
     [CmdletBinding()]
     param(
@@ -364,177 +535,6 @@ function Select-MSBuildPath {
             Write-Error (Get-VstsLocString -Key 'MSB_MSBuildNotFoundVersion0Architecture1' -ArgumentList $PreferredVersion, $Architecture)
         } else {
             Write-Error (Get-VstsLocString -Key 'MSB_MSBuildNotFound')
-        }
-    } finally {
-        Trace-VstsLeavingInvocation $MyInvocation
-    }
-}
-
-# This is an updated version of Get-MsBuildPath for VS version greater than equal to 15.0.
-# Get-MsBuildPath function script first locates Microsoft.Build.Utilities.Core.dll and then uses it to locate the msbuild.exe. 
-# Under the current preview version of VS 17.3.2 this fails due to an assembly conflict.
-# the reflection usage here is redundant, since the msbuild exe lives either in the same folder as this .dll file or in its direct subfolder.
-# [TODO] : Once we have enough telemetry records to be confident of the correctness of this method, replace Get-MSBuildPath with Get-MSBuildPathV2 and remove feature flags.
-function Get-MSBuildPathV2 {
-    [CmdletBinding()]
-    param(
-        [string]$Version,
-        [string]$Architecture)
-
-    $VersionNumber = [int]($Version.Remove(2))
-
-    Trace-VstsEnteringInvocation $MyInvocation
-    try {
-        # Only attempt to find Microsoft.Build.Utilities.Core.dll from a VS 15 Willow install
-        # when "15.0" or latest is specified. In 15.0, the method GetPathToBuildToolsFile(...)
-        # has regressed. When it is called for a version that is not found, the latest version
-        # found is returned instead. Same for "16.0" and "17.0"
-        [System.Reflection.Assembly]$msUtilities = $null
-
-
-        # We do not need Microsoft.Build.Utilities.Core.dll - if we have located this .dll file, we also have the location of msbuild.exe
-        # for the Bitness32 variant since it resides in the same folder.
-        # and for the Bitness64 variant since it resides in the /amd64 folders.
-        # These paths are fixed due to the way VS is installed.
-        $VersionNumber = [int]($Version.Remove(2))
-
-        $specifiedStudio = Get-VisualStudio $VersionNumber
-        if (($VersionNumber -ge 15 -or !$Version) -and # !$Version indicates "latest"
-            ($specifiedStudio = Get-VisualStudio $VersionNumber) -and
-            $specifiedStudio.installationPath) {
-
-                $MsBuildDirectory = "Current"
-            if ($VersionNumber -eq 15) {
-                $MsBuildDirectory = "15.0"
-            }
-
-            if ($Architecture -eq 'x86') {
-                $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\MSBuild.exe");
-                # DotNetFrameworkArchitecture.Bitness32
-            } elseif ($Architecture -eq 'x64') {
-                $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\amd64\MSBuild.exe");
-                # DotNetFrameworkArchitecture.Bitness64
-            } else {
-                $msBuildPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild", $MsBuildDirectory, "Bin\MSBuild.exe");
-                # DotNetFrameworkArchitecture.Bitness32
-            }
-
-            if ($msBuildPath -and (Test-Path -LiteralPath $msBuildPath -PathType Leaf)) {
-                Write-Verbose "MSBuild: $msBuildPath"
-                return $msBuildPath
-            }
-        }
-
-        # Fallback to searching the GAC.
-        if (!$msUtilities) {
-            $msbuildUtilitiesAssemblies = @(
-                "Microsoft.Build.Utilities.Core, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
-                "Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
-                "Microsoft.Build.Utilities.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
-                "Microsoft.Build.Utilities.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
-            )
-
-            # Attempt to load a Microsoft build utilities DLL.
-            $index = 0
-            [System.Reflection.Assembly]$msUtilities = $null
-            while (!$msUtilities -and $index -lt $msbuildUtilitiesAssemblies.Length) {
-                Write-Verbose "Loading $($msbuildUtilitiesAssemblies[$index])"
-                try {
-                    $msUtilities = [System.Reflection.Assembly]::Load((New-Object System.Reflection.AssemblyName($msbuildUtilitiesAssemblies[$index])))
-                } catch [System.IO.FileNotFoundException] {
-                    Write-Verbose "Not found."
-                }
-
-                $index++
-            }
-        }
-
-        [string]$msBuildPath = $null
-
-        # Default to x86 architecture if not specified.
-        if (!$Architecture) {
-            $Architecture = "x86"
-        }
-
-        if ($msUtilities -ne $null) {
-            [type]$t = $msUtilities.GetType('Microsoft.Build.Utilities.ToolLocationHelper')
-            if ($t -ne $null) {
-                # Attempt to load the method info for GetPathToBuildToolsFile. This method
-                # is available in the 16.0, 15.0, 14.0, and 12.0 utilities DLL. It is not available
-                # in the 4.0 utilities DLL.
-                [System.Reflection.MethodInfo]$mi = $t.GetMethod(
-                    "GetPathToBuildToolsFile",
-                    [type[]]@( [string], [string], $msUtilities.GetType("Microsoft.Build.Utilities.DotNetFrameworkArchitecture") ))
-                if ($mi -ne $null -and $mi.GetParameters().Length -eq 3) {
-                    $versions = "16.0", "15.0", "14.0", "12.0", "4.0"
-                    if ($Version) {
-                        $versions = @( $Version )
-                    }
-
-                    # Translate the architecture parameter into the corresponding value of the
-                    # DotNetFrameworkArchitecture enum. Parameter three of the target method info
-                    # takes this enum. Leverage parameter three to get to the enum's type info.
-                    $param3 = $mi.GetParameters()[2]
-                    $archValues = [System.Enum]::GetValues($param3.ParameterType)
-                    [object]$archValue = $null
-                    if ($Architecture -eq 'x86') {
-                        $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
-                    } elseif ($Architecture -eq 'x64') {
-                        $archValue = $archValues.GetValue(2) # DotNetFrameworkArchitecture.Bitness64
-                    } else {
-                        $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
-                    }
-
-                    # Attempt to resolve the path for each version.
-                    $versionIndex = 0
-                    while (!$msBuildPath -and $versionIndex -lt $versions.Length) {
-                        $msBuildPath = $mi.Invoke(
-                            $null,
-                            @( 'msbuild.exe' # string fileName
-                                $versions[$versionIndex] # string toolsVersion
-                                $archValue ))
-                        $versionIndex++
-                    }
-                } elseif (!$Version -or $Version -eq "4.0") {
-                    # Attempt to load the method info GetPathToDotNetFrameworkFile. This method
-                    # is available in the 4.0 utilities DLL.
-                    $mi = $t.GetMethod(
-                        "GetPathToDotNetFrameworkFile",
-                        [type[]]@( [string], $msUtilities.GetType("Microsoft.Build.Utilities.TargetDotNetFrameworkVersion"), $msUtilities.GetType("Microsoft.Build.Utilities.DotNetFrameworkArchitecture") ))
-                    if ($mi -ne $null -and $mi.GetParameters().Length -eq 3) {
-                        # Parameter two of the target method info takes the TargetDotNetFrameworkVersion
-                        # enum. Leverage parameter two to get the enum's type info.
-                        $param2 = $mi.GetParameters()[1];
-                        $frameworkVersionValues = [System.Enum]::GetValues($param2.ParameterType);
-
-                        # Translate the architecture parameter into the corresponding value of the
-                        # DotNetFrameworkArchitecture enum. Parameter three of the target method info
-                        # takes this enum. Leverage parameter three to get to the enum's type info.
-                        $param3 = $mi.GetParameters()[2];
-                        $archValues = [System.Enum]::GetValues($param3.ParameterType);
-                        [object]$archValue = $null
-                        if ($Architecture -eq "x86") {
-                            $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
-                        } elseif ($Architecture -eq "x64") {
-                            $archValue = $archValues.GetValue(2) # DotNetFrameworkArchitecture.Bitness64
-                        } else {
-                            $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
-                        }
-
-                        # Attempt to resolve the path.
-                        $msBuildPath = $mi.Invoke(
-                            $null,
-                            @( "msbuild.exe" # string fileName
-                                $frameworkVersionValues.GetValue($frameworkVersionValues.Length - 1) # enum TargetDotNetFrameworkVersion.VersionLatest
-                                $archValue ))
-                    }
-                }
-            }
-        }
-
-        if ($msBuildPath -and (Test-Path -LiteralPath $msBuildPath -PathType Leaf)) {
-            Write-Verbose "MSBuild: $msBuildPath"
-            $msBuildPath
         }
     } finally {
         Trace-VstsLeavingInvocation $MyInvocation

--- a/common-npm-packages/msbuildhelpers/package-lock.json
+++ b/common-npm-packages/msbuildhelpers/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-msbuildhelpers",
-    "version": "3.245.0",
+    "version": "3.252.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-msbuildhelpers",
-            "version": "3.245.0",
+            "version": "3.252.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/msbuildhelpers/package.json
+++ b/common-npm-packages/msbuildhelpers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-msbuildhelpers",
-    "version": "3.245.0",
+    "version": "3.252.0",
     "description": "Azure Pipelines tasks MSBuild helpers",
     "main": "msbuildhelpers.js",
     "scripts": {


### PR DESCRIPTION
 to avoid reflection for the new vs studio versions since it causes assembly conflict.

### [Related issue 20734](https://github.com/microsoft/azure-pipelines-tasks/issues/20734)

This portion of the Get-MsBuildPath function script first locates **Microsoft.Build.Utilities.Core.dll** and then uses it to locate the msbuild.exe. Under the current preview version of VS this fails due to an assembly conflict.
Fortunately for us, the reflection usage here is redundant, since the msbuild exe lives either in the same folder as this .dll file or in its direct subfolder.
These paths are fixed due to the way VS installation works - e.g. if we have location of the .dll file, we have the location of both of these versions of msbuild.
```
$Architecture = 'x64'

$Path = "C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\Microsoft.Build.Utilities.Core.dll"
$msUtilities = [System.Reflection.Assembly]::LoadFrom($Path)

[type]$t = $msUtilities.GetType('Microsoft.Build.Utilities.ToolLocationHelper')
if ($t -ne $null) 
{
    [System.Reflection.MethodInfo] $mi = $t.GetMethod("GetPathToBuildToolsFile",[type[]]@( [string], [string], $msUtilities.GetType("Microsoft.Build.Utilities.DotNetFrameworkArchitecture") ))

$param3 = $mi.GetParameters()[2]
    $archValues = [System.Enum]::GetValues($param3. ParameterType)

[object] $archValue = $null
        if ($Architecture -eq 'x86') {
            $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
        } elseif ($Architecture -eq 'x64') {
            $archValue = $archValues.GetValue(2) # DotNetFrameworkArchitecture.Bitness64
        } else {
            $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
        }
    Write-Host "archValue = $archValue"

$msBuildPath = $mi.Invoke($null, @( 'msbuild.exe', '17.0', $archValue ))
    $msBuildPath
}
```

### Testing
- Tested the Feature Flag logic by deploying the MSBuildTask with Updated MSBuildHelpers package in a personal test organisation. 
- Verified for the Visual Studio 15,16 and 17 for both Architectures x64 and x86. 