### PR TITLE
updating arm-rest to latest in package.lock.json

### DIFF
--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azure-arm-rest",
-            "version": "3.258.1",
+            "version": "3.259.0",
             "license": "MIT",
             "dependencies": {
                 "@types/jsonwebtoken": "^8.5.8",


### PR DESCRIPTION
### **Description**
after merge, check is failing for package-lock.json. related to this [PR](https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/467)

---

### **Package Name**
arm-rest

---

### **Risk Assessment** (Low / Medium / High)  
Low


### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Package version was bumped — see [versioning guide](https://semver.org/)
- [ ] Verified the package behaves as expected
- [ ] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---

