### PR TITLE
Avoiding buffer length error for json files

### DIFF
--- a/common-npm-packages/webdeployment-common/jsonvariablesubstitutionutility.ts
+++ b/common-npm-packages/webdeployment-common/jsonvariablesubstitutionutility.ts
@@ -185,6 +185,7 @@ export function jsonVariableSubstitution(absolutePath, jsonSubFiles, substituteA
         }
         for(let file of matchFiles) {
             var fileBuffer: Buffer = fs.readFileSync(file);
+            if (fileBuffer.length > 4){
             var fileEncodeType = fileEncoding.detectFileEncoding(file, fileBuffer);
             var fileContent: string = fileBuffer.toString(fileEncodeType[0]);
             if(fileEncodeType[1]) {
@@ -206,7 +207,9 @@ export function jsonVariableSubstitution(absolutePath, jsonSubFiles, substituteA
             }
             
             tl.writeFile(file, (fileEncodeType[1] ? '\uFEFF' : '') + JSON.stringify(jsonObject, null, 4), fileEncodeType[0]);
+            }
         }
+
     }
     
     return isSubstitutionApplied;

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.247.0",
+    "version": "4.252.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-webdeployment-common",
-            "version": "4.247.0",
+            "version": "4.252.0",
             "license": "MIT",
             "dependencies": {
                 "@types/ltx": "3.0.6",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.247.0",
+    "version": "4.252.0",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This change will help in skipping JSON files that are smaller than 4 bytes.