### PR TITLE
Updating latest version of openssl 3.4.0

### DIFF
--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.252.1",
+  "version": "3.254.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-tasks-azure-arm-rest",
-      "version": "3.252.1",
+      "version": "3.254.0",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.252.1",
+  "version": "3.254.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",
@@ -35,6 +35,6 @@
     "typescript": "^4.9.5"
   },
   "scripts": {
-    "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/openssl/3.3.1/M245/openssl.zip ./openssl && node make.js"
+    "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.0/M252/openssl.zip ./openssl && node make.js"
   }
 }


### PR DESCRIPTION
Currently used openssl version 3.3.1 is causing vulnerability issues for customers. So, updating the package with latest openssl version 3.4.0