### PR TITLE
Add execAsync wrapper for NuGetToolRunner2

### DIFF
--- a/common-npm-packages/packaging-common/nuget/NuGetToolRunner2.ts
+++ b/common-npm-packages/packaging-common/nuget/NuGetToolRunner2.ts
@@ -217,6 +217,12 @@ export class NuGetToolRunner2 extends ToolRunner {
         options.env = prepareNuGetExeEnvironment(options.env || process.env, this.settings, this.authInfo);
         return super.exec(options);
     }
+
+    public execAsync(options?: IExecOptions): Promise<number> {
+        options = options || <IExecOptions>{};
+        options.env = prepareNuGetExeEnvironment(options.env || process.env, this.settings, this.authInfo);
+        return super.execAsync(options);
+    }
 }
 
 export function createNuGetToolRunner(nuGetExePath: string, settings: NuGetEnvironmentSettings, authInfo: auth.NuGetExtendedAuthInfo): NuGetToolRunner2 {

--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.252.0",
+    "version": "3.253.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-packaging-common",
-            "version": "3.252.0",
+            "version": "3.253.0",
             "license": "MIT",
             "dependencies": {
                 "@types/ini": "1.3.30",

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.252.0",
+    "version": "3.253.0",
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "mocha _build/Tests/L0.js",


### PR DESCRIPTION
Add a replacement wrapped for the deprecated `exec` method in the `NuGetToolRunner2` class.