### PR TITLE
Update 7zip in utility-common package

### DIFF
--- a/common-npm-packages/utility-common/compressutility.ts
+++ b/common-npm-packages/utility-common/compressutility.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-var path    = require('path');
+var path = require('path');
 import * as tl from "azure-pipelines-task-lib/task";
 import * as trm from 'azure-pipelines-task-lib/toolrunner';
 
@@ -11,7 +11,15 @@ var xpTarLocation: string;
 var xpZipLocation: string;
 // 7zip
 var xpSevenZipLocation: string;
-var winSevenZipLocation: string = path.join(__dirname, 'tools/7zip/7z.exe');
+var winSevenZipLocation: string = getWinSevenZipLocation();
+
+function getWinSevenZipLocation(): string {
+    if (tl.getPipelineFeature("Use7zV2409InUtilityCommonPackage")) {
+        return path.join(__dirname, 'tools/7zip24/7z.exe');
+    } else {
+        return path.join(__dirname, 'tools/7zip5/7z.exe');
+    }
+}
 
 // Creates compressed archive of all files(recusively) inside sourceFolder directory (excluding the sourceFolder directly itself)
 export function createArchive(sourceFolder: string, archiveType: string, archiveFile: string) {
@@ -86,7 +94,7 @@ function zipArchive(archive: string, files: string[]) {
             zip.arg(files[i]);
         }
     } else {
-        zip.arg(".");        
+        zip.arg(".");
     }
 
     return handleExecResult(zip.execSync(getOptions()), archive);
@@ -109,7 +117,7 @@ function tarArchive(archive: string, compression: string, files: string[]) {
     }
     tar.arg('-f');
     tar.arg(archive);
-    if(files.length > 0) {    
+    if(files.length > 0) {
         for (var i = 0; i < files.length; i++) {
             tar.arg(files[i]);
         }

--- a/common-npm-packages/utility-common/make.js
+++ b/common-npm-packages/utility-common/make.js
@@ -1,18 +1,31 @@
-var path = require('path');
-var fs = require('fs');
-var util = require('../build-scripts/util');
-var { downloadArchive } = require('../build-scripts/downloadArchive');
+const path = require('path');
+const fs = require('fs');
 
-var buildPath = './_build'
-var toolPath = './tools'
-var zipUrl = 'https://vstsagenttools.blob.core.windows.net/tools/7zip/5/7zip.zip'
+const util = require('../build-scripts/util');
+const { downloadArchive } = require('../build-scripts/downloadArchive');
 
-const targetPath = downloadArchive(zipUrl, path.join('../_download', toolPath));
-if (!fs.existsSync(toolPath)) {
-    util.mkdir('-p', toolPath);
+const buildPath = './_build';
+const toolPath = './tools';
+const zipUrl5 = 'https://vstsagenttools.blob.core.windows.net/tools/7zip/5/7zip.zip';
+const zipUrl24 = 'https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip';
+
+// Download and extract 7zip version 5
+const targetPath5 = downloadArchive(zipUrl5, path.join('../_download', toolPath, '7zip5'));
+
+if (!fs.existsSync(path.join(toolPath, '7zip5'))) {
+    util.mkdir('-p', path.join(toolPath, '7zip5'));
 }
 
-util.cp('-rf', path.join(targetPath, '*'), toolPath);
+util.cp('-rf', path.join(targetPath5, '*'), path.join(toolPath, '7zip5'));
+
+// Download and extract 7zip version 24.09
+const targetPath24 = downloadArchive(zipUrl24, path.join('../_download', toolPath, '7zip24'));
+
+if (!fs.existsSync(path.join(toolPath, '7zip24'))) {
+    util.mkdir('-p', path.join(toolPath, '7zip24'));
+}
+
+util.cp('-rf', path.join(targetPath24, '*'), path.join(toolPath, '7zip24'));
 
 util.rm('-rf', buildPath)
 util.run(path.join(__dirname, 'node_modules/.bin/tsc') + ' --outDir ' + buildPath);

--- a/common-npm-packages/utility-common/make.js
+++ b/common-npm-packages/utility-common/make.js
@@ -1,38 +1,34 @@
-const path = require('path');
-const fs = require('fs');
+const { existsSync } = require('node:fs');
+const { join } = require('node:path');
 
 const util = require('../build-scripts/util');
 const { downloadArchive } = require('../build-scripts/downloadArchive');
 
 const buildPath = './_build';
 const toolPath = './tools';
-const zipUrl5 = 'https://vstsagenttools.blob.core.windows.net/tools/7zip/5/7zip.zip';
-const zipUrl24 = 'https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip';
 
-// Download and extract 7zip version 5
-const targetPath5 = downloadArchive(zipUrl5, path.join('../_download', toolPath, '7zip5'));
+const zipUrls = {
+    '7zip5': 'https://vstsagenttools.blob.core.windows.net/tools/7zip/5/7zip.zip',
+    '7zip24': 'https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip'
+};
 
-if (!fs.existsSync(path.join(toolPath, '7zip5'))) {
-    util.mkdir('-p', path.join(toolPath, '7zip5'));
+for (const [version, url] of Object.entries(zipUrls)) {
+    const targetPath = join(toolPath, version);
+    const sourcePath = downloadArchive(url, join('../_download', targetPath));
+
+    if (!existsSync(targetPath)) {
+        util.mkdir('-p', targetPath);
+    }
+
+    util.cp('-rf', join(sourcePath, '*'), targetPath);
 }
-
-util.cp('-rf', path.join(targetPath5, '*'), path.join(toolPath, '7zip5'));
-
-// Download and extract 7zip version 24.09
-const targetPath24 = downloadArchive(zipUrl24, path.join('../_download', toolPath, '7zip24'));
-
-if (!fs.existsSync(path.join(toolPath, '7zip24'))) {
-    util.mkdir('-p', path.join(toolPath, '7zip24'));
-}
-
-util.cp('-rf', path.join(targetPath24, '*'), path.join(toolPath, '7zip24'));
 
 util.rm('-rf', buildPath)
-util.run(path.join(__dirname, 'node_modules/.bin/tsc') + ' --outDir ' + buildPath);
+util.run(join(__dirname, 'node_modules/.bin/tsc') + ' --outDir ' + buildPath);
 
-util.cp(path.join(__dirname, 'package.json'), buildPath);
-util.cp(path.join(__dirname, 'package-lock.json'), buildPath);
-util.cp(path.join(__dirname, 'module.json'), buildPath);
+util.cp(join(__dirname, 'package.json'), buildPath);
+util.cp(join(__dirname, 'package-lock.json'), buildPath);
+util.cp(join(__dirname, 'module.json'), buildPath);
 util.cp('-r', 'tools', buildPath);
 util.cp('-r', 'Strings', buildPath);
 util.cp('-r', 'node_modules', buildPath);


### PR DESCRIPTION
**Description:** Update the 7zip dependency to v24.09 in the utility-common package.

Related: [AB#2273409](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2273409), https://github.com/microsoft/azure-pipelines-tasks/issues/20993