### PR TITLE
Add the previous version of 7zip to webdeployment common package

### DIFF
--- a/common-npm-packages/webdeployment-common/build.ps1
+++ b/common-npm-packages/webdeployment-common/build.ps1
@@ -1,4 +1,5 @@
-node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip ./7zip
+node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/7zip/5/7zip.zip ./7zip
+node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip ./7zip24
 node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M142/MSDeploy.zip ./MSDeploy/M142
 node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M229/MSDeploy.zip ./MSDeploy/M229
 node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/ctt/1.6/ctt.zip ./ctt

--- a/common-npm-packages/webdeployment-common/make.js
+++ b/common-npm-packages/webdeployment-common/make.js
@@ -10,6 +10,7 @@ util.cp(path.join(__dirname, 'package.json'), buildPath);
 util.cp(path.join(__dirname, 'package-lock.json'), buildPath);
 util.cp(path.join(__dirname, 'module.json'), buildPath);
 util.cp('-r', '7zip', buildPath);
+util.cp('-r', '7zip24', buildPath);
 util.cp('-r', 'ctt', buildPath);
 util.cp('-r', 'MSDeploy', buildPath);
 util.cp('-r', 'node_modules', buildPath);

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.256.1",
+    "version": "4.257.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-webdeployment-common",
-            "version": "4.256.1",
+            "version": "4.257.0",
             "license": "MIT",
             "dependencies": {
                 "@types/ltx": "3.0.6",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.256.1",
+    "version": "4.257.0",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",
@@ -8,6 +8,7 @@
         "directory": "common-npm-packages/webdeployment-common"
     },
     "scripts": {
+        "prebuild": "cd ../build-scripts && npm install",
         "build": "pwsh build.ps1",
         "test": "nyc --all --src ./_build mocha ./_build/Tests/L0.js"
     },

--- a/common-npm-packages/webdeployment-common/ziputility.ts
+++ b/common-npm-packages/webdeployment-common/ziputility.ts
@@ -8,7 +8,7 @@ var archiver = require('archiver');
 
 const deleteDir = (path: string) => tl.exist(path) && tl.rmRF(path);
 
-const extractWindowsZip = async (fromFile: string, toDir: string, usePowerShell?: boolean) => {    
+const extractWindowsZip = async (fromFile: string, toDir: string, usePowerShell?: boolean) => {
     let forceUsePSUnzip: string = process.env['ADO_FORCE_USE_PSUNZIP'] || 'false'
     tl.debug(`ADO_FORCE_USE_PSUNZIP = '${forceUsePSUnzip}'`)
     if (forceUsePSUnzip.toLowerCase() === 'true') {
@@ -59,7 +59,7 @@ const extractUsingPowerShell = async (fromFile: string, toDir: string) => {
                         .arg('-NonInteractive')
                         .arg('-Command')
                         .arg(command);
-    
+
     let options = <tr.IExecOptions>{
         failOnStdErr: false,
         errStream: process.stdout,
@@ -87,8 +87,16 @@ const extractUsingPowerShell = async (fromFile: string, toDir: string) => {
 }
 
 const extractUsing7zip = async (fromFile: string, toDir: string) => {
-    tl.debug('Using 7zip tool for extracting');
-    var win7zipLocation = path.join(__dirname, '7zip/7zip/7z.exe');
+    let win7zipLocation: string;
+
+    if (tl.getPipelineFeature("Use7zV2409InWebDeploymentCommonPackage")) {
+        win7zipLocation = path.join(__dirname, '7zip24/7zip/7z.exe');
+    } else {
+        win7zipLocation = path.join(__dirname, '7zip/7zip/7z.exe');
+    }
+
+    tl.debug(`Using 7zip tool from ${win7zipLocation} for extracting`);
+
     await tl.tool(win7zipLocation)
         .arg([ 'x', `-o${toDir}`, fromFile ])
         .exec();
@@ -104,14 +112,14 @@ const extractUsingUnzip = async (fromFile: string, toDir: string) => {
 
 export async function unzip(zipFileLocation: string, unzipDirLocation: string) {
     deleteDir(unzipDirLocation);
-    
+
     const isWin = tl.getPlatform() === tl.Platform.Windows;
     tl.debug('windows platform: ' + isWin);
 
-    tl.debug('extracting ' + zipFileLocation + ' to ' + unzipDirLocation);    
+    tl.debug('extracting ' + zipFileLocation + ' to ' + unzipDirLocation);
     if (isWin) {
         await extractWindowsZip(zipFileLocation, unzipDirLocation);
-    } 
+    }
     else{
         await extractUsingUnzip(zipFileLocation, unzipDirLocation);
     }


### PR DESCRIPTION
**Description:** Add the previous version of 7zip by default and the feature flag that switches 7zip version from v23.01 to v24.09

**Related WI:** [AB#2273409](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2273409)