### PR TITLE
comma seperator incorrect encoding issue fix

### DIFF
--- a/common-npm-packages/webdeployment-common/msdeployutility.ts
+++ b/common-npm-packages/webdeployment-common/msdeployutility.ts
@@ -113,13 +113,15 @@ export function getMSDeployCmdArgs(webAppPackage: string, webAppName: string, pr
 function escapeQuotes(additionalArguments: string): string {
     const parsedArgs = parseAdditionalArguments(additionalArguments);
     const separator = ",";
+    let USE_COMMA_SEPERATOR = tl.getBoolFeatureFlag('USE_COMMA_SEPERATOR');
 
     const formattedArgs = parsedArgs.map(function (arg) {
         let formattedArg = '';
         let equalsSignEncountered = false;
         for (let i = 0; i < arg.length; i++) {
-            const char = arg.charAt(i);
-            if (char == separator && equalsSignEncountered) {
+            const char = arg.charAt(i);           
+            let USE_COMMA_SEPERATORS=USE_COMMA_SEPERATOR ? (char == separator && equalsSignEncountered && ((formattedArg.startsWith("'") && formattedArg.endsWith("'")) || (formattedArg.startsWith('"') && formattedArg.endsWith('"')))): (char == separator && equalsSignEncountered);
+            if (USE_COMMA_SEPERATORS) {
                 equalsSignEncountered = false;
                 arg = arg.replace(formattedArg, escapeArg(formattedArg));
                 formattedArg = '';

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.253.0",
+    "version": "4.254.0",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Added feature-flag to enable/disable the fix for connection string having comma Seperator is not encoded correctly while passing as additional arguments in Azure RM web deployment@4.
https://github.com/microsoft/azure-pipelines-tasks/issues/20743 