### PR TITLE
Remove CommaSeperatedConnectionString feature flag

### DIFF
--- a/common-npm-packages/webdeployment-common/Tests/L0MSDeployUtility.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0MSDeployUtility.ts
@@ -1,19 +1,7 @@
 import assert = require("assert");
-import sinon = require("sinon");
-import * as tl from "azure-pipelines-task-lib/task"; // Adjust the import path as needed
 import { getMSDeployCmdArgs, getWebDeployErrorCode } from "../msdeployutility";
 
 export function runGetMSDeployCmdArgsTests() {
-    let getPipelineFeatureStub: sinon.SinonStub;
-
-    before(() => {
-        getPipelineFeatureStub = sinon.stub(tl, "getPipelineFeature");
-        getPipelineFeatureStub.withArgs("CommaSeperatedConnectionString").returns(true); // or whatever value you want to mock
-    });
-
-    after(() => {
-        getPipelineFeatureStub.restore();
-    });
     it('Should produce default valid args', () => {
         const profile = createDefaultPublishProfile();
         const args = getMSDeployCmdArgs('package.zip', 'webapp_name', profile, true, false, true, null, null, null, true, false, false);
@@ -84,24 +72,14 @@ export function runGetMSDeployCmdArgsTests() {
 
         checkParametersIfPresent(args, ['-retryAttempts:11', '-retryInterval:5000']);
     });
-    it('Should CSstring encode correctly', () => {
+    it('Should encode connection strings correctly', () => {
         const profile = createDefaultPublishProfile();
-        tl.getPipelineFeature("CommaSeperatedConnectionString");
         const args = getMSDeployCmdArgs('package.zip', 'webapp_name', profile, false, true, true, null, null, '"-retryAttempts:11 -retryInterval:5000 -setParam:name=\'ConnectionString\',value=\'Encrypt=True;TrustServerCertificate=False;Data Source=some-sql-server.database.windows.net,1433;Initial Catalog=some-database;User Id=someuser;Password=somepassword;\'', false, false, true);
         checkParametersIfPresent(args, ['-retryAttempts:11', '-retryInterval:5000', '-setParam:name="\"ConnectionString\"",value="\"Encrypt=True;TrustServerCertificate=False;Data Source=some-sql-server.database.windows.net,1433;Initial Catalog=some-database;User Id=someuser;Password=somepassword;\""']);
         const CSstring = '-setParam:name="\\"ConnectionString\\"",value="\\"Encrypt=True;TrustServerCertificate=False;Data Source=some-sql-server.database.windows.net,1433;Initial Catalog=some-database;User Id=someuser;Password=somepassword;\\""';
         assert.ok(args.includes(CSstring));
     });
-    it('Should CSstring encode in-correctly', () => {
-        getPipelineFeatureStub.withArgs("CommaSeperatedConnectionString").returns(false);
-        const profile = createDefaultPublishProfile();
-        const args = getMSDeployCmdArgs('package.zip', 'webapp_name', profile, false, true, true, null, null, '"-retryAttempts:11 -retryInterval:5000 -setParam:name=\'ConnectionString\',value=\'Encrypt=True;TrustServerCertificate=False;Data Source=some-sql-server.database.windows.net,1433;Initial Catalog=some-database;User Id=someuser;Password=somepassword;\'', false, false, true);
-        const CSstring = '-setParam:name="ConnectionString",value="Encrypt=True;TrustServerCertificate=False;Data Source=some-sql-server.database.windows.net,1433;Initial Catalog=some-database;User Id=someuser;Password=somepassword;"';
-        assert.ok(!args.includes(CSstring));
-        checkParametersIfPresent(args, ['-retryAttempts:11', '-retryInterval:5000', '-setParam:name="\"ConnectionString\"",value="\"Encrypt=True;TrustServerCertificate=False;Data Source=some-sql-server.database.windows.net,1433;Initial Catalog=some-database;User Id=someuser;Password=somepassword;\""']);
-    });
     it('Should encrypt skip directives correctly', () => {
-        getPipelineFeatureStub.withArgs("CommaSeperatedConnectionString").returns(true);
         const profile = createDefaultPublishProfile();
         const args = getMSDeployCmdArgs('package.zip', 'webapp_name', profile, false, true, true, null, null, '-skip:objectName=filePath,absolutePath="\\web\.config"', false, false, true);
         const skipsubstring = '-skip:objectName=filePath,absolutePath="\\"\\web.config\\""';
@@ -109,7 +87,6 @@ export function runGetMSDeployCmdArgsTests() {
         assert.ok(args.includes(skipsubstring));
     });
     it('Should encrypt skip directives in-correctly', () => {
-        getPipelineFeatureStub.withArgs("CommaSeperatedConnectionString").returns(true);
         const profile = createDefaultPublishProfile();
         const args = getMSDeployCmdArgs('package.zip', 'webapp_name', profile, false, true, true, null, null, '"-retryAttempts:11 -retryInterval:5000 -setParam:name=\'ConnectionString\',value=\'Encrypt=True;TrustServerCertificate=False;Data Source=some-sql-server.database.windows.net,1433;Initial Catalog=some-database;User Id=someuser;Password=somepassword;\' -skip:objectName=filePath data source,absolutePath="\\web\.config"', false, false, true);
         assert.ok(!args.includes('-skip:objectName=filePath data source,absolutePath="\\web.config"'));

--- a/common-npm-packages/webdeployment-common/msdeployutility.ts
+++ b/common-npm-packages/webdeployment-common/msdeployutility.ts
@@ -113,7 +113,6 @@ export function getMSDeployCmdArgs(webAppPackage: string, webAppName: string, pr
 function escapeQuotes(additionalArguments: string): string {
     const parsedArgs = parseAdditionalArguments(additionalArguments);
     const separator = ",";
-    let commaSeperatedCSEnabled = tl.getPipelineFeature('CommaSeperatedConnectionString');
     const formattedArgs = parsedArgs.map(function (arg) {
         let formattedArg = '';
         let equalsSignEncountered = false;
@@ -121,10 +120,9 @@ function escapeQuotes(additionalArguments: string): string {
             const char = arg.charAt(i);
             var connectionStringCheck = new RegExp("\\bdata\\s*source\\s*=", "i");
             let quotedStringCheck = (char == separator && equalsSignEncountered && ((formattedArg.startsWith("'") && formattedArg.endsWith("'")) || (formattedArg.startsWith('"') && formattedArg.endsWith('"'))));
-            let commaSeperatorCheck = commaSeperatedCSEnabled && connectionStringCheck.test(formattedArg) ? quotedStringCheck : (char == separator && equalsSignEncountered);
+            let commaSeperatorCheck = connectionStringCheck.test(formattedArg) ? quotedStringCheck : (char == separator && equalsSignEncountered);
             if (commaSeperatorCheck) {
-                let commaSeperatedCSEnabledTelemetry = ' {"CommaSeperatedConnectionStringFeatureFlagEnabled":"' + commaSeperatedCSEnabled + '"connectionStringCheck":"' + connectionStringCheck.test(formattedArg) + '"}';
-                tl.debug("formattedArg : " + formattedArg + commaSeperatedCSEnabledTelemetry);
+                tl.debug("formattedArg : " + formattedArg + ' {"connectionStringCheck":"' + connectionStringCheck.test(formattedArg) + '"}');
                 equalsSignEncountered = false;
                 arg = arg.replace(formattedArg, escapeArg(formattedArg));
                 formattedArg = '';

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.274.1",
+    "version": "4.274.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-webdeployment-common",
-            "version": "4.274.1",
+            "version": "4.274.2",
             "license": "MIT",
             "dependencies": {
                 "@types/ltx": "3.0.6",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.274.1",
+    "version": "4.274.2",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Description

This PR removes the `CommaSeperatedConnectionString` feature flag from `webdeployment-common` and keeps the current connection-string escaping behavior as the default behavior.
WI: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2359077/
original WI: - [[BUG]: AzureRmWebAppDeployment@4: Comma in setParam argument causes incorrect encoding · Issue #207…](https://github.com/microsoft/azure-pipelines-tasks/issues/20743)

### Changes
- Removed feature flag lookup from [common-npm-packages/webdeployment-common/msdeployutility.ts](common-npm-packages/webdeployment-common/msdeployutility.ts)
- Made the current connection-string parsing and escaping path unconditional
- Simplified debug telemetry to remove feature-flag-specific logging
- Updated L0 tests in [common-npm-packages/webdeployment-common/Tests/L0MSDeployUtility.ts](common-npm-packages/webdeployment-common/Tests/L0MSDeployUtility.ts) to validate the permanent behavior and removed obsolete flag-dependent coverage
- Updated package version from `4.274.1` to `4.274.2` in [common-npm-packages/webdeployment-common/package.json](common-npm-packages/webdeployment-common/package.json) and [common-npm-packages/webdeployment-common/package-lock.json](common-npm-packages/webdeployment-common/package-lock.json)

### Risk
Low. The change is limited to `webdeployment-common` and removes a feature-flag branch while preserving the behavior that is already working and validated by the package-local test suite.

### Validation
- Built `webdeployment-common` with `npm run build`
- Ran package-local tests with `npm test`
- Result: `35 passing`

### Notes
- A repo-root test invocation is noisy in this environment because it pulls in unrelated package prerequisites, so validation was performed with the package-local build and test commands for `webdeployment-common`