### PR TITLE
XML substitution output differs for FileTransformV2- #2255969

### DIFF
--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.253.0",
+    "version": "4.254.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-webdeployment-common",
-            "version": "4.253.0",
+            "version": "4.254.0",
             "license": "MIT",
             "dependencies": {
                 "@types/ltx": "3.0.6",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.253.0",
+    "version": "4.254.0",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",

--- a/common-npm-packages/webdeployment-common/xmlvariablesubstitutionutility.ts
+++ b/common-npm-packages/webdeployment-common/xmlvariablesubstitutionutility.ts
@@ -264,14 +264,14 @@ function updateXmlConnectionStringsNodeAttribute(xmlDomNode, variableMap, replac
             var connectionStringName = xmlDomNode.getAttribute("name");
             if (connectionStringName && variableMap[xmlDomNode.getAttribute("name")]) {
                 let ConfigFileConnStringTokenName = ConfigFileConnStringToken + '(' + connectionStringName + ')';
-                tl.debug(tl.loc('SubstitutingConnectionStringValue' , connectionStringName , ConfigFileConnStringTokenName));
+                console.log(tl.loc('SubstitutingConnectionStringValue' , connectionStringName , ConfigFileConnStringTokenName));
                 xmlDomNode.setAttribute("connectionString", ConfigFileConnStringTokenName);
                 replacableTokenValues[ConfigFileConnStringTokenName] = variableMap[connectionStringName].replace(/"/g, "'");
                 isSubstitutionApplied = true;
             }
             else if(variableMap["connectionString"] != undefined) {
                 let ConfigFileConnStringTokenName = ConfigFileConnStringToken + '(connectionString)';
-                tl.debug(tl.loc('SubstitutingConnectionStringValue' , connectionStringName , ConfigFileConnStringTokenName));
+                console.log(tl.loc('SubstitutingConnectionStringValue' , connectionStringName , ConfigFileConnStringTokenName));
                 xmlDomNode.setAttribute("connectionString", ConfigFileConnStringTokenName);
                 replacableTokenValues[ConfigFileConnStringTokenName] = variableMap["connectionString"].replace(/"/g, "'");
                 isSubstitutionApplied = true


### PR DESCRIPTION
Replace tl.debug with console.log for better visibility in logs for FileTransformV2

GH issue:  [BUG 20850](https://github.com/microsoft/azure-pipelines-tasks/issues/20850?reload=1?reload=1?reload=1%3Freload%3D1)