### PR TITLE
Update jacoco version to 0.8.14

### DIFF
--- a/common-npm-packages/codecoverage-tools/Tests/data/expectedResults.ts
+++ b/common-npm-packages/codecoverage-tools/Tests/data/expectedResults.ts
@@ -248,7 +248,7 @@ cobertura {
 export const jacocoMavenSingleProject = {
     'groupId': 'org.jacoco',
     'artifactId': 'jacoco-maven-plugin',
-    'version': '0.8.11',
+    'version': '0.8.14',
     'configuration': {
         'includes': [{
             'include': [
@@ -298,7 +298,7 @@ export const jacocoMavenMultiProject = `<?xml version="1.0" encoding="UTF-8"?>
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.11</version>
+                        <version>0.8.14</version>
                         <executions>
                             <execution>
                                 <id>jacoco-report-aggregate</id>

--- a/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
+++ b/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
@@ -308,7 +308,7 @@ export function jacocoMavenPluginEnable(includeFilter: string[], excludeFilter: 
     let plugin = {
         "groupId": "org.jacoco",
         "artifactId": "jacoco-maven-plugin",
-        "version": "0.8.11",
+        "version": "0.8.14",
         "configuration": {
             "includes": [{
                 "include": includeFilter,
@@ -385,7 +385,7 @@ export function jacocoMavenMultiModuleReport(
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.11</version>
+                        <version>0.8.14</version>
                         <executions>
                             <execution>
                                 <id>jacoco-report-aggregate</id>

--- a/common-npm-packages/codecoverage-tools/package-lock.json
+++ b/common-npm-packages/codecoverage-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-codecoverage-tools",
-    "version": "3.272.0",
+    "version": "3.273.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-codecoverage-tools",
-            "version": "3.272.0",
+            "version": "3.273.0",
             "license": "MIT",
             "dependencies": {
                 "@types/cheerio": "0.22.0",
@@ -467,6 +467,7 @@
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/acorn/-/acorn-7.4.1.tgz",
             "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3434,7 +3435,8 @@
         "acorn": {
             "version": "7.4.1",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo="
+            "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
+            "peer": true
         },
         "acorn-jsx": {
             "version": "5.3.2",

--- a/common-npm-packages/codecoverage-tools/package-lock.json
+++ b/common-npm-packages/codecoverage-tools/package-lock.json
@@ -467,7 +467,6 @@
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/acorn/-/acorn-7.4.1.tgz",
             "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3435,8 +3434,7 @@
         "acorn": {
             "version": "7.4.1",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
-            "peer": true
+            "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo="
         },
         "acorn-jsx": {
             "version": "5.3.2",

--- a/common-npm-packages/codecoverage-tools/package.json
+++ b/common-npm-packages/codecoverage-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-codecoverage-tools",
-    "version": "3.272.0",
+    "version": "3.273.0",
     "author": "Microsoft Corporation",
     "description": "VSTS Tasks Code Coverage Tools",
     "license": "MIT",


### PR DESCRIPTION
### **Description**
 The Maven@4 task hardcodes JaCoCo Maven plugin version 0.8.11 via the codecoverage-tools package. JaCoCo 0.8.11 doesn't support Java 23+ class files, causing builds to fail with:

   Unsupported class file major version 69

  This PR bumps JaCoCo from 0.8.11 → 0.8.14, adding support for Java 23–25 (class file major versions 67–69).

   - Fixes microsoft/azure-pipelines-tasks#21940
   - Related: microsoft/azure-pipelines-tasks#21185

WI - [AB#2375581](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2375581)

---

### **Package Name**
 azure-pipelines-tasks-codecoverage-tools

---

### **Risk Assessment** (Low / Medium / High)  
_Assess the level of risk and provide reasoning (e.g., scope, impact, backward compatibility)._

---

### **Unit Tests Added or Updated**   
- [ ] Unit tests added or updated
- [ ] Manual tests performed

---

### **Additional Testing Performed**
_List all other tests performed (manual or automated, including integration, regression, scenario tests, etc.). Include links to test results or logs._

---

### **Documentation Changes Required** ( No)  
_Indicate whether related documentation needs to be updated. Provide links to the updated documentation if applicable._

---

### **Dependencies**
- jacoco-maven-plugin
  0.8.11 → 0.8.14

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Package version was bumped — see [versioning guide](https://semver.org/)
- [ ] Verified the package behaves as expected
- [ ] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---

