### PR TITLE
ArtifactToolInstaller: Optional install to dedicated path 

### DIFF
--- a/common-npm-packages/packaging-common/Tests/L0.ts
+++ b/common-npm-packages/packaging-common/Tests/L0.ts
@@ -1,6 +1,7 @@
 import { npmcommon } from "./npm/npmL0";
 import { nugetcommon } from "./nuget/nugetL0";
 import { nugettoolgetter } from "./nuget/nugetToolGetterTests";
+import { artifactToolUtilities } from "./universal/artifactToolUtilitiesL0";
 import * as pkgLocationUtils from "../locationUtilities";
 import * as assert from "assert";
 
@@ -8,6 +9,7 @@ describe("packaging-common Task Suite", function() {
     describe("nuget common", nugetcommon);
     describe("nuget tool getter", nugettoolgetter);
     describe("npm common", npmcommon);
+    describe("artifact tool utilities", artifactToolUtilities);
 });
 
 describe("packaging-common locationUtilities Suite", function() {

--- a/common-npm-packages/packaging-common/Tests/universal/artifactToolUtilitiesL0.ts
+++ b/common-npm-packages/packaging-common/Tests/universal/artifactToolUtilitiesL0.ts
@@ -72,9 +72,9 @@ export function artifactToolUtilities() {
         return { mockToollib };
     }
 
-    it("uses pinned version when UPack.ArtifactToolCacheVersion is true", async () => {
+    it("uses pinned version when UPack.EnableFixedArtifactToolLocation is true", async () => {
         createMocks(
-            { "UPack.ArtifactToolCacheVersion": "true" },
+            { "UPack.EnableFixedArtifactToolLocation": "true" },
             { version: "0.2.542", uri: "https://example.com/artifacttool.zip" }
         );
 
@@ -84,9 +84,9 @@ export function artifactToolUtilities() {
         assert(result.includes("0.0.1-latest"), `Expected path to contain 0.0.1-latest, got: ${result}`);
     });
 
-    it("uses pinned version when UPack.ArtifactToolCacheVersion is True (case insensitive)", async () => {
+    it("uses pinned version when UPack.EnableFixedArtifactToolLocation is True (case insensitive)", async () => {
         createMocks(
-            { "UPack.ArtifactToolCacheVersion": "True" },
+            { "UPack.EnableFixedArtifactToolLocation": "True" },
             { version: "0.2.542", uri: "https://example.com/artifacttool.zip" }
         );
 
@@ -96,10 +96,10 @@ export function artifactToolUtilities() {
         assert(result.includes("0.0.1-latest"), `Expected path to contain 0.0.1-latest, got: ${result}`);
     });
 
-    it("uses server version when UPack.ArtifactToolCacheVersion is false", async () => {
+    it("uses server version when UPack.EnableFixedArtifactToolLocation is false", async () => {
         const serverVersion = "0.2.542";
         createMocks(
-            { "UPack.ArtifactToolCacheVersion": "false" },
+            { "UPack.EnableFixedArtifactToolLocation": "false" },
             { version: serverVersion, uri: "https://example.com/artifacttool.zip" }
         );
 

--- a/common-npm-packages/packaging-common/Tests/universal/artifactToolUtilitiesL0.ts
+++ b/common-npm-packages/packaging-common/Tests/universal/artifactToolUtilitiesL0.ts
@@ -1,0 +1,111 @@
+import * as assert from "assert";
+import * as mocker from "azure-pipelines-task-lib/lib-mocker";
+
+export function artifactToolUtilities() {
+    before(() => {
+        mocker.disable();
+        mocker.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        } as mocker.MockOptions);
+    });
+
+    after(() => {
+        mocker.disable();
+    });
+
+    beforeEach(() => {
+        mocker.resetCache();
+    });
+
+    afterEach(() => {
+        mocker.deregisterAll();
+    });
+
+    function createMocks(variables: { [key: string]: string }, toolMetadata: { version: string; uri: string }, cachedToolPath?: string) {
+        const defaultVars: { [key: string]: string } = {
+            "Agent.TempDirectory": "C:\\temp",
+            ...variables
+        };
+        const mockTl = {
+            getVariable: (name: string) => defaultVars[name],
+            osType: () => "Windows_NT",
+            debug: (_msg: string) => {},
+            loc: (key: string, ...args: any[]) => key,
+            exist: (_path: string) => true,
+            mkdirP: (_path: string) => {}
+        };
+
+        const mockToollib = {
+            findLocalTool: (_toolName: string, _version: string, _arch?: string) => cachedToolPath || "",
+            downloadTool: (_url: string) => Promise.resolve("C:\\temp\\zipped"),
+            cacheDir: (_sourceDir: string, _tool: string, version: string, _arch?: string) => Promise.resolve(`C:\\agent\\_tool\\artifacttool\\${version}\\x64`)
+        };
+
+        const mockPkgLocationUtils = {
+            getWebApiWithProxy: (_serviceUri: string, _accessToken: string) => ({
+                vsoClient: {
+                    getVersioningData: () => Promise.resolve({ requestUrl: "https://example.com/api" })
+                },
+                rest: {
+                    get: () => Promise.resolve({ statusCode: 200, result: toolMetadata })
+                }
+            }),
+            retryOnExceptionHelper: (fn: () => Promise<any>, _retries: number, _delay: number) => fn()
+        };
+
+        const mockAdmZip = function() {
+            return { extractAllTo: () => {} };
+        };
+
+        const mockOs = {
+            arch: () => "x64"
+        };
+
+        mocker.registerMock("azure-pipelines-task-lib", mockTl);
+        mocker.registerMock("azure-pipelines-task-lib/task", mockTl);
+        mocker.registerMock("azure-pipelines-tool-lib/tool", mockToollib);
+        mocker.registerMock("../locationUtilities", mockPkgLocationUtils);
+        mocker.registerMock("adm-zip", mockAdmZip);
+        mocker.registerMock("os", mockOs);
+
+        return { mockToollib };
+    }
+
+    it("uses pinned version when UPack.ArtifactToolCacheVersion is true", async () => {
+        createMocks(
+            { "UPack.ArtifactToolCacheVersion": "true" },
+            { version: "0.2.542", uri: "https://example.com/artifacttool.zip" }
+        );
+
+        const artifactToolUtilities = require("../../universal/ArtifactToolUtilities");
+        const result = await artifactToolUtilities.getArtifactToolFromService("https://service.com", "token", "artifacttool");
+
+        assert(result.includes("0.0.1-latest"), `Expected path to contain 0.0.1-latest, got: ${result}`);
+    });
+
+    it("uses pinned version when UPack.ArtifactToolCacheVersion is True (case insensitive)", async () => {
+        createMocks(
+            { "UPack.ArtifactToolCacheVersion": "True" },
+            { version: "0.2.542", uri: "https://example.com/artifacttool.zip" }
+        );
+
+        const artifactToolUtilities = require("../../universal/ArtifactToolUtilities");
+        const result = await artifactToolUtilities.getArtifactToolFromService("https://service.com", "token", "artifacttool");
+
+        assert(result.includes("0.0.1-latest"), `Expected path to contain 0.0.1-latest, got: ${result}`);
+    });
+
+    it("uses server version when UPack.ArtifactToolCacheVersion is false", async () => {
+        const serverVersion = "0.2.542";
+        createMocks(
+            { "UPack.ArtifactToolCacheVersion": "false" },
+            { version: serverVersion, uri: "https://example.com/artifacttool.zip" }
+        );
+
+        const artifactToolUtilities = require("../../universal/ArtifactToolUtilities");
+        const result = await artifactToolUtilities.getArtifactToolFromService("https://service.com", "token", "artifacttool");
+
+        assert(result.includes(serverVersion), `Expected path to contain version ${serverVersion}, got: ${result}`);
+    });
+}

--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.273.0",
+    "version": "3.273.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
@@ -333,22 +333,6 @@
                 "node": ">=12.0"
             }
         },
-        "node_modules/azure-pipelines-task-lib/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
-            "license": "MIT"
-        },
-        "node_modules/azure-pipelines-task-lib/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
         "node_modules/azure-pipelines-task-lib/node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
@@ -385,6 +369,22 @@
                 "qs": "^6.9.1",
                 "tunnel": "0.0.6",
                 "underscore": "^1.12.1"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+            "license": "MIT"
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.14",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/braces": {
@@ -768,9 +768,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs=",
+            "version": "1.16.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
             "funding": [
                 {
                     "type": "individual",
@@ -1110,9 +1110,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
+            "version": "4.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1291,17 +1291,10 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
-        "node_modules/mocha/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+            "version": "2.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha1-T0GkEZAhbuNgZ+w4FSb+lTnE8K4=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1485,9 +1478,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+            "version": "2.3.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -1908,9 +1901,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=",
+            "version": "1.13.8",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
             "license": "MIT"
         },
         "node_modules/utf8-byte-length": {
@@ -2290,20 +2283,6 @@
                     "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.15.tgz",
                     "integrity": "sha1-wsmz1POxyRHnKyOU6E/ZG8yB4I4="
                 },
-                "balanced-match": {
-                    "version": "1.0.2",
-                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-                    "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
-                },
-                "brace-expansion": {
-                    "version": "1.1.12",
-                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-                    "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
-                    "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
                 "minimatch": {
                     "version": "3.1.5",
                     "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
@@ -2338,6 +2317,20 @@
                         "underscore": "^1.12.1"
                     }
                 }
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+        },
+        "brace-expansion": {
+            "version": "1.1.14",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "braces": {
@@ -2591,9 +2584,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs="
+            "version": "1.16.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw="
         },
         "foreground-child": {
             "version": "3.3.1",
@@ -2790,9 +2783,9 @@
             "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU="
         },
         "js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
+            "version": "4.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1"
@@ -2913,16 +2906,10 @@
                 "yargs-unparser": "^2.0.0"
             },
             "dependencies": {
-                "balanced-match": {
-                    "version": "1.0.2",
-                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-                    "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
-                    "dev": true
-                },
                 "brace-expansion": {
-                    "version": "2.0.2",
-                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
-                    "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+                    "version": "2.1.0",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.0.tgz",
+                    "integrity": "sha1-T0GkEZAhbuNgZ+w4FSb+lTnE8K4=",
                     "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0"
@@ -3042,9 +3029,9 @@
             "dev": true
         },
         "picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI="
+            "version": "2.3.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE="
         },
         "q": {
             "version": "1.5.1",
@@ -3289,9 +3276,9 @@
             "dev": true
         },
         "underscore": {
-            "version": "1.13.7",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA="
+            "version": "1.13.8",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss="
         },
         "utf8-byte-length": {
             "version": "1.0.5",

--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-packaging-common",
-            "version": "3.273.0",
+            "version": "3.273.1",
             "license": "MIT",
             "dependencies": {
                 "@types/ini": "1.3.30",

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.273.0",
+    "version": "3.273.1",
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "mocha _build/Tests/L0.js",

--- a/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
+++ b/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
@@ -85,7 +85,14 @@ export async function getArtifactToolFromService(serviceUri: string, accessToken
         throw new Error(tl.loc("Error_UnexpectedErrorFailedToGetToolMetadata", artifactToolGetUrl.requestUrl));
     }
 
-    let artifactToolPath = toollib.findLocalTool(toolName, artifactToolUri.result['version']);
+    // When UPack.ArtifactToolCacheVersion is "true", all versions resolve to a single cache slot
+    // at <Agent.ToolsDirectory>/artifacttool/0.0.1/<arch>, avoiding version-specific directories.
+    const pinCacheVersion = (tl.getVariable("UPack.ArtifactToolCacheVersion") || "").toLowerCase() === "true";
+    const cacheVersion = pinCacheVersion
+        ? "0.0.1-latest"
+        : artifactToolUri.result['version'];
+
+    let artifactToolPath = toollib.findLocalTool(toolName, cacheVersion);
     if (!artifactToolPath) {
         tl.debug(tl.loc("Info_DownloadingArtifactTool", artifactToolUri.result['uri']));
 
@@ -94,7 +101,7 @@ export async function getArtifactToolFromService(serviceUri: string, accessToken
         tl.debug("Downloaded zipped artifact tool to " + zippedToolsDir);
         const unzippedToolsDir = await extractZip(zippedToolsDir);
 
-        artifactToolPath = await toollib.cacheDir(unzippedToolsDir, toolName, artifactToolUri.result['version']);
+        artifactToolPath = await toollib.cacheDir(unzippedToolsDir, toolName, cacheVersion);
     } else {
         tl.debug(tl.loc("Info_ResolvedToolFromCache", artifactToolPath));
     }

--- a/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
+++ b/common-npm-packages/packaging-common/universal/ArtifactToolUtilities.ts
@@ -85,9 +85,9 @@ export async function getArtifactToolFromService(serviceUri: string, accessToken
         throw new Error(tl.loc("Error_UnexpectedErrorFailedToGetToolMetadata", artifactToolGetUrl.requestUrl));
     }
 
-    // When UPack.ArtifactToolCacheVersion is "true", all versions resolve to a single cache slot
-    // at <Agent.ToolsDirectory>/artifacttool/0.0.1/<arch>, avoiding version-specific directories.
-    const pinCacheVersion = (tl.getVariable("UPack.ArtifactToolCacheVersion") || "").toLowerCase() === "true";
+    // When UPack.EnableFixedArtifactToolLocation is "true", all versions resolve to a single cache slot
+    // at <Agent.ToolsDirectory>/artifacttool/0.0.1-latest/<arch>, avoiding version-specific directories.
+    const pinCacheVersion = (tl.getVariable("UPack.EnableFixedArtifactToolLocation") || "").toLowerCase() === "true";
     const cacheVersion = pinCacheVersion
         ? "0.0.1-latest"
         : artifactToolUri.result['version'];


### PR DESCRIPTION
### **Description**
Expand functionality of the Artifact Tool Installer to conditionally use a fixed version of the task. 
[AB#2381127](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2381127)

---

### **Package Name**
packaging-common

---

### **Risk Assessment** (Low / Medium / High)  
low - This is only conditional. Discovery of the 

---

### **Unit Tests Added or Updated**   
- [Y] Unit tests added or updated
- [Y] Manual tests performed

---

### **Additional Testing Performed**
E2E testing 

---

### **Documentation Changes Required** (Yes / No)  
N

---

### **Dependencies**
minor/patch updates include:
follow-redirects: 1.15.6 → 1.16.0
js-yaml: 4.1.0 → 4.1.1
underscore: 1.13.7 → 1.13.8
picomatch: 2.3.1 → 2.3.2
brace-expansion: 1.1.12 → 1.1.14 (top-level lock entry)
brace-expansion (nested under mocha): 2.0.2 → 2.1.0

---

### **Checklist**
- [Y] Related issue linked (if applicable)
- [Y] Package version was bumped — see [versioning guide](https://semver.org/)
- [Y] Verified the package behaves as expected
- [n/a] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---

