### PR TITLE
2197050 Validate tool versions before running them

### DIFF
--- a/common-npm-packages/azure-arm-rest/azCliUtility.ts
+++ b/common-npm-packages/azure-arm-rest/azCliUtility.ts
@@ -205,21 +205,20 @@ async function getLatestAzureModuleReleaseVersion(moduleName: string): Promise<s
     }
 }
 
-export async function validateAzModuleVersion(moduleName: string, CurrentVersion: string, displayName: string, versionsToReduce: number, isMajor: boolean = false): Promise<void> {
-    const DisplayWarningForOlderAzVersion: boolean = tl.getPipelineFeature("Show_Warning_On_old_version");
+export async function validateAzModuleVersion(moduleName: string, currentVersion: string, displayName: string, versionsToReduce: number, isMajor: boolean = false): Promise<void> {
+    const DisplayWarningForOlderAzVersion: boolean = tl.getPipelineFeature("showWarningOnOlderAzureModules");
     try {
         if (DisplayWarningForOlderAzVersion) {
             const latestRelease: string = await getLatestAzureModuleReleaseVersion(moduleName);
             if (latestRelease) {
                 const [latestsemver, latestMajor, latestMinor] = latestRelease.match(/(\d+).(\d+).(\d+)/);
-                const [currentsemver, currentMajor, currentMinor] = CurrentVersion.match(/(\d+).(\d+).(\d+)/);
-                tl.debug(`the currentsemver Version is ${currentsemver}`);
-                tl.debug(`the latestsemver version is ${latestsemver}`);
+                const [currentsemver, currentMajor, currentMinor] = currentVersion.match(/(\d+).(\d+).(\d+)/);
+                tl.debug(`For the module ${moduleName} the current semver Version is ${currentsemver} and the latest semver version is ${latestsemver}`)
                 let displayWarning = false;
-                if (isMajor && (Number(currentMajor) < (Number(latestMajor) - versionsToReduce))) {
+                if (isMajor && Number(currentMajor) < Number(latestMajor) - versionsToReduce) {
                     displayWarning = true;
                 }
-                if (!isMajor && ((Number(currentMajor) < Number(latestMajor)) || (Number(currentMinor) < (Number(latestMinor) - versionsToReduce)))) {
+                if (!isMajor && (Number(currentMajor) < Number(latestMajor) || Number(currentMinor) < Number(latestMinor) - versionsToReduce)) {
                     displayWarning = true;
                 }
                 if (displayWarning) {

--- a/common-npm-packages/azure-arm-rest/azCliUtility.ts
+++ b/common-npm-packages/azure-arm-rest/azCliUtility.ts
@@ -205,8 +205,8 @@ async function getLatestAzureModuleReleaseVersion(moduleName: string): Promise<s
     }
 }
 
-export async function validateAzModuleVersion(moduleName: string, currentVersion: string, displayName: string, versionsToReduce: number, isMajor: boolean = false): Promise<void> {
-    const DisplayWarningForOlderAzVersion: boolean = tl.getPipelineFeature("showWarningOnOlderAzureModules");
+export async function validateAzModuleVersion(moduleName: string, currentVersion: string, displayName: string, versionTolerance: number, checkOnlyMajorVersion: boolean = false): Promise<void> {
+    const DisplayWarningForOlderAzVersion: boolean = tl.getPipelineFeature("ShowWarningOnOlderAzureModules");
     try {
         if (DisplayWarningForOlderAzVersion) {
             const latestRelease: string = await getLatestAzureModuleReleaseVersion(moduleName);
@@ -215,10 +215,10 @@ export async function validateAzModuleVersion(moduleName: string, currentVersion
                 const [currentsemver, currentMajor, currentMinor] = currentVersion.match(/(\d+).(\d+).(\d+)/);
                 tl.debug(`For the module ${moduleName} the current semver Version is ${currentsemver} and the latest semver version is ${latestsemver}`)
                 let displayWarning = false;
-                if (isMajor && Number(currentMajor) < Number(latestMajor) - versionsToReduce) {
+                if (checkOnlyMajorVersion && Number(currentMajor) < Number(latestMajor) - versionTolerance) {
                     displayWarning = true;
                 }
-                if (!isMajor && (Number(currentMajor) < Number(latestMajor) || Number(currentMinor) < Number(latestMinor) - versionsToReduce)) {
+                if (!checkOnlyMajorVersion && (Number(currentMajor) < Number(latestMajor) || Number(currentMinor) < Number(latestMinor) - versionTolerance)) {
                     displayWarning = true;
                 }
                 if (displayWarning) {

--- a/common-npm-packages/azure-arm-rest/module.json
+++ b/common-npm-packages/azure-arm-rest/module.json
@@ -188,6 +188,7 @@
         "VirtualApplicationDoesNotExist": "Virtual application doesn't exists : %s",
         "CantDownloadClusterCredentials": "Failed to fetch credentials for the cluster %s. Reason %s. Make sure the service connection is assigned an appropriate Azure RBAC role: https://aka.ms/azdo-aks-rm-access.",
         "KubernetesClusterResourceGroup": "Kubernetes cluster %s, resource group %s.",
-        "SettingAzureCloud": "Setting active cloud to: %s"
+        "SettingAzureCloud": "Setting active cloud to: %s",
+        "lowerAzWarning": "%s version %s is out of date, the latest version is %s"
     }
 }

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.256.0",
+  "version": "3.256.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-tasks-azure-arm-rest",
-      "version": "3.256.0",
+      "version": "3.256.1",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.256.1",
+    "version": "3.257.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azure-arm-rest",
-            "version": "3.256.1",
+            "version": "3.257.0",
             "license": "MIT",
             "dependencies": {
                 "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest",
-  "version": "3.256.0",
+  "version": "3.256.1",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.256.1",
+    "version": "3.257.0",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",


### PR DESCRIPTION
**Package Name**:  azure-pipelines-tasks-azure-arm-rest

**Change Description**:  Added new methods to support this feature ([Feature 2197050](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2197050): Validate tool versions before running them). where we need to validate the AZ module and AzureCli and display a warning to customer