### PR TITLE
  Update `@xmldom/xmldom` to 0.8.13 in webdeployment-common to fix CG alert

### DIFF
--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -12,7 +12,7 @@
                 "@types/ltx": "3.0.6",
                 "@types/mocha": "^5.2.7",
                 "@types/node": "^16.11.39",
-                "@xmldom/xmldom": "git+https://github.com/xmldom/xmldom.git#0.8.12",
+                "@xmldom/xmldom": "git+https://github.com/xmldom/xmldom.git#0.8.13",
                 "archiver": "7.0.1",
                 "azure-pipelines-task-lib": "^5.2.8",
                 "ltx": "2.8.0",
@@ -638,13 +638,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/@sinonjs/text-encoding": {
-            "version": "0.7.3",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
-            "integrity": "sha1-KCBG8D6IbjUrLV9dpet1XgFFfz8=",
-            "dev": true,
-            "license": "(Unlicense OR Apache-2.0)"
-        },
         "node_modules/@types/events": {
             "version": "3.0.3",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/events/-/events-3.0.3.tgz",
@@ -694,8 +687,8 @@
             "license": "MIT"
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.8.12",
-            "resolved": "git+ssh://git@github.com/xmldom/xmldom.git#189cb78a83e81e1515880988a399e863a8be85ac",
+            "version": "0.8.13",
+            "resolved": "git+ssh://git@github.com/xmldom/xmldom.git#e5c14802592685bb872c042c54c3f73758875c85",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -938,9 +931,9 @@
             "license": "MIT"
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "5.2.8",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-            "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+            "version": "5.2.10",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
+            "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
@@ -1130,9 +1123,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+            "version": "1.1.14",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -1703,9 +1696,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha1-d31z1yqS+OxNLkEOtHNSpWuOg0A=",
+            "version": "1.16.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
             "funding": [
                 {
                     "type": "individual",
@@ -2561,9 +2554,9 @@
             }
         },
         "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+            "version": "2.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha1-T0GkEZAhbuNgZ+w4FSb+lTnE8K4=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2611,17 +2604,26 @@
             "license": "MIT"
         },
         "node_modules/nise": {
-            "version": "6.1.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nise/-/nise-6.1.1.tgz",
-            "integrity": "sha1-eOqTzEm+Ei5Ey3yP31l7Dod4tko=",
+            "version": "6.1.5",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nise/-/nise-6.1.5.tgz",
+            "integrity": "sha1-ovTNB9jTjrxa5VABaO6g8IovpLk=",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@sinonjs/commons": "^3.0.1",
-                "@sinonjs/fake-timers": "^13.0.1",
-                "@sinonjs/text-encoding": "^0.7.3",
+                "@sinonjs/fake-timers": "^15.1.1",
                 "just-extend": "^6.2.0",
-                "path-to-regexp": "^8.1.0"
+                "path-to-regexp": "^8.3.0"
+            }
+        },
+        "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+            "version": "15.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+            "integrity": "sha1-4ab3FxlBqtzDHSzqF0QmTVi4s0w=",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1"
             }
         },
         "node_modules/node-preload": {
@@ -4454,12 +4456,6 @@
                 }
             }
         },
-        "@sinonjs/text-encoding": {
-            "version": "0.7.3",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
-            "integrity": "sha1-KCBG8D6IbjUrLV9dpet1XgFFfz8=",
-            "dev": true
-        },
         "@types/events": {
             "version": "3.0.3",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/events/-/events-3.0.3.tgz",
@@ -4502,8 +4498,8 @@
             "dev": true
         },
         "@xmldom/xmldom": {
-            "version": "git+ssh://git@github.com/xmldom/xmldom.git#189cb78a83e81e1515880988a399e863a8be85ac",
-            "from": "@xmldom/xmldom@git+https://github.com/xmldom/xmldom.git#0.8.12"
+            "version": "git+ssh://git@github.com/xmldom/xmldom.git#e5c14802592685bb872c042c54c3f73758875c85",
+            "from": "@xmldom/xmldom@git+https://github.com/xmldom/xmldom.git#0.8.13"
         },
         "abort-controller": {
             "version": "3.0.0",
@@ -4665,9 +4661,9 @@
             "integrity": "sha1-Gwco4Ukp1RuFtEm38G4nwRReOM4="
         },
         "azure-pipelines-task-lib": {
-            "version": "5.2.8",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-            "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+            "version": "5.2.10",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
+            "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
             "requires": {
                 "adm-zip": "^0.5.10",
                 "minimatch": "^3.1.5",
@@ -4767,9 +4763,9 @@
             "dev": true
         },
         "brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+            "version": "1.1.14",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5129,9 +5125,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha1-d31z1yqS+OxNLkEOtHNSpWuOg0A="
+            "version": "1.16.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw="
         },
         "foreground-child": {
             "version": "2.0.0",
@@ -5683,9 +5679,9 @@
             },
             "dependencies": {
                 "brace-expansion": {
-                    "version": "2.0.2",
-                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
-                    "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+                    "version": "2.1.0",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.0.tgz",
+                    "integrity": "sha1-T0GkEZAhbuNgZ+w4FSb+lTnE8K4=",
                     "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0"
@@ -5721,16 +5717,26 @@
             "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
         },
         "nise": {
-            "version": "6.1.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nise/-/nise-6.1.1.tgz",
-            "integrity": "sha1-eOqTzEm+Ei5Ey3yP31l7Dod4tko=",
+            "version": "6.1.5",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nise/-/nise-6.1.5.tgz",
+            "integrity": "sha1-ovTNB9jTjrxa5VABaO6g8IovpLk=",
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^3.0.1",
-                "@sinonjs/fake-timers": "^13.0.1",
-                "@sinonjs/text-encoding": "^0.7.3",
+                "@sinonjs/fake-timers": "^15.1.1",
                 "just-extend": "^6.2.0",
-                "path-to-regexp": "^8.1.0"
+                "path-to-regexp": "^8.3.0"
+            },
+            "dependencies": {
+                "@sinonjs/fake-timers": {
+                    "version": "15.1.1",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+                    "integrity": "sha1-4ab3FxlBqtzDHSzqF0QmTVi4s0w=",
+                    "dev": true,
+                    "requires": {
+                        "@sinonjs/commons": "^3.0.1"
+                    }
+                }
             }
         },
         "node-preload": {

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.272.1",
+    "version": "4.274.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-webdeployment-common",
-            "version": "4.272.1",
+            "version": "4.274.0",
             "license": "MIT",
             "dependencies": {
                 "@types/ltx": "3.0.6",
                 "@types/mocha": "^5.2.7",
                 "@types/node": "^16.11.39",
-                "@xmldom/xmldom": "git+https://github.com/xmldom/xmldom.git#0.8.13",
+                "@xmldom/xmldom": "^0.8.13",
                 "archiver": "7.0.1",
                 "azure-pipelines-task-lib": "^5.2.8",
                 "ltx": "2.8.0",
@@ -4499,7 +4499,7 @@
         },
         "@xmldom/xmldom": {
             "version": "git+ssh://git@github.com/xmldom/xmldom.git#e5c14802592685bb872c042c54c3f73758875c85",
-            "from": "@xmldom/xmldom@git+https://github.com/xmldom/xmldom.git#0.8.13"
+            "from": "@xmldom/xmldom@^0.8.13"
         },
         "abort-controller": {
             "version": "3.0.0",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.272.1",
+    "version": "4.274.0",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",
@@ -22,7 +22,7 @@
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",
         "@types/node": "^16.11.39",
-        "@xmldom/xmldom": "git+https://github.com/xmldom/xmldom.git#0.8.12",
+        "@xmldom/xmldom": "git+https://github.com/xmldom/xmldom.git#0.8.13",
         "archiver": "7.0.1",
         "azure-pipelines-task-lib": "^5.2.8",
         "ltx": "2.8.0",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -22,7 +22,7 @@
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",
         "@types/node": "^16.11.39",
-        "@xmldom/xmldom": "git+https://github.com/xmldom/xmldom.git#0.8.13",
+        "@xmldom/xmldom": "^0.8.13",
         "archiver": "7.0.1",
         "azure-pipelines-task-lib": "^5.2.8",
         "ltx": "2.8.0",


### PR DESCRIPTION
### Context

Fix CG vulnerability — update `@xmldom/xmldom` from git-pinned `0.8.12` to `^0.8.13` (npm registry) in `webdeployment-common`.

### Changes

- Bump `webdeployment-common` version `4.272.1` → `4.274.0`
- Update `@xmldom/xmldom` to `^0.8.13` 
- Regenerated package-lock.json

### Regression risk

**Low.** All 0.8.x changes are backwards-compatible. The codebase only uses `DOMParser.parseFromString()` and basic DOM traversal — none of the patched APIs are affected.

### Testing

- Build: passes
- Tests: **36 passing**, 0 failures