### PR TITLE
Fix duplicate feed-* key in packageSourceMapping sync when a manual feed- entry already exists

### DIFF
--- a/common-npm-packages/packaging-common/nuget/NuGetConfigHelper2.ts
+++ b/common-npm-packages/packaging-common/nuget/NuGetConfigHelper2.ts
@@ -193,23 +193,42 @@ export class NuGetConfigHelper2 {
     const psmSources = psmNode?.packageSource;
     if (!Array.isArray(psmSources) || psmSources.length === 0) { tl.debug("no <packageSource> children."); return; }
 
+    // Keys already present in <packageSourceMapping>. Used to detect when a
+    // target prefixed key already exists (e.g. a user added a manual
+    // "feed-<name>" entry as the historical workaround from
+    // https://github.com/NuGet/Home/issues/11406). Renaming blindly in that
+    // case produces two identical "feed-<name>" keys and NuGet fails with
+    // "multiple package sources associated with the same key(s)".
+    const existingKeys = new Set<string>();
+    for (const src of psmSources) {
+        const k = src?.$?.key;
+        if (typeof k === "string") { existingKeys.add(k.trim()); }
+    }
+
     let changed = false;
     for (const src of psmSources) {
         const a = src?.$;
         if (!a || typeof a.key !== "string") { continue; }
         const originalKey = a.key.trim();
 
-        // If this mapping key maps to an internal feed now prefixed, rewrite it.
+        // Already prefixed -> leave as-is (idempotent).
+        if (originalKey.startsWith("feed-")) { continue; }
+
         const prefixedKey = originalToPrefixed.get(originalKey);
-        if (prefixedKey && originalKey !== prefixedKey) {
-            tl.debug(`PackageSourceMapping-Sync: key '${originalKey}' -> '${prefixedKey}'`);
-            a.key = prefixedKey;
-            changed = true;
+        if (!prefixedKey || originalKey === prefixedKey) { continue; }
+
+        // If the prefixed key is already declared, renaming would create a
+        // duplicate key. Leave the original node untouched instead. NuGet
+        // ignores a mapping entry whose key no longer matches a packageSources
+        // entry, so the stale unprefixed node is harmless.
+        if (existingKeys.has(prefixedKey)) {
+            tl.debug(`PackageSourceMapping-Sync: '${prefixedKey}' already present; skipping rename of '${originalKey}'.`);
             continue;
         }
 
-        // Already prefixed -> leave as-is (idempotent).
-        if (originalKey.startsWith("feed-")) { continue; }
+        tl.debug(`PackageSourceMapping-Sync: key '${originalKey}' -> '${prefixedKey}'`);
+        a.key = prefixedKey;
+        changed = true;
     }
 
     if (changed) {

--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.273.1",
+    "version": "3.273.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-packaging-common",
-            "version": "3.273.1",
+            "version": "3.273.2",
             "license": "MIT",
             "dependencies": {
                 "@types/ini": "1.3.30",

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-packaging-common",
-    "version": "3.273.1",
+    "version": "3.273.2",
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "mocha _build/Tests/L0.js",


### PR DESCRIPTION
## Fix: avoid duplicate `feed-*` keys in packageSourceMapping when a manual workaround entry already exists

### What

`syncPackageSourceMappingKeys` (added in #543) renamed internal `<packageSource key="X">`
mapping entries to `feed-X` without checking whether a `feed-X` entry already existed.
Configs that carried the historical manual `feed-X` workaround (NuGet/Home#11406) ended up
with two identical `feed-X` keys, breaking restore with:

> PackageSourceMapping is enabled and there are multiple package sources associated with
> the same key(s): feed-<name>.

### Change

- Build a set of keys already present in `<packageSourceMapping>` before rewriting.
- If the target `feed-<name>` key already exists, **skip the rename** and leave the
  original node untouched, instead of unconditionally overwriting `a.key` (which produced
  a duplicate `feed-<name>` key).
- Keep the existing idempotency guard for nodes already prefixed.

Nothing is added or removed — the only behavioural change is one extra guard that prevents
a rename when it would collide with an existing key. Forward iteration is preserved.

### Patch

`common-npm-packages/packaging-common/nuget/NuGetConfigHelper2.ts` — replaces the rewrite loop:

```typescript
    // Keys already present in <packageSourceMapping>. Used to detect when a
    // target prefixed key already exists (e.g. a user added a manual
    // "feed-<name>" entry as the historical workaround from
    // https://github.com/NuGet/Home/issues/11406). Renaming blindly in that
    // case produces two identical "feed-<name>" keys and NuGet fails with
    // "multiple package sources associated with the same key(s)".
    const existingKeys = new Set<string>();
    for (const src of psmSources) {
        const k = src?.$?.key;
        if (typeof k === "string") { existingKeys.add(k.trim()); }
    }

    let changed = false;
    for (const src of psmSources) {
        const a = src?.$;
        if (!a || typeof a.key !== "string") { continue; }
        const originalKey = a.key.trim();

        // Already prefixed -> leave as-is (idempotent).
        if (originalKey.startsWith("feed-")) { continue; }

        const prefixedKey = originalToPrefixed.get(originalKey);
        if (!prefixedKey || originalKey === prefixedKey) { continue; }

        // If the prefixed key is already declared, renaming would create a
        // duplicate key. Leave the original node untouched instead. NuGet
        // ignores a mapping entry whose key no longer matches a packageSources
        // entry, so the stale unprefixed node is harmless.
        if (existingKeys.has(prefixedKey)) {
            tl.debug(`PackageSourceMapping-Sync: '${prefixedKey}' already present; skipping rename of '${originalKey}'.`);
            continue;
        }

        tl.debug(`PackageSourceMapping-Sync: key '${originalKey}' -> '${prefixedKey}'`);
        a.key = prefixedKey;
        changed = true;
    }
```

### Notes

This deliberately leaves the original unprefixed node in place rather than removing it.
A mapping entry referencing a key that no longer exists in `<packageSources>` (because the
source was renamed to `feed-<name>`) is ignored by NuGet, not an error — so the stale node
is harmless, and skipping is the smallest, lowest-risk change. The correct match
(`feed-<name>` → pattern) is still provided by the pre-existing entry.

### Testing

Repro config with both `MyFeed` and `feed-MyFeed` in `<packageSourceMapping>` now restores
successfully; temp config contains a single `feed-MyFeed` key.

Fixes #634
