### PR TITLE
Sanitize Docker output to prevent ##vso[] logging-command injection

### DIFF
--- a/common-npm-packages/docker-common/Tests/L0.ts
+++ b/common-npm-packages/docker-common/Tests/L0.ts
@@ -1,0 +1,5 @@
+import { runDockerCommandSanitizationTests } from './dockerOutputSanitizationTests';
+
+describe('docker-common suite', () => {
+    describe('Docker command output sanitization', runDockerCommandSanitizationTests);
+});

--- a/common-npm-packages/docker-common/Tests/dockerOutputSanitizationTests.ts
+++ b/common-npm-packages/docker-common/Tests/dockerOutputSanitizationTests.ts
@@ -1,0 +1,309 @@
+import assert = require("assert");
+import { EventEmitter } from "events";
+import { Writable } from "stream";
+
+// Set environment variables required by azure-pipelines-task-lib before importing dockerCommandUtils
+process.env['INPUT_BUILDCONTEXT'] = '/tmp/build';
+process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] = '/tmp/work';
+
+import * as dockerCommandUtils from "../dockercommandutils";
+
+/**
+ * Minimal mock for ToolRunner that simulates Docker command execution.
+ * When exec() is called, it emits stdout/stderr data and writes to the
+ * provided outStream/errStream options, mimicking real ToolRunner behavior.
+ */
+class MockToolRunner extends EventEmitter {
+    public simulatedStdout: string = "";
+    public simulatedStderr: string = "";
+
+    arg(_val: string | string[]): void { }
+    line(_val: string): void { }
+
+    exec(options?: any): Promise<void> {
+        if (this.simulatedStdout) {
+            this.emit("stdout", this.simulatedStdout);
+        }
+        if (this.simulatedStderr) {
+            this.emit("stderr", this.simulatedStderr);
+        }
+
+        return new Promise<void>((resolve) => {
+            const writes: Promise<void>[] = [];
+
+            if (this.simulatedStdout && options && options.outStream) {
+                writes.push(new Promise<void>((res) => {
+                    options.outStream.write(this.simulatedStdout, 'utf8', () => res());
+                }));
+            }
+            if (this.simulatedStderr && options && options.errStream) {
+                writes.push(new Promise<void>((res) => {
+                    options.errStream.write(this.simulatedStderr, 'utf8', () => res());
+                }));
+            }
+
+            Promise.all(writes).then(() => resolve());
+        });
+    }
+}
+
+/**
+ * Mock ContainerConnection that uses MockToolRunner.
+ * Captures exec options and intercepts what the sanitized outStream/errStream
+ * writes to process.stdout/stderr during exec.
+ */
+class MockContainerConnection {
+    public lastExecOptions: any = null;
+    public mockToolRunner: MockToolRunner;
+    public stdoutWritten: string = "";
+    public stderrWritten: string = "";
+
+    constructor(simulatedStdout: string = "", simulatedStderr: string = "") {
+        this.mockToolRunner = new MockToolRunner();
+        this.mockToolRunner.simulatedStdout = simulatedStdout;
+        this.mockToolRunner.simulatedStderr = simulatedStderr;
+    }
+
+    createCommand(): MockToolRunner {
+        return this.mockToolRunner;
+    }
+
+    execCommand(command: MockToolRunner, options?: any): Promise<void> {
+        this.lastExecOptions = options;
+
+        // Intercept process.stdout/stderr ONLY during exec to capture what
+        // the sanitized stream writes (avoids capturing task-lib debug output)
+        const origStdout = process.stdout.write;
+        const origStderr = process.stderr.write;
+        const self = this;
+
+        process.stdout.write = function (chunk: any, encodingOrCb?: any, cb?: any): boolean {
+            self.stdoutWritten += typeof chunk === 'string' ? chunk : chunk.toString();
+            const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb;
+            if (typeof callback === 'function') callback();
+            return true;
+        } as any;
+
+        process.stderr.write = function (chunk: any, encodingOrCb?: any, cb?: any): boolean {
+            self.stderrWritten += typeof chunk === 'string' ? chunk : chunk.toString();
+            const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb;
+            if (typeof callback === 'function') callback();
+            return true;
+        } as any;
+
+        return command.exec(options).then(() => {
+            process.stdout.write = origStdout;
+            process.stderr.write = origStderr;
+        }).catch((err) => {
+            process.stdout.write = origStdout;
+            process.stderr.write = origStderr;
+            throw err;
+        });
+    }
+}
+
+export function runDockerCommandSanitizationTests() {
+
+    describe('build()', () => {
+
+        it('Should pass outStream and errStream options to execCommand', (done) => {
+            const connection = new MockContainerConnection("output");
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"], (_output) => {}
+            ).then(() => {
+                assert.ok(connection.lastExecOptions, "execCommand should receive options");
+                assert.ok(connection.lastExecOptions.outStream, "options should have outStream");
+                assert.ok(connection.lastExecOptions.errStream, "options should have errStream");
+                done();
+            }).catch(done);
+        });
+
+        it('Should not use raw process.stdout as outStream', (done) => {
+            const connection = new MockContainerConnection("output");
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"], (_output) => {}
+            ).then(() => {
+                assert.notStrictEqual(connection.lastExecOptions.outStream, process.stdout,
+                    "outStream must be a sanitizing wrapper, not raw process.stdout");
+                assert.notStrictEqual(connection.lastExecOptions.errStream, process.stderr,
+                    "errStream must be a sanitizing wrapper, not raw process.stderr");
+                done();
+            }).catch(done);
+        });
+
+        it('Should sanitize ##vso[task.prependpath] in stdout', (done) => {
+            const connection = new MockContainerConnection("##vso[task.prependpath]/tmp/pwned");
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"], (_output) => {}
+            ).then(() => {
+                assert.ok(!connection.stdoutWritten.includes("##vso["),
+                    "##vso[ should be sanitized before reaching process.stdout");
+                assert.ok(connection.stdoutWritten.includes("#vso[task.prependpath]"),
+                    "Sanitized text should still be readable");
+                done();
+            }).catch(done);
+        });
+
+        it('Should sanitize ##vso[ on stderr (BuildKit scenario)', (done) => {
+            const connection = new MockContainerConnection("", "##vso[task.setvariable variable=x]y");
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"], (_output) => {}
+            ).then(() => {
+                assert.ok(!connection.stderrWritten.includes("##vso["),
+                    "##vso[ should be sanitized on stderr too");
+                assert.ok(connection.stderrWritten.includes("#vso[task.setvariable"),
+                    "Sanitized command should still appear in stderr");
+                done();
+            }).catch(done);
+        });
+
+        it('Should still provide raw output to the callback for internal parsing', (done) => {
+            const maliciousOutput = '##vso[task.prependpath]/tmp/pwned';
+            const connection = new MockContainerConnection(maliciousOutput);
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"],
+                (output) => {
+                    assert.ok(output.includes("##vso[task.prependpath]"),
+                        "Raw callback should receive unsanitized data for image ID extraction");
+                }
+            ).then(() => {
+                done();
+            }).catch(done);
+        });
+
+        it('Should not modify clean Docker build output', (done) => {
+            const cleanOutput = 'Successfully built abc123\nSuccessfully tagged test:latest';
+            const connection = new MockContainerConnection(cleanOutput);
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"], (_output) => {}
+            ).then(() => {
+                assert.strictEqual(connection.stdoutWritten, cleanOutput,
+                    "Clean output should pass through unmodified");
+                done();
+            }).catch(done);
+        });
+
+        it('Should handle case-insensitive ##VSO[ variants', (done) => {
+            const connection = new MockContainerConnection("##VSO[task.prependpath]/tmp/pwned");
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"], (_output) => {}
+            ).then(() => {
+                assert.ok(!connection.stdoutWritten.includes("##VSO["),
+                    "Case-insensitive ##VSO[ should be sanitized");
+                done();
+            }).catch(done);
+        });
+
+        it('Should sanitize multiple ##vso[ commands in one output chunk', (done) => {
+            const multiCommand = '##vso[task.prependpath]/a\nnormal line\n##vso[task.setvariable variable=x]y';
+            const connection = new MockContainerConnection(multiCommand);
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"], (_output) => {}
+            ).then(() => {
+                assert.ok(!connection.stdoutWritten.includes("##vso["),
+                    "All ##vso[ instances should be sanitized");
+                assert.ok(connection.stdoutWritten.includes("normal line"),
+                    "Non-malicious output should be preserved");
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('command()', () => {
+
+        it('Should sanitize ##vso[ commands in stdout', (done) => {
+            const connection = new MockContainerConnection("##vso[task.prependpath]/tmp/pwned");
+
+            dockerCommandUtils.command(
+                connection as any, "run", "malicious-image", (_output) => {}
+            ).then(() => {
+                assert.ok(!connection.stdoutWritten.includes("##vso["),
+                    "stdout should be sanitized");
+                done();
+            }).catch(done);
+        });
+
+        it('Should still provide raw output to the callback', (done) => {
+            const maliciousOutput = '##vso[task.setvariable variable=SECRET]stolen';
+            const connection = new MockContainerConnection(maliciousOutput);
+
+            dockerCommandUtils.command(
+                connection as any, "run", "image",
+                (output) => {
+                    assert.ok(output.includes("##vso[task.setvariable"),
+                        "Raw callback should receive unsanitized data");
+                }
+            ).then(() => {
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('push()', () => {
+
+        it('Should sanitize ##vso[ commands in stdout', (done) => {
+            const connection = new MockContainerConnection("##vso[task.prependpath]/tmp/evil");
+
+            dockerCommandUtils.push(
+                connection as any, "myimage:latest", "", (_image, _output) => {}
+            ).then(() => {
+                assert.ok(!connection.stdoutWritten.includes("##vso["),
+                    "stdout should be sanitized");
+                done();
+            }).catch(done);
+        });
+
+        it('Should still provide raw output to the callback', (done) => {
+            const maliciousOutput = '##vso[task.prependpath]/tmp/evil';
+            const connection = new MockContainerConnection(maliciousOutput);
+
+            dockerCommandUtils.push(
+                connection as any, "myimage:latest", "",
+                (_image, output) => {
+                    assert.ok(output.includes("##vso[task.prependpath]"),
+                        "Raw callback should receive unsanitized data");
+                }
+            ).then(() => {
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('start()', () => {
+
+        it('Should sanitize ##vso[ commands in stdout', (done) => {
+            const connection = new MockContainerConnection("##vso[task.prependpath]/tmp/evil");
+
+            dockerCommandUtils.start(
+                connection as any, "container-1", "", (_container, _output) => {}
+            ).then(() => {
+                assert.ok(!connection.stdoutWritten.includes("##vso["),
+                    "stdout should be sanitized");
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('stop()', () => {
+
+        it('Should sanitize ##vso[ commands in stdout', (done) => {
+            const connection = new MockContainerConnection("##vso[task.prependpath]/tmp/evil");
+
+            dockerCommandUtils.stop(
+                connection as any, "container-1", "", (_container, _output) => {}
+            ).then(() => {
+                assert.ok(!connection.stdoutWritten.includes("##vso["),
+                    "stdout should be sanitized");
+                done();
+            }).catch(done);
+        });
+    });
+}

--- a/common-npm-packages/docker-common/Tests/dockerOutputSanitizationTests.ts
+++ b/common-npm-packages/docker-common/Tests/dockerOutputSanitizationTests.ts
@@ -16,6 +16,8 @@ import * as dockerCommandUtils from "../dockercommandutils";
 class MockToolRunner extends EventEmitter {
     public simulatedStdout: string = "";
     public simulatedStderr: string = "";
+    /** When set, stdout is written as separate chunks instead of a single write. */
+    public simulatedStdoutChunks: string[] = null;
 
     arg(_val: string | string[]): void { }
     line(_val: string): void { }
@@ -31,7 +33,16 @@ class MockToolRunner extends EventEmitter {
         return new Promise<void>((resolve) => {
             const writes: Promise<void>[] = [];
 
-            if (this.simulatedStdout && options && options.outStream) {
+            if (this.simulatedStdoutChunks && options && options.outStream) {
+                // Write as multiple chunks to simulate pipe buffer splits
+                let chain = Promise.resolve();
+                for (const chunk of this.simulatedStdoutChunks) {
+                    chain = chain.then(() => new Promise<void>((res) => {
+                        options.outStream.write(chunk, 'utf8', () => res());
+                    }));
+                }
+                writes.push(chain);
+            } else if (this.simulatedStdout && options && options.outStream) {
                 writes.push(new Promise<void>((res) => {
                     options.outStream.write(this.simulatedStdout, 'utf8', () => res());
                 }));
@@ -42,7 +53,14 @@ class MockToolRunner extends EventEmitter {
                 }));
             }
 
-            Promise.all(writes).then(() => resolve());
+            Promise.all(writes).then(() => {
+                // Signal end to flush any stateful carry-over in the sanitized stream
+                if (options && options.outStream && typeof options.outStream.end === 'function') {
+                    options.outStream.end(() => resolve());
+                } else {
+                    resolve();
+                }
+            });
         });
     }
 }
@@ -302,6 +320,95 @@ export function runDockerCommandSanitizationTests() {
             ).then(() => {
                 assert.ok(!connection.stdoutWritten.includes("##vso["),
                     "stdout should be sanitized");
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('chunk-split bypass prevention', () => {
+
+        it('Should sanitize ##vso[ split across two chunks: "##vs" + "o[..."', (done) => {
+            const connection = new MockContainerConnection();
+            connection.mockToolRunner.simulatedStdoutChunks = [
+                "some output ##vs",
+                "o[task.prependpath]/tmp/pwned\n"
+            ];
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"], (_output) => {}
+            ).then(() => {
+                assert.ok(!connection.stdoutWritten.includes("##vso["),
+                    "##vso[ split across chunks should still be sanitized");
+                assert.ok(connection.stdoutWritten.includes("#vso[task.prependpath]"),
+                    "Sanitized marker should be present");
+                done();
+            }).catch(done);
+        });
+
+        it('Should sanitize ##vso[ split as "##" + "vso[..."', (done) => {
+            const connection = new MockContainerConnection();
+            connection.mockToolRunner.simulatedStdoutChunks = [
+                "##",
+                "vso[task.setvariable variable=x]y"
+            ];
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"], (_output) => {}
+            ).then(() => {
+                assert.ok(!connection.stdoutWritten.includes("##vso["),
+                    "##vso[ split as ## + vso[ should be sanitized");
+                done();
+            }).catch(done);
+        });
+
+        it('Should sanitize ##vso[ split as "####vs" + "o[..." (marker after partial)', (done) => {
+            const connection = new MockContainerConnection();
+            connection.mockToolRunner.simulatedStdoutChunks = [
+                "####vs",
+                "o[task.prependpath]/tmp/pwned"
+            ];
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"], (_output) => {}
+            ).then(() => {
+                assert.ok(!connection.stdoutWritten.includes("##vso["),
+                    "##vso[ preceded by extra # chars and split should be sanitized");
+                done();
+            }).catch(done);
+        });
+
+        it('Should handle three-way chunk split: "#" + "#vso" + "[..."', (done) => {
+            const connection = new MockContainerConnection();
+            connection.mockToolRunner.simulatedStdoutChunks = [
+                "#",
+                "#vso",
+                "[task.prependpath]/tmp/pwned"
+            ];
+
+            dockerCommandUtils.build(
+                connection as any, "Dockerfile", "", [], ["test:latest"], (_output) => {}
+            ).then(() => {
+                assert.ok(!connection.stdoutWritten.includes("##vso["),
+                    "##vso[ split across three chunks should be sanitized");
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('getHistory()', () => {
+
+        it('Should pass sanitized exec options to execCommand', (done) => {
+            const maliciousHistory = 'createdAt:2024-01-01; layerSize:0B; createdBy:##vso[task.prependpath]/tmp/pwned; layerId:sha256:abc';
+            const connection = new MockContainerConnection(maliciousHistory);
+
+            dockerCommandUtils.getHistory(
+                connection as any, "myimage:latest"
+            ).then(() => {
+                assert.ok(connection.lastExecOptions, "execCommand should receive options");
+                assert.ok(connection.lastExecOptions.outStream, "options should have outStream");
+                assert.ok(connection.lastExecOptions.errStream, "options should have errStream");
+                assert.ok(!connection.stdoutWritten.includes("##vso["),
+                    "getHistory stdout should be sanitized");
                 done();
             }).catch(done);
         });

--- a/common-npm-packages/docker-common/dockercommandutils.ts
+++ b/common-npm-packages/docker-common/dockercommandutils.ts
@@ -6,6 +6,7 @@ import ContainerConnection from "./containerconnection";
 import * as pipelineUtils from "./pipelineutils";
 import * as path from "path";
 import * as crypto from "crypto";
+import { Writable } from "stream";
 
 const matchPatternForSize = new RegExp(/[\d\.]+/);
 const orgUrl = tl.getVariable('System.TeamFoundationCollectionUri');
@@ -43,7 +44,9 @@ export function build(connection: ContainerConnection, dockerFile: string, comma
         output += data;
     });
 
-    return connection.execCommand(command).then(() => {
+    // Use a sanitized output stream so that ##vso[] commands embedded in Docker
+    // build output cannot be interpreted by the agent (CVE fix for logging-command injection).
+    return connection.execCommand(command, sanitizedExecOptions).then(() => {
         // Return the std output of the command by calling the delegate
         onCommandOut(output);
     });
@@ -60,7 +63,8 @@ export function command(connection: ContainerConnection, dockerCommand: string, 
         output += data;
     });
 
-    return connection.execCommand(command).then(() => {
+    // Use a sanitized output stream to prevent logging-command injection.
+    return connection.execCommand(command, sanitizedExecOptions).then(() => {
         // Return the std output of the command by calling the delegate
         onCommandOut(output);
     });
@@ -78,7 +82,8 @@ export function push(connection: ContainerConnection, image: string, commandArgu
         output += data;
     });
 
-    return connection.execCommand(command).then(() => {
+    // Use a sanitized output stream to prevent logging-command injection.
+    return connection.execCommand(command, sanitizedExecOptions).then(() => {
         // Return the std output of the command by calling the delegate
         onCommandOut(image, output + "\n");
     });
@@ -96,7 +101,8 @@ export function start(connection: ContainerConnection, container: string, comman
         output += data;
     });
 
-    return connection.execCommand(command).then(() => {
+    // Use a sanitized output stream to prevent logging-command injection.
+    return connection.execCommand(command, sanitizedExecOptions).then(() => {
         // Return the std output of the command by calling the delegate
         onCommandOut(container, output + "\n");
     });
@@ -114,7 +120,8 @@ export function stop(connection: ContainerConnection, container: string, command
         output += data;
     });
 
-    return connection.execCommand(command).then(() => {
+    // Use a sanitized output stream to prevent logging-command injection.
+    return connection.execCommand(command, sanitizedExecOptions).then(() => {
         // Return the std output of the command by calling the delegate
         onCommandOut(container, output + "\n");
     });
@@ -432,3 +439,41 @@ function isBuildKitBuild(): boolean {
     const isBuildKitBuildValue = tl.getVariable("DOCKER_BUILDKIT");
     return isBuildKitBuildValue && Number(isBuildKitBuildValue) == 1;
 }
+
+// Matches ##vso[ at the start of a line (the prefix the agent uses to detect logging commands).
+// Case-insensitive because the agent accepts any casing.
+const vsoCommandPattern = /##vso\[/gi;
+
+/**
+ * Strips ##vso[ command prefixes from Docker output so that the Azure Pipelines
+ * agent does not interpret attacker-controlled Docker build output as logging
+ * commands (e.g. task.prependpath, task.setvariable).
+ *
+ * The replacement preserves the text for human readability while making it
+ * invisible to the agent's command parser.
+ */
+function sanitizeDockerOutput(data: string): string {
+    return data.replace(vsoCommandPattern, "#vso[");
+}
+
+/**
+ * Creates a Writable stream that sanitizes ##vso[] commands before forwarding
+ * data to the given destination stream. Used as the outStream / errStream option
+ * for ToolRunner.exec() so that Docker output is still visible in the build log
+ * but cannot inject agent commands.
+ */
+function createSanitizedOutputStream(destination: NodeJS.WritableStream): NodeJS.WritableStream {
+    return new Writable({
+        write(chunk: Buffer | string, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+            const text = chunk.toString();
+            const sanitized = sanitizeDockerOutput(text);
+            destination.write(sanitized, 'utf8', callback);
+        }
+    });
+}
+
+// Exec options shared by all docker command functions to prevent logging-command injection.
+const sanitizedExecOptions = {
+    outStream: createSanitizedOutputStream(process.stdout),
+    errStream: createSanitizedOutputStream(process.stderr)
+};

--- a/common-npm-packages/docker-common/dockercommandutils.ts
+++ b/common-npm-packages/docker-common/dockercommandutils.ts
@@ -7,6 +7,7 @@ import * as pipelineUtils from "./pipelineutils";
 import * as path from "path";
 import * as crypto from "crypto";
 import { Writable } from "stream";
+import { StringDecoder } from "string_decoder";
 
 const matchPatternForSize = new RegExp(/[\d\.]+/);
 const orgUrl = tl.getVariable('System.TeamFoundationCollectionUri');
@@ -46,7 +47,7 @@ export function build(connection: ContainerConnection, dockerFile: string, comma
 
     // Use a sanitized output stream so that ##vso[] commands embedded in Docker
     // build output cannot be interpreted by the agent (CVE fix for logging-command injection).
-    return connection.execCommand(command, sanitizedExecOptions).then(() => {
+    return connection.execCommand(command, createSanitizedExecOptions()).then(() => {
         // Return the std output of the command by calling the delegate
         onCommandOut(output);
     });
@@ -64,7 +65,7 @@ export function command(connection: ContainerConnection, dockerCommand: string, 
     });
 
     // Use a sanitized output stream to prevent logging-command injection.
-    return connection.execCommand(command, sanitizedExecOptions).then(() => {
+    return connection.execCommand(command, createSanitizedExecOptions()).then(() => {
         // Return the std output of the command by calling the delegate
         onCommandOut(output);
     });
@@ -83,7 +84,7 @@ export function push(connection: ContainerConnection, image: string, commandArgu
     });
 
     // Use a sanitized output stream to prevent logging-command injection.
-    return connection.execCommand(command, sanitizedExecOptions).then(() => {
+    return connection.execCommand(command, createSanitizedExecOptions()).then(() => {
         // Return the std output of the command by calling the delegate
         onCommandOut(image, output + "\n");
     });
@@ -102,7 +103,7 @@ export function start(connection: ContainerConnection, container: string, comman
     });
 
     // Use a sanitized output stream to prevent logging-command injection.
-    return connection.execCommand(command, sanitizedExecOptions).then(() => {
+    return connection.execCommand(command, createSanitizedExecOptions()).then(() => {
         // Return the std output of the command by calling the delegate
         onCommandOut(container, output + "\n");
     });
@@ -121,7 +122,7 @@ export function stop(connection: ContainerConnection, container: string, command
     });
 
     // Use a sanitized output stream to prevent logging-command injection.
-    return connection.execCommand(command, sanitizedExecOptions).then(() => {
+    return connection.execCommand(command, createSanitizedExecOptions()).then(() => {
         // Return the std output of the command by calling the delegate
         onCommandOut(container, output + "\n");
     });
@@ -341,7 +342,7 @@ export async function getHistory(connection: ContainerConnection, image: string)
     });
 
     try {
-        connection.execCommand(command).then(() => {
+        connection.execCommand(command, createSanitizedExecOptions()).then(() => {
             defer.resolve();
         });
     }
@@ -440,9 +441,19 @@ function isBuildKitBuild(): boolean {
     return isBuildKitBuildValue && Number(isBuildKitBuildValue) == 1;
 }
 
-// Matches ##vso[ at the start of a line (the prefix the agent uses to detect logging commands).
+// Matches one or more # followed by vso[ — the prefix the Azure Pipelines agent
+// uses to detect logging commands.  We match #+  (not just ##) so that inputs
+// like "####vso[" are fully neutralised in a single pass rather than leaving a
+// residual "##vso[" after replacing the inner match.
 // Case-insensitive because the agent accepts any casing.
-const vsoCommandPattern = /##vso\[/gi;
+const vsoCommandPattern = /#+vso\[/gi;
+
+// Regex that matches a trailing suffix which could be the START of a #+vso[
+// sequence split across chunks.  We carry over:
+//   - any run of # characters at the end, and
+//   - an optional partial "v", "vs", or "vso" after the hashes.
+// Case-insensitive to mirror vsoCommandPattern.
+const trailingPartialMarker = /#+(?:v(?:s(?:o)?)?)?$/i;
 
 /**
  * Strips ##vso[ command prefixes from Docker output so that the Azure Pipelines
@@ -461,19 +472,54 @@ function sanitizeDockerOutput(data: string): string {
  * data to the given destination stream. Used as the outStream / errStream option
  * for ToolRunner.exec() so that Docker output is still visible in the build log
  * but cannot inject agent commands.
+ *
+ * The stream is stateful: it carries over any trailing characters that could be
+ * the start of a #+vso[ token split across pipe-buffer chunks.  A StringDecoder
+ * is used to avoid mojibake when a multibyte UTF-8 sequence is split across
+ * chunk boundaries.
  */
 function createSanitizedOutputStream(destination: NodeJS.WritableStream): NodeJS.WritableStream {
+    const decoder = new StringDecoder('utf8');
+    let pending = "";
+
     return new Writable({
-        write(chunk: Buffer | string, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
-            const text = chunk.toString();
-            const sanitized = sanitizeDockerOutput(text);
-            destination.write(sanitized, 'utf8', callback);
+        write(chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+            // Decode safely (handles split multibyte sequences)
+            const text = typeof chunk === 'string' ? chunk : decoder.write(chunk);
+            pending += text;
+
+            // Keep any trailing characters that could be the start of #+vso[
+            // so we can detect the marker even when it spans chunks.
+            const tailMatch = trailingPartialMarker.exec(pending);
+            const safeEnd = tailMatch ? tailMatch.index : pending.length;
+
+            const toWrite = pending.substring(0, safeEnd);
+            pending = pending.substring(safeEnd);
+
+            if (toWrite) {
+                destination.write(sanitizeDockerOutput(toWrite), 'utf8', callback);
+            } else {
+                callback();
+            }
+        },
+        final(callback: (error?: Error | null) => void): void {
+            // Flush any remaining pending bytes (including decoder remainder)
+            pending += decoder.end();
+            if (pending) {
+                destination.write(sanitizeDockerOutput(pending), 'utf8', callback);
+            } else {
+                callback();
+            }
         }
     });
 }
 
-// Exec options shared by all docker command functions to prevent logging-command injection.
-const sanitizedExecOptions = {
-    outStream: createSanitizedOutputStream(process.stdout),
-    errStream: createSanitizedOutputStream(process.stderr)
-};
+// Creates fresh exec options for each docker command invocation.
+// Each call returns new stream instances so that stateful carry-over buffers
+// don't leak across commands and streams can be properly ended.
+function createSanitizedExecOptions(): { outStream: NodeJS.WritableStream; errStream: NodeJS.WritableStream } {
+    return {
+        outStream: createSanitizedOutputStream(process.stdout),
+        errStream: createSanitizedOutputStream(process.stderr)
+    };
+}

--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.274.0",
+    "version": "2.276.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.274.0",
+            "version": "2.276.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",
@@ -19,6 +19,7 @@
                 "q": "1.4.1"
             },
             "devDependencies": {
+                "mocha": "^11.7.5",
                 "typescript": "^4.9.5"
             }
         },
@@ -207,6 +208,109 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -240,6 +344,17 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@types/jsonwebtoken": {
@@ -319,6 +434,39 @@
             "engines": {
                 "node": ">= 14"
             }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
+            "dev": true,
+            "license": "Python-2.0"
         },
         "node_modules/array-union": {
             "version": "1.0.2",
@@ -478,6 +626,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -528,6 +683,100 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha1-e+N6TAPJruHs/oYqSiOyxwwgXTA=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
@@ -563,6 +812,19 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/decamelize": {
+            "version": "4.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/default-browser": {
@@ -633,6 +895,16 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
+        "node_modules/diff": {
+            "version": "7.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/diff/-/diff-7.0.0.tgz",
+            "integrity": "sha1-P7NNOHzXbYA/buvqZ7kh2rAYKpo=",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -647,6 +919,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -655,6 +934,13 @@
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
@@ -684,6 +970,29 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/execa": {
@@ -746,6 +1055,33 @@
                 "node": ">=8"
             }
         },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/flat": {
+            "version": "5.0.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE=",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "bin": {
+                "flat": "cli.js"
+            }
+        },
         "node_modules/follow-redirects": {
             "version": "1.16.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
@@ -766,6 +1102,36 @@
                 }
             }
         },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -779,6 +1145,16 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
             }
         },
         "node_modules/get-intrinsic": {
@@ -888,6 +1264,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/has-symbols": {
             "version": "1.1.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -910,6 +1296,16 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/he/-/he-1.2.0.tgz",
+            "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "he": "bin/he"
             }
         },
         "node_modules/http-proxy-agent": {
@@ -997,6 +1393,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
@@ -1069,6 +1475,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-plain-obj": {
+            "version": "2.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-stream": {
             "version": "2.0.1",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
@@ -1076,6 +1492,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -1102,11 +1531,50 @@
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "license": "ISC"
         },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha1-iDOp2Jq0rN5hiJQr0cU7Y5DtWoo=",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
         "node_modules/js-md4": {
             "version": "0.3.2",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
             "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
             "license": "MIT"
+        },
+        "node_modules/js-yaml": {
+            "version": "4.2.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha1-K9noVoLdkb1GmvuAnYFgQ7PUlSQ=",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
         },
         "node_modules/jsonwebtoken": {
             "version": "9.0.3",
@@ -1163,6 +1631,22 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1204,6 +1688,30 @@
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
             "license": "MIT"
+        },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
@@ -1288,6 +1796,110 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/mocha": {
+            "version": "11.7.6",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mocha/-/mocha-11.7.6.tgz",
+            "integrity": "sha1-674imJ0Ey7lCSjYwcyBHZiTEGjM=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browser-stdout": "^1.3.1",
+                "chokidar": "^4.0.1",
+                "debug": "^4.3.5",
+                "diff": "^7.0.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-up": "^5.0.0",
+                "glob": "^10.4.5",
+                "he": "^1.2.0",
+                "is-path-inside": "^3.0.3",
+                "js-yaml": "^4.1.0",
+                "log-symbols": "^4.1.0",
+                "minimatch": "^9.0.5",
+                "ms": "^2.1.3",
+                "picocolors": "^1.1.1",
+                "serialize-javascript": "^6.0.2",
+                "strip-json-comments": "^3.1.1",
+                "supports-color": "^8.1.1",
+                "workerpool": "^9.2.0",
+                "yargs": "^17.7.2",
+                "yargs-parser": "^21.1.1",
+                "yargs-unparser": "^2.0.0"
+            },
+            "bin": {
+                "_mocha": "bin/_mocha",
+                "mocha": "bin/mocha.js"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/mocha/node_modules/brace-expansion": {
+            "version": "2.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha1-xoscQRHHaq46b7pV1JbO4Qw52tg=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/mocha/node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mocha/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/ms": {
@@ -1519,6 +2131,55 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1542,6 +2203,30 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha1-eWCmaIiFlKByCxKpEdGnQqufEdI=",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.2",
@@ -1630,6 +2315,40 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "4.1.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha1-64WAFDX78qfuWPGeCSGwaPxplI0=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/reusify": {
             "version": "1.1.0",
@@ -1754,6 +2473,16 @@
                 "semver": "bin/semver"
             }
         },
+        "node_modules/serialize-javascript": {
+            "version": "6.0.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha1-3voeBVyDv21Z6oBdjahiJU62psI=",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -1866,6 +2595,64 @@
             "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
             "license": "ISC"
         },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -1873,6 +2660,35 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/to-regex-range": {
@@ -2000,6 +2816,50 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/workerpool": {
+            "version": "9.3.4",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/workerpool/-/workerpool-9.3.4.tgz",
+            "integrity": "sha1-9skjlbIUGv144qiJ6AyzOP6fykE=",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
@@ -2041,6 +2901,74 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4.0"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha1-mR3zmspnWhkrgW4eA2P5110qomk=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-unparser": {
+            "version": "2.0.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         }
     }

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.274.0",
+    "version": "2.276.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",
@@ -24,9 +24,11 @@
         "q": "1.4.1"
     },
     "devDependencies": {
+        "mocha": "^11.7.5",
         "typescript": "^4.9.5"
     },
     "scripts": {
-        "build": "cd ../build-scripts && npm install && cd ../docker-common && node make.js"
+        "build": "cd ../build-scripts && npm install && cd ../docker-common && node make.js",
+        "test": "npm run build && mocha _build/Tests/L0.js"
     }
 }


### PR DESCRIPTION
### **Description**

**Security fix: Logging-command injection via Docker task output (MSRC Case 122404 / VULN-195611)**

AB#2378653

The Azure Pipelines Docker tasks (`Docker@2`, `ContainerBuild@0`) stream child process stdout/stderr directly to the agent via `ToolRunner.exec()`. The agent scans everything written to process.stdout for `##vso[]` prefixes and interprets them as logging commands. An attacker with queue-builds permission can craft a Dockerfile that emits `##vso[task.prependpath]` (or `task.setvariable`, etc.) via `RUN echo`, hijacking the PATH or injecting variables for subsequent pipeline steps — achieving arbitrary code execution.

**Fix:** Wrap `outStream`/`errStream` passed to `ToolRunner.exec()` with a sanitizing `Writable` stream that replaces `##vso[` with `#vso[` (case-insensitive) before the agent sees it. The raw output is still available via the `stdout`/`stderr` event listeners for internal parsing (image ID extraction, digest capture, etc.).

**Impact:** All 5 public command functions (`build`, `command`, `push`, `start`, `stop`) now use sanitized exec options. Existing behavior is preserved — only the agent-visible output is neutered.

---

### **Package Name**

`azure-pipelines-tasks-docker-common`

---

### **Risk Assessment** (Low / Medium / High)

**Low**

- The fix is additive — it wraps the output stream without changing any command logic or argument handling.
- The sanitization only affects what the agent sees on stdout/stderr; internal output callbacks still receive raw data for parsing (image IDs, digests).
- The replacement (`##vso[` → `#vso[`) is safe — legitimate pipeline logging commands are never emitted by Docker itself.
- Backward compatible: no API changes, no new dependencies beyond `mocha` (devDependency for tests).

---

### **Unit Tests Added or Updated**

- [x] Unit tests added or updated
- [x] Manual tests performed

14 new unit tests covering all 5 public functions:
- Verifies `outStream`/`errStream` options are provided and are NOT raw `process.stdout`/`process.stderr`
- Verifies `##vso[task.prependpath]` is sanitized in stdout
- Verifies `##vso[task.setvariable]` is sanitized in stderr (BuildKit scenario)
- Verifies raw output callback still receives unsanitized data (for image ID extraction)
- Verifies clean Docker output passes through unmodified
- Verifies case-insensitive variants (`##VSO[`) are caught
- Verifies multiple `##vso[` commands in a single chunk are all sanitized

---

### **Additional Testing Performed**

End-to-end validation in `onetocny-corp` Azure DevOps organization:

1. **Reproduced the vulnerability** — Created a pipeline with a Dockerfile containing `RUN echo "##vso[task.prependpath]/tmp/pwned"`. Confirmed `/tmp/pwned` appeared in PATH of subsequent steps.

2. **Validated Docker@2 fix** — Built the task with the patched `docker-common` package (via `npm pack` + local `.tgz` reference per wiki process), uploaded to org via `tfx`, reran pipeline → `PATH is clean — injection was blocked.` ✅

3. **Validated ContainerBuild@0 fix** — Same process for the only other affected task → `PATH is clean - injection was blocked.` ✅

Pipeline runs: Docker2-Injection-Repro (run 32), ContainerBuild0-Injection-Repro (run 33) in `onetocny-corp/playground`.

---

### **Documentation Changes Required** (Yes / No)

No — this is an internal implementation change with no public API surface modifications.

---

### **Dependencies**

- `mocha` `^11.7.5` added as a **devDependency** (for unit test execution only, not shipped with the package)

---

### **Checklist**

- [x] Related issue linked (if applicable)
- [x] Package version was bumped — see [versioning guide](https://semver.org/)
- [x] Verified the package behaves as expected
- [x] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)
