### PR TITLE
Update azure-arm-rest to v3.262.0

### DIFF
--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -14,7 +14,7 @@
                 "@types/q": "1.5.4",
                 "@types/uuid": "^8.3.0",
                 "azure-pipelines-task-lib": "^4.13.0",
-                "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
+                "azure-pipelines-tasks-azure-arm-rest": "^3.262.0",
                 "del": "2.2.0",
                 "q": "1.4.1"
             },

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -19,7 +19,7 @@
         "@types/q": "1.5.4",
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.262.0",
         "del": "2.2.0",
         "q": "1.4.1"
     },


### PR DESCRIPTION
### **Description**
Updated the `azure-pipelines-tasks-azure-arm-rest` dependency in `package.json` to version ^3.262.0

---

### **Package Name**
azure-pipelines-tasks-azure-arm-rest

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated**   
- [ ] Unit tests added or updated
- [ ] Manual tests performed

---

### **Additional Testing Performed**


---

### **Documentation Changes Required** (Yes / No)  

---

### **Dependencies**
azure-pipelines-tasks-azure-arm-rest

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Package version was bumped — see [versioning guide](https://semver.org/)
- [ ] Verified the package behaves as expected
- [ ] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---

