### PR TITLE
2303551 Need to Change the Audience for Kudo calls as AppService for …

### DIFF
--- a/common-npm-packages/azure-arm-rest/azure-arm-endpoint.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-endpoint.ts
@@ -22,6 +22,73 @@ export class AzureRMEndpoint {
         'AzureStack': 'azurestack'
     }
 
+    private _azureScopes = {
+        AzureCloud: {
+            resoucemanager: 'https://management.azure.com/.default',
+            appservice: 'https://appservice.azure.com/.default',
+            storage: 'https://storage.azure.com/.default',
+            keyvalut: 'https://vault.azure.net/.default',
+            sqldatabase: 'https://database.windows.net/.default',
+            cosmosdb: 'https://cosmos.azure.com/.default',
+            servicebus: 'https://servicebus.azure.net/.default',
+            eventhubs: 'https://eventhubs.azure.net/.default',
+            eventgrid: 'https://eventgrid.azure.net/.default',
+            cognitiveservices: 'https://cognitiveservices.azure.com/.default',
+            containerregistry: 'https://containerregistry.azure.net/.default',
+            devops: 'https://app.vssps.visualstudio.com/.default',
+            batch: 'https://batch.core.windows.net/.default',
+            datafactory: 'https://datafactory.azure.net/.default'
+        },
+        AzureChinaCloud: {
+            resourcemanager: "https://management.chinacloudapi.cn/.default",
+            appservice: "https://appservice.azure.cn/.default",
+            storage: "https://storage.azure.cn/.default",
+            keyvalut: "https://vault.azure.cn/.default",
+            sqldatabase: "https://database.chinacloudapi.cn/.default",
+            cosmosdb: "https://cosmos.azure.cn/.default",
+            servicebus: "https://servicebus.azure.cn/.default",
+            eventhubs: "https://eventhubs.azure.cn/.default",
+            eventgrid: "https://eventgrid.azure.cn/.default",
+            cognitiveservices: "https://cognitiveservices.azure.cn/.default",
+            containerregistry: "https://containerregistry.azure.cn/.default",
+            devops: "https://app.vssps.visualstudio.cn/.default",
+            batch: "https://batch.core.chinacloudapi.cn/.default",
+            datafactory: "https://datafactory.azure.cn/.default"
+        },
+        AzureUSGovernment: {
+            resoucemanager: 'https://management.usgovcloudapi.net/.default',
+            appservice: 'https://appservice.azure.us/.default',
+            storage: 'https://storage.azure.us/.default',
+            keyvalut: 'https://vault.azure.us/.default',
+            sqldatabase: 'https://database.usgovcloudapi.net/.default',
+            cosmosdb: 'https://cosmos.azure.us/.default',
+            servicebus: 'https://servicebus.azure.us/.default',
+            eventhubs: 'https://eventhubs.azure.us/.default',
+            eventgrid: 'https://eventgrid.azure.us/.default',
+            cognitiveservices: 'https://cognitiveservices.azure.us/.default',
+            containerregistry: 'https://containerregistry.azure.us/.default',
+            devops: 'https://app.vssps.visualstudio.us/.default',
+            batch: 'https://batch.core.usgovcloudapi.net/.default',
+            datafactory: 'https://datafactory.azure.us/.default'
+        },
+        AzureGermanCloud: {
+            resoucemanager: 'https://management.microsoftazure.de/.default',
+            appservice: 'https://appservice.azure.de/.default',
+            storage: 'https://storage.azure.de/.default',
+            keyvalut: 'https://vault.azure.de/.default',
+            sqldatabase: 'https://database.cloudapi.de/.default',
+            cosmosdb: 'https://cosmos.azure.de/.default',
+            servicebus: 'https://servicebus.azure.de/.default',
+            eventhubs: 'https://eventhubs.azure.de/.default',
+            eventgrid: 'https://eventgrid.azure.de/.default',
+            cognitiveservices: 'https://cognitiveservices.azure.de/.default',
+            containerregistry: 'https://containerregistry.azure.de/.default',
+            devops: 'https://app.vssps.visualstudio.de/.default',
+            batch: 'https://batch.core.cloudapi.de/.default',
+            datafactory: 'https://datafactory.azure.de/.default'
+        }
+    }
+
     constructor(connectedServiceName: string) {
         this._connectedServiceName = connectedServiceName;
         this.endpoint = null;
@@ -132,7 +199,11 @@ export class AzureRMEndpoint {
                         this.endpoint.activeDirectoryResourceID = this.endpoint.url;
                     }
                 }
-
+                let scopes: any;
+                const allowScopeLevelToken = tl.getPipelineFeature("ALLOWSCOPELEVELTOKEN");
+                if (allowScopeLevelToken && this.endpoint.environment && this.endpoint.environment.toLowerCase() != this._environments.AzureStack) {
+                    scopes = this.getScopesByEnvironment();
+                }
                 let access_token: string = tl.getEndpointAuthorizationParameter(this._connectedServiceName, "apitoken", true);
                 this.endpoint.applicationTokenCredentials = new ApplicationTokenCredentials(
                     this._connectedServiceName,
@@ -149,7 +220,9 @@ export class AzureRMEndpoint {
                     this.endpoint.servicePrincipalCertificatePath,
                     this.endpoint.isADFSEnabled,
                     access_token,
-                    useMSAL
+                    useMSAL,
+                    allowScopeLevelToken,
+                    scopes
                 );
             }
         }
@@ -217,6 +290,10 @@ export class AzureRMEndpoint {
         }
 
         return endpoint;
+    }
+
+    private getScopesByEnvironment(): any {
+         return this._azureScopes[this.endpoint.environment];
     }
 }
 

--- a/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
+++ b/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
@@ -118,7 +118,7 @@ export class AzureAppServiceUtility {
         const password = publishingCredentials.properties["publishingPassword"];
 
         if (scmPolicyCheck === false) {
-            token = await this._appService._client.getCredentials().getToken();
+            token = await this._appService._client.getCredentials().acquireTokenForScope("appservice");
             method = "Bearer";
             // Though bearer AuthN is used, lets try to set publish profile password for mask hints to maintain compat with old behavior for MSDEPLOY.
             // This needs to be cleaned up once MSDEPLOY suppport is removed. Safe handle the exception setting up mask hint as we dont want to fail here.

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.259.2",
+    "version": "3.262.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azure-arm-rest",
-            "version": "3.259.2",
+            "version": "3.262.0",
             "license": "MIT",
             "dependencies": {
+                "@azure/identity": "^3.4.2",
                 "@types/jsonwebtoken": "^8.5.8",
                 "@types/mocha": "^5.2.7",
                 "@types/node": "^10.17.0",
@@ -32,6 +33,222 @@
                 "typescript": "^4.9.5"
             }
         },
+        "node_modules/@azure/abort-controller": {
+            "version": "1.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+            "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@azure/core-auth": {
+            "version": "1.10.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-auth/-/core-auth-1.10.0.tgz",
+            "integrity": "sha1-aNunA2CA4dnVaZxOSCFKt5b6c60=",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-util": "^1.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-client": {
+            "version": "1.10.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-client/-/core-client-1.10.0.tgz",
+            "integrity": "sha1-n07JyJpjUWknhArmIMYOgRoLVKM=",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-auth": "^1.4.0",
+                "@azure/core-rest-pipeline": "^1.20.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/core-util": "^1.6.1",
+                "@azure/logger": "^1.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline": {
+            "version": "1.22.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.0.tgz",
+            "integrity": "sha1-duRKdQk6L0d/xUuE9GBJ3CzmWAA=",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-auth": "^1.8.0",
+                "@azure/core-tracing": "^1.0.1",
+                "@azure/core-util": "^1.11.0",
+                "@azure/logger": "^1.0.0",
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-tracing": {
+            "version": "1.3.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-tracing/-/core-tracing-1.3.0.tgz",
+            "integrity": "sha1-NBFT9bKSdTnriYV3ZR7kjOmN2iU=",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-util": {
+            "version": "1.13.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-util/-/core-util-1.13.0.tgz",
+            "integrity": "sha1-/Cg0/FHh4rt0twwoS0D4JNhnQio=",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.0.0",
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/identity": {
+            "version": "3.4.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/identity/-/identity-3.4.2.tgz",
+            "integrity": "sha1-awFyTJyqx8ratrY8dlhDRb2o4t4=",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.5.0",
+                "@azure/core-client": "^1.4.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/core-util": "^1.6.1",
+                "@azure/logger": "^1.0.0",
+                "@azure/msal-browser": "^3.5.0",
+                "@azure/msal-node": "^2.5.1",
+                "events": "^3.0.0",
+                "jws": "^4.0.0",
+                "open": "^8.0.0",
+                "stoppable": "^1.1.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@azure/identity/node_modules/jwa": {
+            "version": "2.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jwa/-/jwa-2.0.0.tgz",
+            "integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
+            "license": "MIT",
+            "dependencies": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/@azure/identity/node_modules/jws": {
+            "version": "4.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jws/-/jws-4.0.0.tgz",
+            "integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
+            "license": "MIT",
+            "dependencies": {
+                "jwa": "^2.0.0",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/@azure/logger": {
+            "version": "1.3.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/logger/-/logger-1.3.0.tgz",
+            "integrity": "sha1-VQHPhdT1JjBgKozHXfdlaMlpqCc=",
+            "license": "MIT",
+            "dependencies": {
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/msal-browser": {
+            "version": "3.28.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-browser/-/msal-browser-3.28.1.tgz",
+            "integrity": "sha1-kTL8iAe/zCscOzw7moXU30FFcUg=",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/msal-common": "14.16.0"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+            "version": "14.16.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-14.16.0.tgz",
+            "integrity": "sha1-80cPyux4jb5QhZlSzUmTQL2iPXo=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/@azure/msal-common": {
             "version": "13.3.1",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
@@ -39,6 +256,38 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-node": {
+            "version": "2.16.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-2.16.3.tgz",
+            "integrity": "sha1-i4BRUq14CwSNbCszsdTibXtGM2g=",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/msal-common": "14.16.1",
+                "jsonwebtoken": "^9.0.0",
+                "uuid": "^8.3.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+            "version": "14.16.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-14.16.1.tgz",
+            "integrity": "sha1-0j7M5AgjpNA610Fg3IGdYuDAp4c=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-node/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@types/jsonwebtoken": {
@@ -67,6 +316,42 @@
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/q/-/q-1.5.4.tgz",
             "integrity": "sha1-FZJUFOCtLNdlv+9YhC9+JqesyyQ=",
             "license": "MIT"
+        },
+        "node_modules/@typespec/ts-http-runtime": {
+            "version": "0.3.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.0.tgz",
+            "integrity": "sha1-9Qb/IXDllKJX+OeKoZYIjzpGoi0=",
+            "license": "MIT",
+            "dependencies": {
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/adm-zip": {
             "version": "0.5.15",
@@ -204,6 +489,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/define-lazy-prop": {
+            "version": "2.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/des.js": {
             "version": "1.1.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
@@ -242,6 +536,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/events/-/events-3.3.0.tgz",
+            "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.x"
             }
         },
         "node_modules/follow-redirects": {
@@ -391,6 +694,28 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/http-proxy-agent/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/https-proxy-agent": {
             "version": "4.0.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
@@ -443,6 +768,33 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=",
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/js-md4": {
@@ -775,6 +1127,23 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/open": {
+            "version": "8.4.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/open/-/open-8.4.2.tgz",
+            "integrity": "sha1-W1/+Ko95Pc0qrXPlUMuHtZywhPk=",
+            "license": "MIT",
+            "dependencies": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -950,6 +1319,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/stoppable": {
+            "version": "1.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/stoppable/-/stoppable-1.1.0.tgz",
+            "integrity": "sha1-MtpWjoPqSIsI5NfqLDvMnXUBXVs=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4",
+                "npm": ">=6"
+            }
+        },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -1090,10 +1469,202 @@
         }
     },
     "dependencies": {
+        "@azure/abort-controller": {
+            "version": "1.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+            "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
+            "requires": {
+                "tslib": "^2.2.0"
+            }
+        },
+        "@azure/core-auth": {
+            "version": "1.10.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-auth/-/core-auth-1.10.0.tgz",
+            "integrity": "sha1-aNunA2CA4dnVaZxOSCFKt5b6c60=",
+            "requires": {
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-util": "^1.11.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@azure/abort-controller": {
+                    "version": "2.1.2",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+                    "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@azure/core-client": {
+            "version": "1.10.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-client/-/core-client-1.10.0.tgz",
+            "integrity": "sha1-n07JyJpjUWknhArmIMYOgRoLVKM=",
+            "requires": {
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-auth": "^1.4.0",
+                "@azure/core-rest-pipeline": "^1.20.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/core-util": "^1.6.1",
+                "@azure/logger": "^1.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@azure/abort-controller": {
+                    "version": "2.1.2",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+                    "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@azure/core-rest-pipeline": {
+            "version": "1.22.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.0.tgz",
+            "integrity": "sha1-duRKdQk6L0d/xUuE9GBJ3CzmWAA=",
+            "requires": {
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-auth": "^1.8.0",
+                "@azure/core-tracing": "^1.0.1",
+                "@azure/core-util": "^1.11.0",
+                "@azure/logger": "^1.0.0",
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@azure/abort-controller": {
+                    "version": "2.1.2",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+                    "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@azure/core-tracing": {
+            "version": "1.3.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-tracing/-/core-tracing-1.3.0.tgz",
+            "integrity": "sha1-NBFT9bKSdTnriYV3ZR7kjOmN2iU=",
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@azure/core-util": {
+            "version": "1.13.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-util/-/core-util-1.13.0.tgz",
+            "integrity": "sha1-/Cg0/FHh4rt0twwoS0D4JNhnQio=",
+            "requires": {
+                "@azure/abort-controller": "^2.0.0",
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@azure/abort-controller": {
+                    "version": "2.1.2",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+                    "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@azure/identity": {
+            "version": "3.4.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/identity/-/identity-3.4.2.tgz",
+            "integrity": "sha1-awFyTJyqx8ratrY8dlhDRb2o4t4=",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.5.0",
+                "@azure/core-client": "^1.4.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/core-util": "^1.6.1",
+                "@azure/logger": "^1.0.0",
+                "@azure/msal-browser": "^3.5.0",
+                "@azure/msal-node": "^2.5.1",
+                "events": "^3.0.0",
+                "jws": "^4.0.0",
+                "open": "^8.0.0",
+                "stoppable": "^1.1.0",
+                "tslib": "^2.2.0"
+            },
+            "dependencies": {
+                "jwa": {
+                    "version": "2.0.0",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jwa/-/jwa-2.0.0.tgz",
+                    "integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
+                    "requires": {
+                        "buffer-equal-constant-time": "1.0.1",
+                        "ecdsa-sig-formatter": "1.0.11",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "jws": {
+                    "version": "4.0.0",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jws/-/jws-4.0.0.tgz",
+                    "integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
+                    "requires": {
+                        "jwa": "^2.0.0",
+                        "safe-buffer": "^5.0.1"
+                    }
+                }
+            }
+        },
+        "@azure/logger": {
+            "version": "1.3.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/logger/-/logger-1.3.0.tgz",
+            "integrity": "sha1-VQHPhdT1JjBgKozHXfdlaMlpqCc=",
+            "requires": {
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@azure/msal-browser": {
+            "version": "3.28.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-browser/-/msal-browser-3.28.1.tgz",
+            "integrity": "sha1-kTL8iAe/zCscOzw7moXU30FFcUg=",
+            "requires": {
+                "@azure/msal-common": "14.16.0"
+            },
+            "dependencies": {
+                "@azure/msal-common": {
+                    "version": "14.16.0",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-14.16.0.tgz",
+                    "integrity": "sha1-80cPyux4jb5QhZlSzUmTQL2iPXo="
+                }
+            }
+        },
         "@azure/msal-common": {
             "version": "13.3.1",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
             "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA="
+        },
+        "@azure/msal-node": {
+            "version": "2.16.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-2.16.3.tgz",
+            "integrity": "sha1-i4BRUq14CwSNbCszsdTibXtGM2g=",
+            "requires": {
+                "@azure/msal-common": "14.16.1",
+                "jsonwebtoken": "^9.0.0",
+                "uuid": "^8.3.0"
+            },
+            "dependencies": {
+                "@azure/msal-common": {
+                    "version": "14.16.1",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-14.16.1.tgz",
+                    "integrity": "sha1-0j7M5AgjpNA610Fg3IGdYuDAp4c="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
+            }
         },
         "@types/jsonwebtoken": {
             "version": "8.5.9",
@@ -1117,6 +1688,32 @@
             "version": "1.5.4",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/q/-/q-1.5.4.tgz",
             "integrity": "sha1-FZJUFOCtLNdlv+9YhC9+JqesyyQ="
+        },
+        "@typespec/ts-http-runtime": {
+            "version": "0.3.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.0.tgz",
+            "integrity": "sha1-9Qb/IXDllKJX+OeKoZYIjzpGoi0=",
+            "requires": {
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "agent-base": {
+                    "version": "7.1.4",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+                    "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g="
+                },
+                "https-proxy-agent": {
+                    "version": "7.0.6",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+                    "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
+                    "requires": {
+                        "agent-base": "^7.1.2",
+                        "debug": "4"
+                    }
+                }
+            }
         },
         "adm-zip": {
             "version": "0.5.15",
@@ -1213,6 +1810,11 @@
                 "gopd": "^1.0.1"
             }
         },
+        "define-lazy-prop": {
+            "version": "2.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8="
+        },
         "des.js": {
             "version": "1.1.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
@@ -1242,6 +1844,11 @@
             "version": "1.3.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8="
+        },
+        "events": {
+            "version": "3.3.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/events/-/events-3.3.0.tgz",
+            "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA="
         },
         "follow-redirects": {
             "version": "1.15.6",
@@ -1327,6 +1934,22 @@
                 "function-bind": "^1.1.2"
             }
         },
+        "http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
+            "requires": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "dependencies": {
+                "agent-base": {
+                    "version": "7.1.4",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+                    "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g="
+                }
+            }
+        },
         "https-proxy-agent": {
             "version": "4.0.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
@@ -1361,6 +1984,19 @@
             "integrity": "sha1-pzY6Jb7pQv76sN4Tv2qjcsgtzDc=",
             "requires": {
                 "hasown": "^2.0.2"
+            }
+        },
+        "is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao="
+        },
+        "is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+            "requires": {
+                "is-docker": "^2.0.0"
             }
         },
         "js-md4": {
@@ -1606,6 +2242,16 @@
                 "wrappy": "1"
             }
         },
+        "open": {
+            "version": "8.4.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/open/-/open-8.4.2.tgz",
+            "integrity": "sha1-W1/+Ko95Pc0qrXPlUMuHtZywhPk=",
+            "requires": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
+            }
+        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1709,6 +2355,11 @@
                 "get-intrinsic": "^1.2.4",
                 "object-inspect": "^1.13.1"
             }
+        },
+        "stoppable": {
+            "version": "1.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/stoppable/-/stoppable-1.1.0.tgz",
+            "integrity": "sha1-MtpWjoPqSIsI5NfqLDvMnXUBXVs="
         },
         "supports-preserve-symlinks-flag": {
             "version": "1.0.0",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.259.2",
+    "version": "3.262.0",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",
@@ -14,6 +14,7 @@
     },
     "homepage": "https://github.com/microsoft/azure-pipelines-tasks-common-packages#readme",
     "dependencies": {
+        "@azure/identity": "^3.4.2",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",


### PR DESCRIPTION
### **Description**
Currently we are communicating ARM resources with the help of ARM jwt. This way is going to be deprecated from ARM level. Hence we made changes to the common package based to generate a token based on a audience to communicate with the ARM resources.

AB#2303551

[User Story 2303551](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2303551): Need to Change the Audience for Kudo calls as AppService for security hygiene

### **Package Name**
azure-pipelines-tasks-azure-arm-rest

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated**   
- [N/A] Unit tests added or updated
- [X] Manual tests performed

---

### **Additional Testing Performed**
Updated to the Task AzureRMWebappDeploymentV5 with this package and validated with all schemes of service connection 

### **Documentation Changes Required** (Yes / No)  
No

---

### **Dependencies**
N/A
---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Package version was bumped — see [versioning guide](https://semver.org/)
- [x] Verified the package behaves as expected
- [N/A] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---

