### PR TITLE
Updated node-forge package to resolve vulnerability in kubernetes-common package

### DIFF
--- a/common-npm-packages/kubernetes-common/package-lock.json
+++ b/common-npm-packages/kubernetes-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-kubernetes-common",
-    "version": "2.266.0",
+    "version": "2.267.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-kubernetes-common",
-            "version": "2.266.0",
+            "version": "2.267.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "5.2.7",
@@ -17,7 +17,7 @@
                 "azure-pipelines-task-lib": "^4.0.0-preview",
                 "azure-pipelines-tool-lib": "^2.0.7",
                 "js-yaml": "3.13.1",
-                "node-forge": "^1.3.1"
+                "node-forge": "^1.3.3"
             },
             "devDependencies": {
                 "shelljs": "^0.8.5",
@@ -496,9 +496,9 @@
             "license": "MIT"
         },
         "node_modules/node-forge": {
-            "version": "1.3.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-forge/-/node-forge-1.3.1.tgz",
-            "integrity": "sha1-vo2iryQ7JBfV9kancGY6krfp3tM=",
+            "version": "1.3.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-forge/-/node-forge-1.3.3.tgz",
+            "integrity": "sha1-CtgPYzOzoARegnrCC39zX5NxZ1E=",
             "license": "(BSD-3-Clause OR GPL-2.0)",
             "engines": {
                 "node": ">= 6.13.0"
@@ -1089,9 +1089,9 @@
             "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "node-forge": {
-            "version": "1.3.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-forge/-/node-forge-1.3.1.tgz",
-            "integrity": "sha1-vo2iryQ7JBfV9kancGY6krfp3tM="
+            "version": "1.3.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-forge/-/node-forge-1.3.3.tgz",
+            "integrity": "sha1-CtgPYzOzoARegnrCC39zX5NxZ1E="
         },
         "nodejs-file-downloader": {
             "version": "4.13.0",

--- a/common-npm-packages/kubernetes-common/package.json
+++ b/common-npm-packages/kubernetes-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-kubernetes-common",
-    "version": "2.266.0",
+    "version": "2.267.0",
     "description": "Common Library for Kubernetes",
     "repository": {
         "type": "git",
@@ -22,7 +22,7 @@
         "azure-pipelines-task-lib": "^4.0.0-preview",
         "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "node-forge": "^1.3.1"
+        "node-forge": "^1.3.3"
     },
     "devDependencies": {
         "shelljs": "^0.8.5",


### PR DESCRIPTION
### **Description**

The node-forge package version 1.3.1 is marked as vulnerable
We are updating to 1.3.3 (suggestion was to update to 1.3.2 but newer version 1.3.3. is available so we are going for that)

[AB#2338097](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2338097)
[Component Governence](https://dev.azure.com/mseng/PipelineTools/_componentGovernance/903/alert/341192?typeId=194094)

---

### **Package Name**
kubernetes-common

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated**   

We don't have any test cases for kubernetes-common
Package will be tested once available in the feed along with the tasks

- [ ] Unit tests added or updated
- [ ] Manual tests performed

---

### **Additional Testing Performed**
Ran npm audit to check if vulnerability was removed after updating the package


### Before package update: 

```
### npm audit report

brace-expansion  <=1.1.11
brace-expansion Regular Expression Denial of Service vulnerability - https://github.com/advisories/GHSA-v6h2-p8h4-qcjw
fix available via `npm audit fix`
node_modules/brace-expansion

js-yaml  <3.14.2
Severity: moderate
js-yaml has prototype pollution in merge (<<) - https://github.com/advisories/GHSA-mh29-5h37-fv8m
fix available via `npm audit fix --force`
Will install js-yaml@3.14.2, which is outside the stated dependency range
node_modules/js-yaml

node-forge  1.3.1
Severity: high
node-forge has ASN.1 Unbounded Recursion - https://github.com/advisories/GHSA-554w-wpv2-vw27
node-forge has an Interpretation Conflict vulnerability via its ASN.1 Validator Desynchronization - https://github.com/advisories/GHSA-5gfm-wpxj-wjgq        
node-forge is vulnerable to ASN.1 OID Integer Truncation - https://github.com/advisories/GHSA-65ch-62r8-g69g
fix available via `npm audit fix`
node_modules/node-forge

3 vulnerabilities (1 low, 1 moderate, 1 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues, run:
  npm audit fix --force

```

### After package update:

```
npm audit report

brace-expansion  <=1.1.11
brace-expansion Regular Expression Denial of Service vulnerability - https://github.com/advisories/GHSA-v6h2-p8h4-qcjw
fix available via `npm audit fix`
node_modules/brace-expansion

js-yaml  <3.14.2
Severity: moderate
js-yaml has prototype pollution in merge (<<) - https://github.com/advisories/GHSA-mh29-5h37-fv8m
fix available via `npm audit fix --force`
Will install js-yaml@3.14.2, which is outside the stated dependency range
node_modules/js-yaml

2 vulnerabilities (1 low, 1 moderate)

To address issues that do not require attention, run:
  npm audit fix

To address all issues, run:
  npm audit fix --force

```

---


### **Documentation Changes Required** (Yes / No)  
_Indicate whether related documentation needs to be updated. Provide links to the updated documentation if applicable._

---

### **Dependencies**
_List any dependencies introduced or updated in this PR._

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Package version was bumped — see [versioning guide](https://semver.org/)
- [ ] Verified the package behaves as expected
- [x] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---

