### PR TITLE
Suppress CodeQL warning

### DIFF
--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -415,6 +415,7 @@ export class ApplicationTokenCredentials {
                     // thumbprint
                     const certEncoded = certFile.match(/-----BEGIN CERTIFICATE-----\s*([\s\S]+?)\s*-----END CERTIFICATE-----/i)[1];
                     const certDecoded = Buffer.from(certEncoded, "base64");
+                    // CodeQL [SM01510] External Dependency: Azure CLI generated certificates support only sha1 // CodeQL [SM04514] External Dependency: Azure CLI generated certificates support only sha1
                     const thumbprint = crypto.createHash("sha1").update(certDecoded).digest("hex").toUpperCase();
 
                     if (!thumbprint) {


### PR DESCRIPTION
**Package:** azure-pipelines-tasks-azure-arm-rest

**Description:**
Suppressing the CodeQL warning because Azure CLI works with sha1.

More details here:
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2236224
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2242888