### PR TITLE
Fix JAVA_HOME var name for arm64

### DIFF
--- a/common-npm-packages/java-common/java-common.ts
+++ b/common-npm-packages/java-common/java-common.ts
@@ -128,7 +128,6 @@ export function findJavaHome(jdkVersion: string, jdkArch: string): string {
     if(jdkArch.toLowerCase() === 'arm64'){
          // For arm64, we use a different environment variable naming convention
          envName = "JAVA_HOME_" + jdkMajorVersion + "_" + jdkArch.toLowerCase();
-         tl.debug('envName for arm64 is ' + envName);
          discoveredJavaHome = process.env[envName];
     } else {
         envName = "JAVA_HOME_" + jdkMajorVersion + "_" + jdkArch.toUpperCase();

--- a/common-npm-packages/java-common/java-common.ts
+++ b/common-npm-packages/java-common/java-common.ts
@@ -121,10 +121,20 @@ export function findJavaHome(jdkVersion: string, jdkArch: string): string {
 
     const jdkShortVersion: string = getShortJavaVersion(jdkVersion);
     const jdkMajorVersion: number = coerce(jdkShortVersion).major;
-    // jdkArchitecture is either x64 or x86
+    // jdkArchitecture is either x64, x86 or arm64
     // envName for version 1.7 and x64 would be "JAVA_HOME_7_X64"
-    var envName = "JAVA_HOME_" + jdkMajorVersion + "_" + jdkArch.toUpperCase();
-    let discoveredJavaHome = tl.getVariable(envName);
+    var envName: string;
+    let discoveredJavaHome: string;
+    if(jdkArch.toLowerCase() === 'arm64'){
+         // For arm64, we use a different environment variable naming convention
+         envName = "JAVA_HOME_" + jdkMajorVersion + "_" + jdkArch.toLowerCase();
+         tl.debug('envName for arm64 is ' + envName);
+         discoveredJavaHome = process.env[envName];
+    } else {
+        envName = "JAVA_HOME_" + jdkMajorVersion + "_" + jdkArch.toUpperCase();
+        discoveredJavaHome = tl.getVariable(envName);
+    }
+
     if (!discoveredJavaHome) {
         if (isWindows) {
             discoveredJavaHome = readJavaHomeFromRegistry(jdkShortVersion, jdkArch);

--- a/common-npm-packages/java-common/package-lock.json
+++ b/common-npm-packages/java-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-java-common",
-    "version": "2.262.0",
+    "version": "2.263.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-java-common",
-            "version": "2.262.0",
+            "version": "2.263.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/java-common/package-lock.json
+++ b/common-npm-packages/java-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-java-common",
-    "version": "2.256.0",
+    "version": "2.262.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-java-common",
-            "version": "2.256.0",
+            "version": "2.262.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/java-common/package.json
+++ b/common-npm-packages/java-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-java-common",
-    "version": "2.262.0",
+    "version": "2.263.0",
     "description": "Azure Pipelines tasks Java Common",
     "main": "java-common.js",
     "scripts": {

--- a/common-npm-packages/java-common/package.json
+++ b/common-npm-packages/java-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-java-common",
-    "version": "2.256.0",
+    "version": "2.262.0",
     "description": "Azure Pipelines tasks Java Common",
     "main": "java-common.js",
     "scripts": {


### PR DESCRIPTION
### **Description**
This PR includes changes to the construction of JAVA_HOME_{version}_{arch} environment variable for arm64.
Associated WI: [AB#2296780](https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2296780)

Issue:
When tasks relying on java-common package for getting jdk path are run on arm64 agent, they fail with below error even if jdk is correctly installed:

##[error]Error: Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable 'JAVA_HOME_11_ARM64' exists and is set to the location of a corresponding JDK.

Cause:
JAVA_HOME_x_arch environment variable is not found and the value for this variable is returned as undefined on macos-arm64 machines. This is because the variable name is [converted to uppercase](https://github.com/microsoft/azure-pipelines-tasks-common-packages/blob/1f07b94fcb0514edd5787dadd3c6b17328f796f7/common-npm-packages/java-common/java-common.ts#L126) before getting the variable value. Whereas for arm64 agents, the suffix part of this variable name is [in lowercase at agent level](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#java). 

Solution:
Since environment variable names are case-sensitive on macos, updating the construction of env variable name when architecture specified is arm64. This will correctly identify the env variable for specified jdk path and jdk version.

---

### **Package Name**
[azure-pipelines-tasks-java-common](https://www.npmjs.com/package/azure-pipelines-tasks-java-common)

---

### **Risk Assessment** (Low / Medium / High)  
_Assess the level of risk and provide reasoning (e.g., scope, impact, backward compatibility)._
Low

---

### **Unit Tests Added or Updated**   
- [ ] Unit tests added or updated
- [x] Manual tests performed

---

### **Additional Testing Performed**
Manually tested affected tasks with updated java-common on arm64 agent.
Tested below tasks through canary test pipelines:
[GradleV4 ](https://canarytestpf.visualstudio.com/canarytestspf/_build/results?buildId=512&view=logs&j=e8e4ca16-68da-5e75-56f8-d12d036b1254)
[GradleV3](https://canarytestpf.visualstudio.com/canarytestspf/_build/results?buildId=504&view=results)

[MavenV4](https://canarytestpf.visualstudio.com/canarytestspf/_build/results?buildId=533&view=results)
[MavenV3 ](https://canarytestpf.visualstudio.com/canarytestspf/_build/results?buildId=534&view=results)
[MavenV2](https://canarytestpf.visualstudio.com/canarytestspf/_build/results?buildId=532&view=results)

---

### **Documentation Changes Required** (Yes / No)  
_Indicate whether related documentation needs to be updated. Provide links to the updated documentation if applicable._

---

### **Dependencies**
_List any dependencies introduced or updated in this PR._

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Package version was bumped — see [versioning guide](https://semver.org/)
- [x] Verified the package behaves as expected
- [ ] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---

