### PR TITLE
Fix 7zip path in Utility-Common package

### DIFF
--- a/common-npm-packages/utility-common/compressutility.ts
+++ b/common-npm-packages/utility-common/compressutility.ts
@@ -15,10 +15,10 @@ var winSevenZipLocation: string = getWinSevenZipLocation();
 
 function getWinSevenZipLocation(): string {
     if (tl.getPipelineFeature("Use7zV2501InUtilityCommonPackage")) {
-        return path.join(__dirname, 'tools/7zip25/7z.exe');
+        return path.join(__dirname, 'tools/7zip25/7zip/7z.exe');
     }
     else {
-        return path.join(__dirname, 'tools/7zip24/7z.exe');
+        return path.join(__dirname, 'tools/7zip24/7zip/7z.exe');
     }
 }
 

--- a/common-npm-packages/utility-common/package-lock.json
+++ b/common-npm-packages/utility-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-utility-common",
-    "version": "3.266.0",
+    "version": "3.267.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-utility-common",
-            "version": "3.266.0",
+            "version": "3.267.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "~16.11.39",

--- a/common-npm-packages/utility-common/package.json
+++ b/common-npm-packages/utility-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-utility-common",
-    "version": "3.266.0",
+    "version": "3.267.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### **Context**

Fixing 7zip path.
7zip path is wrongly mentioned as tools/7zip24/7z.exe. Hence changing the path to tools/7zip24/7zip/7z.exe
📌 [7Zip WorkItem](https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2330536)

---

### **Description**

I tested AzureVMssDeploymentv1 task - https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=231127&view=results where i found warning
##[warning]Could not compress custom scripts. Will use individual files. Error: Error: Unable to locate executable file: 'D:\a_tasks\AzureVmssDeployment_4dda660c-b643-4598-a4a2-61080d0002d9\1.266.0\node_modules\azure-pipelines-tasks-utility-common\tools\7zip25\7z.exe'. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.

Here the tasks is not failing because we have a fallback logic to use custom scripts. Previous 7zip version paths were also incorrect and resulted in the same warning

---

### **Package Name**
Utility-Common

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Testing Performed**
Tested manual in private org by uploading changes to AzureVmssDeploymentV1 task.
https://dev.azure.com/v-phivTT/firstProject/_build/results?buildId=220&view=results


### **Checklist**
- [ ] Related issue linked (if applicable)
- [x] Package version was bumped — see [versioning guide](https://semver.org/)
- [x] Verified the package behaves as expected
- [ ] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---

