### PR TITLE
Removed EnableDockerReservedNameCheck feature flag in docker-common package

### DIFF
--- a/common-npm-packages/docker-common/containerimageutils.ts
+++ b/common-npm-packages/docker-common/containerimageutils.ts
@@ -4,7 +4,6 @@ import * as fs from 'fs';
 import ContainerConnection from "./containerconnection";
 
 const reservedImageName = "scratch";
-const reservedNameCheck = tl.getPipelineFeature('EnableDockerReservedNameCheck');
 
 export function hasRegistryComponent(imageName: string): boolean {
     var periodIndex = imageName.indexOf("."),
@@ -167,24 +166,16 @@ export function getImageDigest(connection: ContainerConnection, imageName: strin
 }
 
 function pullImage(connection: ContainerConnection, imageName: string) {
-    if (reservedNameCheck) {
-        if (imageName.toLowerCase() != reservedImageName) {
-            pullImageReservedNameCheck(connection, imageName);
-        }
-    } else {
-        pullImageReservedNameCheck(connection, imageName);
+    if (imageName.toLowerCase() != reservedImageName) {
+        runPullImageCommand(connection, imageName);
     }
 }
 
 function inspectImage(connection: ContainerConnection, imageName): any {
     try {
         let inspectObj = null;
-        if (reservedNameCheck) {
-            if (imageName.toLowerCase() != reservedImageName) {
-                inspectObj = inspectImageReservedName(connection, imageName);
-            }
-        } else {
-            inspectObj = inspectImageReservedName(connection, imageName);
+        if (imageName.toLowerCase() != reservedImageName) {
+            inspectObj = runInspectImageCommand(connection, imageName);
         }
         return inspectObj;
     } catch (error) {
@@ -313,7 +304,7 @@ export class baseImageDetails{
     name: string;
     digest: string ;
 }
-function pullImageReservedNameCheck(connection: ContainerConnection, imageName: string) {
+function runPullImageCommand(connection: ContainerConnection, imageName: string) {
     let pullCommand = connection.createCommand();
     pullCommand.arg("pull");
     pullCommand.arg(imageName);
@@ -322,7 +313,7 @@ function pullImageReservedNameCheck(connection: ContainerConnection, imageName: 
         tl.debug(`An error was found pulling the image ${imageName}, the command output was ${pullResult.stderr}`);
     }
 }
-function inspectImageReservedName(connection: ContainerConnection, imageName): any {
+function runInspectImageCommand(connection: ContainerConnection, imageName): any {
         let inspectCommand = connection.createCommand();
         inspectCommand.arg("inspect");
         inspectCommand.arg(imageName);

--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -457,9 +457,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+            "version": "1.1.14",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -747,9 +747,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha1-d31z1yqS+OxNLkEOtHNSpWuOg0A=",
+            "version": "1.16.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
             "funding": [
                 {
                     "type": "individual",
@@ -1544,9 +1544,9 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+            "version": "2.3.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"

--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.273.0",
+    "version": "2.274.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.273.0",
+            "version": "2.274.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.273.0",
+    "version": "2.274.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Description
These FF was enabled as part of M263 deployments and we monitored these many sprints it working as expected, so we are removing the FF 
This PR removes the dynamic EnableDockerReservedNameCheck feature flag from `docker-common` and keeps the currently working behavior as the default path.

WI: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2337465/
original bug wi: [[BUG]: Docker build task tries to pull scratch image · Issue #20929 · microsoft/azure-pipelines-tas…](https://github.com/microsoft/azure-pipelines-tasks/issues/20929)

### Changes
- Removed `EnableDockerReservedNameCheck` from [common-npm-packages/docker-common/containerimageutils.ts](common-npm-packages/docker-common/containerimageutils.ts)
- Removed the obsolete non-flagged fallback flow and made the reserved-name handling unconditional
- Preserved the special handling for the reserved `scratch` image name
- Renamed internal helper methods to match the simplified behavior
- Bumped `azure-pipelines-tasks-docker-common` version from `2.273.0` to `2.274.0` in [common-npm-packages/docker-common/package.json](common-npm-packages/docker-common/package.json) and [common-npm-packages/docker-common/package-lock.json](common-npm-packages/docker-common/package-lock.json)
- Refreshed the lockfile to address audit findings

### Dependency updates
- `brace-expansion` `1.1.12 -> 1.1.14`
- `follow-redirects` `1.15.11 -> 1.16.0`
- `picomatch` `2.3.1 -> 2.3.2`

### Risk
Low. The code change is scoped to `docker-common` and removes a feature-flag branch by keeping the already validated path as the only behavior.

