### PR TITLE
Add NuGet os and fs module mocking functions

### DIFF
--- a/common-npm-packages/packaging-common/Tests/nuget/NuGetMockHelper.ts
+++ b/common-npm-packages/packaging-common/Tests/nuget/NuGetMockHelper.ts
@@ -1,16 +1,17 @@
 import tmrm = require('azure-pipelines-task-lib/mock-run');
+import os = require('os');
 
-import {VersionInfo} from '../../pe-parser/VersionResource'
-	
+import { VersionInfo } from '../../pe-parser/VersionResource'
+
 export function registerNugetToolGetterMock(tmr: tmrm.TaskMockRunner) {
     tmr.registerMock('azure-pipelines-tasks-packaging-common/nuget/NuGetToolGetter', {
-        getNuGet: function(versionSpec) {
+        getNuGet: function (versionSpec) {
             return "c:\\from\\tool\\installer\\nuget.exe";
         },
-        cacheBundledNuGet: function(version, path){
+        cacheBundledNuGet: function (version, path) {
             return version;
         },
-        getMSBuildVersionString: function() {
+        getMSBuildVersionString: function () {
             return "1.0.0.0";
         },
         FORCE_NUGET_4_0_0: 'FORCE_NUGET_4_0_0',
@@ -19,18 +20,18 @@ export function registerNugetToolGetterMock(tmr: tmrm.TaskMockRunner) {
         DEFAULT_NUGET_VERSION: '4.9.6',
         DEFAULT_NUGET_PATH_SUFFIX: 'NuGet/4.9.6/',
         NUGET_EXE_TOOL_PATH_ENV_VAR: "NuGetExeToolPath"
-    } )
+    })
 }
 
 export function registerNugetToolGetterMockUnix(tmr: tmrm.TaskMockRunner) {
     tmr.registerMock('azure-pipelines-tasks-packaging-common/nuget/NuGetToolGetter', {
-        getNuGet: function(versionSpec) {
+        getNuGet: function (versionSpec) {
             return '~/myagent/_work/_tasks/NuGet/nuget.exe';
         },
-        cacheBundledNuGet: function(version, path){
+        cacheBundledNuGet: function (version, path) {
             return version;
         },
-        getMSBuildVersionString: function() {
+        getMSBuildVersionString: function () {
             return "1.0.0.0";
         },
         FORCE_NUGET_4_0_0: 'FORCE_NUGET_4_0_0',
@@ -39,24 +40,24 @@ export function registerNugetToolGetterMockUnix(tmr: tmrm.TaskMockRunner) {
         DEFAULT_NUGET_VERSION: '4.9.6',
         DEFAULT_NUGET_PATH_SUFFIX: 'NuGet/4.9.6/',
         NUGET_EXE_TOOL_PATH_ENV_VAR: "NuGetExeToolPath"
-    } )
+    })
 }
 
 export function registerNugetUtilityMock(tmr: tmrm.TaskMockRunner, projectFile: string[]) {
     tmr.registerMock('azure-pipelines-tasks-packaging-common/nuget/Utility', {
-        getPatternsArrayFromInput: function(input) {
+        getPatternsArrayFromInput: function (input) {
             return [input];
         },
-        resolveFilterSpec: function(filterSpec, basePath?, allowEmptyMatch?) {
+        resolveFilterSpec: function (filterSpec, basePath?, allowEmptyMatch?) {
             return projectFile;
         },
-        stripLeadingAndTrailingQuotes: function(path) {
+        stripLeadingAndTrailingQuotes: function (path) {
             return path;
         },
-        locateCredentialProvider: function(path) {
+        locateCredentialProvider: function (path) {
             return 'c:\\agent\\home\\directory\\externals\\nuget\\CredentialProvider';
         },
-        setConsoleCodePage: function() {
+        setConsoleCodePage: function () {
             var tlm = require('azure-pipelines-task-lib/mock-task');
             tlm.debug(`setting console code page`);
         },
@@ -66,15 +67,15 @@ export function registerNugetUtilityMock(tmr: tmrm.TaskMockRunner, projectFile: 
             project: string,
             nuGetVersion: VersionInfo,
             accessToken?: string) {
-            if(project) {
+            if (project) {
                 return 'https://vsts/' + project + '/packagesource';
             }
             return 'https://vsts/packagesource';
         }
-    } );
-    
+    });
+
     tmr.registerMock('./Utility', {
-        resolveToolPath: function(path) {
+        resolveToolPath: function (path) {
             return path;
         }
     });
@@ -82,19 +83,19 @@ export function registerNugetUtilityMock(tmr: tmrm.TaskMockRunner, projectFile: 
 
 export function registerNugetUtilityMockUnix(tmr: tmrm.TaskMockRunner, projectFile: string[]) {
     tmr.registerMock('azure-pipelines-tasks-packaging-common/nuget/Utility', {
-        getPatternsArrayFromInput: function(input) {
+        getPatternsArrayFromInput: function (input) {
             return [input];
         },
-        resolveFilterSpec: function(filterSpec, basePath?, allowEmptyMatch?) {
+        resolveFilterSpec: function (filterSpec, basePath?, allowEmptyMatch?) {
             return projectFile;
         },
-        resolveToolPath: function(path) {
+        resolveToolPath: function (path) {
             return path;
         },
-        locateCredentialProvider: function(path) {
+        locateCredentialProvider: function (path) {
             return '~/myagent/_work/_tasks/NuGet/CredentialProvider';
         },
-        setConsoleCodePage: function() {
+        setConsoleCodePage: function () {
             var tlm = require('azure-pipelines-task-lib/mock-task');
             tlm.debug(`setting console code page`);
         },
@@ -109,8 +110,52 @@ export function registerNugetUtilityMockUnix(tmr: tmrm.TaskMockRunner, projectFi
     });
 
     tmr.registerMock('./Utility', {
-        resolveToolPath: function(path) {
+        resolveToolPath: function (path) {
             return path;
         }
+    });
+}
+
+export function registerNugetWindowsMock(tmr: tmrm.TaskMockRunner) {
+    os.platform = () => {
+        return 'win32' as NodeJS.Platform;
+    }
+    tmr.registerMock('os', os);
+}
+
+export function registerNugetMacOsMock(tmr: tmrm.TaskMockRunner) {
+    os.platform = () => {
+        return 'darwin' as NodeJS.Platform;
+    }
+    tmr.registerMock('os', os);
+}
+
+export function registerNugetUbuntu22Mock(tmr: tmrm.TaskMockRunner) {
+    os.platform = () => {
+        return 'linux' as NodeJS.Platform;
+    }
+    tmr.registerMock('os', os);
+
+    const lsbContents = `DISTRIB_ID=Ubuntu
+                         DISTRIB_RELEASE=22.04`;
+
+    tmr.registerMock('fs', {
+        existsSync: (filepath: string) => filepath.startsWith('/etc/'),
+        readFileSync: (filepath: string) => filepath.startsWith('/etc/') ? lsbContents : ''
+    });
+}
+
+export function registerNugetUbuntu24Mock(tmr: tmrm.TaskMockRunner) {
+    os.platform = () => {
+        return 'linux' as NodeJS.Platform;
+    }
+    tmr.registerMock('os', os);
+
+    const lsbContents = `DISTRIB_ID=Ubuntu
+                         DISTRIB_RELEASE=24.04`;
+
+    tmr.registerMock('fs', {
+        existsSync: (filepath: string) => filepath.startsWith('/etc/'),
+        readFileSync: (filepath: string) => filepath.startsWith('/etc/') ? lsbContents : ''
     });
 }

--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.246.2",
+    "version": "3.252.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-packaging-common",
-            "version": "3.246.2",
+            "version": "3.252.0",
             "license": "MIT",
             "dependencies": {
                 "@types/ini": "1.3.30",

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.246.2",
+    "version": "3.252.0",
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "mocha _build/Tests/L0.js",


### PR DESCRIPTION
Replacement of #427 

Adding mockable 'os' and 'fs' modules to support the rollout of NuGetCommandV2 updates for the Ubuntu 24.04 versions without mono.