### PR TITLE
Bump artifacts-common and az-blobstorage-provider versions to remediate dependency vulnerabilities

### DIFF
--- a/common-npm-packages/artifacts-common/package-lock.json
+++ b/common-npm-packages/artifacts-common/package-lock.json
@@ -1,25 +1,25 @@
 {
     "name": "azure-pipelines-tasks-artifacts-common",
-    "version": "2.273.0",
+    "version": "2.276.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-artifacts-common",
-            "version": "2.273.0",
+            "version": "2.276.0",
             "license": "MIT",
             "dependencies": {
                 "@types/fs-extra": "8.0.0",
                 "@types/mocha": "^5.2.6",
                 "@types/node": "^16.11.39",
                 "azure-devops-node-api": "^15.1.3",
-                "azure-pipelines-task-lib": "^5.2.8",
+                "azure-pipelines-task-lib": "^5.2.11",
                 "fs-extra": "8.1.0",
                 "node-fetch": "^2.7.0",
                 "semver": "^6.3.1"
             },
             "devDependencies": {
-                "@types/node-fetch": "^2.6.11",
+                "@types/node-fetch": "^2.6.13",
                 "typescript": "5.1.6"
             }
         },
@@ -80,14 +80,14 @@
             "license": "MIT"
         },
         "node_modules/@types/node-fetch": {
-            "version": "2.6.11",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node-fetch/-/node-fetch-2.6.11.tgz",
-            "integrity": "sha1-mzm3hmXa4OgqCPAvSWfWLGb5XSQ=",
+            "version": "2.6.13",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+            "integrity": "sha1-4Mm3te29sbUM4ywSfoXogIctVu4=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
-                "form-data": "^4.0.0"
+                "form-data": "^4.0.4"
             }
         },
         "node_modules/adm-zip": {
@@ -132,9 +132,9 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "5.2.8",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-            "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+            "version": "5.2.11",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
+            "integrity": "sha1-4WT2NUK4K1n7dRDmeuRuTTC/J94=",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
@@ -403,9 +403,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs=",
+            "version": "1.16.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
             "funding": [
                 {
                     "type": "individual",
@@ -423,17 +423,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha1-eEzczgZpqdaOlNEaxO6pgIjt0sQ=",
+            "version": "4.0.6",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -570,9 +570,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+            "version": "2.0.4",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -844,9 +844,9 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+            "version": "2.3.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -867,9 +867,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.14.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.1.tgz",
-            "integrity": "sha1-pB2FudOQLzHSeGF5BQYpSIGHEVk=",
+            "version": "6.15.2",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha1-/VVCbXEEA93MxF4PnqsW23cn7Ok=",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
@@ -1140,9 +1140,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=",
+            "version": "1.13.8",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
             "license": "MIT"
         },
         "node_modules/universalify": {

--- a/common-npm-packages/artifacts-common/package.json
+++ b/common-npm-packages/artifacts-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-artifacts-common",
-    "version": "2.273.0",
+    "version": "2.276.0",
     "description": "Azure Artifacts common code (for new authentication tasks)",
     "scripts": {
         "build": "cd ../build-scripts && npm install && cd ../artifacts-common && node make.js"
@@ -17,13 +17,13 @@
         "@types/mocha": "^5.2.6",
         "@types/node": "^16.11.39",
         "azure-devops-node-api": "^15.1.3",
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.2.11",
         "fs-extra": "8.1.0",
         "node-fetch": "^2.7.0",
         "semver": "^6.3.1"
     },
     "devDependencies": {
-        "@types/node-fetch": "^2.6.11",
+        "@types/node-fetch": "^2.6.13",
         "typescript": "5.1.6"
     }
 }

--- a/common-npm-packages/az-blobstorage-provider/package-lock.json
+++ b/common-npm-packages/az-blobstorage-provider/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "azp-tasks-az-blobstorage-provider",
-    "version": "3.276.0",
+    "version": "3.276.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azp-tasks-az-blobstorage-provider",
-            "version": "3.276.0",
+            "version": "3.276.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^4.13.1",
                 "@azure/storage-blob": "12.17.0",
                 "artifact-engine": "^1.271.1",
-                "azure-pipelines-task-lib": "^5.2.10",
+                "azure-pipelines-task-lib": "^5.2.11",
                 "globalthis": "^1.0.3",
                 "q": "1.4.1"
             },
@@ -509,9 +509,9 @@
             "license": "MIT"
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "5.2.10",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-            "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+            "version": "5.2.11",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
+            "integrity": "sha1-4WT2NUK4K1n7dRDmeuRuTTC/J94=",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "^0.5.10",
@@ -895,16 +895,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha1-eEzczgZpqdaOlNEaxO6pgIjt0sQ=",
+            "version": "4.0.6",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -1069,9 +1069,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+            "version": "2.0.4",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"

--- a/common-npm-packages/az-blobstorage-provider/package.json
+++ b/common-npm-packages/az-blobstorage-provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azp-tasks-az-blobstorage-provider",
-    "version": "3.276.0",
+    "version": "3.276.1",
     "description": "Common Library to download blobs from azure storage",
     "repository": {
         "type": "git",
@@ -17,7 +17,7 @@
         "@azure/identity": "^4.13.1",
         "@azure/storage-blob": "12.17.0",
         "artifact-engine": "^1.271.1",
-        "azure-pipelines-task-lib": "^5.2.10",
+        "azure-pipelines-task-lib": "^5.2.11",
         "globalthis": "^1.0.3",
         "q": "1.4.1"
     },


### PR DESCRIPTION
### **Description**
Vulnerabilities were identified in dependency versions used by common-packages, specifically form-data 4.0.4. 
These dependencies have now been upgraded to the latest secure versions to address the issues.

Associated work item :
[AB#2433050](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2433050)

## Changes

Updated azure-pipelines-tasks-artifacts-common:
 version: 2.273.0 -> 2.276.0
 azure-pipelines-task-lib: ^5.2.8 -> ^5.2.11
 @types/node-fetch: ^2.6.11 -> ^2.6.13

Updated azp-tasks-az-blobstorage-provider:
 version: 3.276.0 -> 3.276.1
 azure-pipelines-task-lib: ^5.2.10 -> ^5.2.11

 Regenerated lockfiles to reflect dependency updates:
 package-lock.json
 package-lock.json

- This PR makes the following changes:
It updates vulnerable packages in the package.json files for
common-npm-packages/artifacts-common, az-blobstorage-provider to safer versions.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated**   
NA

---

### **Additional Testing Performed**
Testing is not done, will be testing as part of the upcoming task modifications.


---

### **Documentation Changes Required** (Yes / No)  
NA

---

### **Dependencies**
NA

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Package version was bumped — see [versioning guide](https://semver.org/)
- [ ] Verified the package behaves as expected
- [ ] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---
