### PR TITLE
Resolve issues in CI checks

### DIFF
--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.254.0",
+  "version": "3.256.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-tasks-azure-arm-rest",
-      "version": "3.254.0",
+      "version": "3.256.0",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.254.2",
+  "version": "3.256.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",

--- a/common-npm-packages/msbuildhelpers/Tests/L0.ts
+++ b/common-npm-packages/msbuildhelpers/Tests/L0.ts
@@ -9,11 +9,13 @@ describe('Common-MSBuildHelpers Suite', function () {
     const { MSBUILDHELPERS_ENABLE_TELEMETRY } = process.env;
 
     before((done) => {
+        process.env.MSBUILDHELPERS_ENABLE_TELEMETRY = "false";
+
         if (psm.testSupported()) {
             psr = new psm.PSRunner();
             psr.start();
         }
-        process.env.MSBUILDHELPERS_ENABLE_TELEMETRY = "false";
+
         done();
     });
 
@@ -21,6 +23,7 @@ describe('Common-MSBuildHelpers Suite', function () {
         if (psr) {
             psr.kill();
         }
+
         process.env.MSBUILDHELPERS_ENABLE_TELEMETRY = MSBUILDHELPERS_ENABLE_TELEMETRY;
     });
 

--- a/common-npm-packages/msbuildhelpers/Tests/L0.ts
+++ b/common-npm-packages/msbuildhelpers/Tests/L0.ts
@@ -6,13 +6,14 @@ var psr = null;
 
 describe('Common-MSBuildHelpers Suite', function () {
     this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 30000);
+    const { MSBUILDHELPERS_ENABLE_TELEMETRY } = process.env;
 
     before((done) => {
         if (psm.testSupported()) {
             psr = new psm.PSRunner();
             psr.start();
         }
-
+        process.env.MSBUILDHELPERS_ENABLE_TELEMETRY = "false";
         done();
     });
 
@@ -20,6 +21,7 @@ describe('Common-MSBuildHelpers Suite', function () {
         if (psr) {
             psr.kill();
         }
+        process.env.MSBUILDHELPERS_ENABLE_TELEMETRY = MSBUILDHELPERS_ENABLE_TELEMETRY;
     });
 
     if (psm.testSupported()) {

--- a/common-npm-packages/msbuildhelpers/Tests/Select-MSBuildPath.ErrorsIfVersionNotFound.ps1
+++ b/common-npm-packages/msbuildhelpers/Tests/Select-MSBuildPath.ErrorsIfVersionNotFound.ps1
@@ -13,4 +13,8 @@ Assert-WasCalled Get-MSBuildPath -- -Version '15.0' -Architecture 'Some architec
 Assert-WasCalled Get-MSBuildPath -- -Version '14.0' -Architecture 'Some architecture'
 Assert-WasCalled Get-MSBuildPath -- -Version '12.0' -Architecture 'Some architecture'
 Assert-WasCalled Get-MSBuildPath -- -Version '4.0' -Architecture 'Some architecture'
-Assert-WasCalled Get-MSBuildPath -Times 6
+Assert-WasCalled Get-MSBuildPath -Times 5 -ParametersEvaluator {
+    $Version -in @('16.0', '15.0', '14.0', '12.0', '4.0') -and
+    $Architecture -eq 'Some architecture'
+}
+Assert-WasCalled Get-MSBuildPath -Times 6 -ArgumentsEvaluator { $args.count -eq 4 }

--- a/common-npm-packages/msbuildhelpers/Tests/Select-MSBuildPath.FallsBackFrom14.ps1
+++ b/common-npm-packages/msbuildhelpers/Tests/Select-MSBuildPath.FallsBackFrom14.ps1
@@ -12,5 +12,8 @@ $actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '1
 
 # Assert.
 Assert-WasCalled Write-Warning
-Assert-WasCalled Get-MSBuildPath -Times 5
+Assert-WasCalled Get-MSBuildPath -Times 5 -ParametersEvaluator {
+    $Version -in @('17.0', '16.0', '15.0', '14.0', '12.0') -and
+    $Architecture -eq 'Some architecture'
+}
 Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/msbuildhelpers/Tests/Select-MSBuildPath.FallsBackFrom15.ps1
+++ b/common-npm-packages/msbuildhelpers/Tests/Select-MSBuildPath.FallsBackFrom15.ps1
@@ -12,5 +12,8 @@ $actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '1
 
 # Assert.
 Assert-WasCalled Write-Warning
-Assert-WasCalled Get-MSBuildPath -Times 4
+Assert-WasCalled Get-MSBuildPath -Times 4 -ParametersEvaluator {
+    $Version -in @('17.0', '16.0', '15.0', '14.0') -and
+    $Architecture -eq 'Some architecture'
+}
 Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/msbuildhelpers/Tests/Select-MSBuildPath.FallsForwardFrom12.ps1
+++ b/common-npm-packages/msbuildhelpers/Tests/Select-MSBuildPath.FallsForwardFrom12.ps1
@@ -12,5 +12,8 @@ $actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '1
 
 # Assert.
 Assert-WasCalled Write-Warning
-Assert-WasCalled Get-MSBuildPath -Times 5
+Assert-WasCalled Get-MSBuildPath -Times 5 -ParametersEvaluator  {
+    $Version -in @('12.0', '17.0', '16.0', '15.0', '14.0') -and
+    $Architecture -eq 'Some architecture'
+}
 Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/msbuildhelpers/Tests/Select-MSBuildPath.FallsForwardFrom14.ps1
+++ b/common-npm-packages/msbuildhelpers/Tests/Select-MSBuildPath.FallsForwardFrom14.ps1
@@ -12,5 +12,8 @@ $actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '1
 
 # Assert.
 Assert-WasCalled Write-Warning
-Assert-WasCalled Get-MSBuildPath -Times 4
+Assert-WasCalled Get-MSBuildPath -Times 4 -ParametersEvaluator {
+    $Version -in @('17.0', '16.0', '15.0', '14.0') -and
+    $Architecture -eq 'Some architecture'
+}
 Assert-AreEqual -Expected 'Some resolved location' -Actual $actual


### PR DESCRIPTION
**Description**: This PR addresses the following issues in CI checks:

- Different versions in package.json and package-lock.json in azure-arm-rest package
- Multiple invocation issue when telemetry feature flag is enabled. Disabled the telemetry feature flag as a temporary solution. This issue will be permanently resolved once the functions are merged soon.