### PR TITLE
Updating msbuildhelpers package to have signed binary 

### DIFF
--- a/common-npm-packages/msbuildhelpers/package-lock.json
+++ b/common-npm-packages/msbuildhelpers/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-msbuildhelpers",
-    "version": "3.256.1",
+    "version": "3.259.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-msbuildhelpers",
-            "version": "3.256.1",
+            "version": "3.259.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/msbuildhelpers/package.json
+++ b/common-npm-packages/msbuildhelpers/package.json
@@ -4,7 +4,7 @@
     "description": "Azure Pipelines tasks MSBuild helpers",
     "main": "msbuildhelpers.js",
     "scripts": {
-        "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/vswhere/1_0_62/vswhere.zip ./tools && node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/msbuildlogger/5/msbuildlogger.zip ./tools && node make.js"
+        "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/vswhere/1_0_62/vswhere.zip ./tools && node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/msbuildlogger/6/msbuildlogger.zip ./tools && node make.js"
     },
     "repository": {
         "type": "git",

--- a/common-npm-packages/msbuildhelpers/package.json
+++ b/common-npm-packages/msbuildhelpers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-msbuildhelpers",
-    "version": "3.256.1",
+    "version": "3.259.0",
     "description": "Azure Pipelines tasks MSBuild helpers",
     "main": "msbuildhelpers.js",
     "scripts": {


### PR DESCRIPTION
### **Description**
The existing binary *Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll* in the msbuildhelpers package was not signed, updating the blob with signed binary.


---

### **Package Name**
 **msbuildhelpers**

---

### **Risk Assessment** (Low / Medium / High)  
**Low**  

---

### **Unit Tests Added or Updated**   
- [ ] Unit tests added or updated
- [x] Manual tests performed
![image](https://github.com/user-attachments/assets/f48adf40-2dd3-4115-9099-714e30832516)


---

### **Additional Testing Performed**
Packed the package, imported to the task (MSBuildV1). Built and uploaded the task to my test org, where it was tested against the canary tests for the Task.

---

### **Documentation Changes Required** (Yes / No)  
**No**

---

### **Dependencies**
Updated the Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Package version was bumped — see [versioning guide](https://semver.org/)
- [x] Verified the package behaves as expected
- [ ] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---

