### PR TITLE
Update azure-arm-rest to version 3.263.1 in docker-common

### DIFF
--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.263.1",
+    "version": "2.264.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.263.1",
+            "version": "2.264.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",
@@ -14,7 +14,7 @@
                 "@types/q": "1.5.4",
                 "@types/uuid": "^8.3.0",
                 "azure-pipelines-task-lib": "^4.13.0",
-                "azure-pipelines-tasks-azure-arm-rest": "^3.263.0",
+                "azure-pipelines-tasks-azure-arm-rest": "3.263.1",
                 "del": "2.2.0",
                 "q": "1.4.1"
             },
@@ -445,9 +445,9 @@
             }
         },
         "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-            "version": "3.263.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.263.0.tgz",
-            "integrity": "sha1-UOsMEorkX3/wsGmEEtjlfr85/CU=",
+            "version": "3.263.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.263.1.tgz",
+            "integrity": "sha1-wv9I8XydPX8oOeSZUOXux+jkarA=",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^3.4.2",
@@ -2012,9 +2012,9 @@
             }
         },
         "azure-pipelines-tasks-azure-arm-rest": {
-            "version": "3.263.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.263.0.tgz",
-            "integrity": "sha1-UOsMEorkX3/wsGmEEtjlfr85/CU=",
+            "version": "3.263.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.263.1.tgz",
+            "integrity": "sha1-wv9I8XydPX8oOeSZUOXux+jkarA=",
             "requires": {
                 "@azure/identity": "^3.4.2",
                 "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.263.1",
+    "version": "2.264.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",
@@ -19,7 +19,7 @@
         "@types/q": "1.5.4",
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.263.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.263.1",
         "del": "2.2.0",
         "q": "1.4.1"
     },


### PR DESCRIPTION
### **Description**
This PR updates azure-arm-rest common package in docker-common

Related WI: [AB#2318446](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2318446)

---

### **Package Name**
docker-common

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated**   
- [ ] Unit tests added or updated
- [ ] Manual tests performed

---

### **Additional Testing Performed**
_List all other tests performed (manual or automated, including integration, regression, scenario tests, etc.). Include links to test results or logs._

---

### **Documentation Changes Required** (Yes / No)  
_Indicate whether related documentation needs to be updated. Provide links to the updated documentation if applicable._

---

### **Dependencies**
_List any dependencies introduced or updated in this PR._

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Package version was bumped — see [versioning guide](https://semver.org/)
- [ ] Verified the package behaves as expected
- [x] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---

