### PR TITLE
Make Docker command exec error output optional based on the pipeline feature

### DIFF
--- a/common-npm-packages/docker-common/containerconnection.ts
+++ b/common-npm-packages/docker-common/containerconnection.ts
@@ -43,6 +43,7 @@ export default class ContainerConnection {
     public execCommand(command: tr.ToolRunner, options?: tr.IExecOptions) {
         let errlines = [];
         let dockerHostVar = tl.getVariable("DOCKER_HOST");
+
         if (dockerHostVar) {
             tl.debug(tl.loc('ConnectingToDockerHost', dockerHostVar));
         }
@@ -50,13 +51,16 @@ export default class ContainerConnection {
         command.on("errline", line => {
             errlines.push(line);
         });
+        
+        const hideDockerExecTaskLogIssueErrorOutput = tl.getPipelineFeature("hideDockerExecTaskLogIssueErrorOutput");
+
         return command.exec(options).fail(error => {
             if (dockerHostVar) {
                 tl.warning(tl.loc('DockerHostVariableWarning', dockerHostVar));
             }
 
             errlines.forEach(line => {
-                if (tl.getPipelineFeature("HideDockerExecTaskLogIssueErrorOutput")) {
+                if (hideDockerExecTaskLogIssueErrorOutput) {
                     console.log(`##[error]${line}`);
                 } else {
                     tl.error(line);

--- a/common-npm-packages/docker-common/containerconnection.ts
+++ b/common-npm-packages/docker-common/containerconnection.ts
@@ -50,12 +50,18 @@ export default class ContainerConnection {
         command.on("errline", line => {
             errlines.push(line);
         });
-        return command.exec(options).fail(error => {            
+        return command.exec(options).fail(error => {
             if (dockerHostVar) {
                 tl.warning(tl.loc('DockerHostVariableWarning', dockerHostVar));
             }
 
-            errlines.forEach(line => tl.error(line));
+            errlines.forEach(line => {
+                if (tl.getPipelineFeature("HideDockerExecTaskLogIssueErrorOutput")) {
+                    console.log(`##[error]${line}`);
+                } else {
+                    tl.error(line);
+                }
+            });
             throw error;
         });
     }

--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.255.0",
+    "version": "2.256.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.255.0",
+            "version": "2.256.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.254.0",
+    "version": "2.255.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.254.0",
+            "version": "2.255.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.255.0",
+    "version": "2.256.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.254.0",
+    "version": "2.255.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",


### PR DESCRIPTION
**Description**:
This PR adds a handling pipeline feature **HideDockerExecTaskLogIssueErrorOutput** to control whether Docker exec error logging is optional.

When the flag is enabled, Docker exec log output is processed as error logs rather than individual log issues, resulting in a cleaner build UI where these errors are not displayed.

The problem is described in [#20968](https://github.com/microsoft/azure-pipelines-tasks/issues/20968).

After merging this PR and the package releasing, we need to update the dependency in [the Docker@2 task](https://github.com/microsoft/azure-pipelines-tasks/blob/5e7e926a82e97d39c50fdfd99350c13a9137066c/Tasks/DockerV2/package.json#L9)