### PR TITLE
azure-arm-rest: add gated Kudu log VSO-command sanitizer (MSRC 125166)

### DIFF
--- a/common-npm-packages/azure-arm-rest/Tests/L0-kudu-log-sanitizer-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-kudu-log-sanitizer-tests.ts
@@ -1,0 +1,122 @@
+import assert = require('assert');
+import { sanitizeKuduLogForConsole } from '../azure-arm-app-service-kudu';
+
+// sanitizeKuduLogForConsole is a pure function (its only side effect is a console.log telemetry
+// emission and a read of the DISTRIBUTEDTASK_TASKS_ENABLEKUDULOGVSOCOMMANDSANITIZATION env var
+// via tl.getPipelineFeature), so it is exercised in-process here rather than via the
+// MockTestRunner subprocess pattern used for the HTTP-calling Kudu methods elsewhere in this
+// folder - no HTTP mocking is needed and env var manipulation is all that's required to flip
+// the feature on/off between cases.
+const FEATURE_ENV_VAR = 'DISTRIBUTEDTASK_TASKS_ENABLEKUDULOGVSOCOMMANDSANITIZATION';
+
+export function KuduLogSanitizerTests() {
+    describe('sanitizeKuduLogForConsole', () => {
+        let originalFeatureValue: string | undefined;
+        let originalConsoleLog: (...args: any[]) => void;
+        let consoleOutput: string[];
+
+        beforeEach(() => {
+            originalFeatureValue = process.env[FEATURE_ENV_VAR];
+            delete process.env[FEATURE_ENV_VAR];
+
+            consoleOutput = [];
+            originalConsoleLog = console.log;
+            console.log = (...args: any[]) => {
+                consoleOutput.push(args.join(' '));
+            };
+        });
+
+        afterEach(() => {
+            if (originalFeatureValue === undefined) {
+                delete process.env[FEATURE_ENV_VAR];
+            } else {
+                process.env[FEATURE_ENV_VAR] = originalFeatureValue;
+            }
+            console.log = originalConsoleLog;
+        });
+
+        it('leaves clean text untouched and emits no telemetry', () => {
+            const clean = 'npm install\nadded 42 packages in 3s\n';
+
+            const result = sanitizeKuduLogForConsole(clean, 'AzureRmWebAppDeployment');
+
+            assert.strictEqual(result, clean, 'clean text should pass through unmodified');
+            assert.strictEqual(
+                consoleOutput.some(line => line.includes('telemetry.publish')),
+                false,
+                'no telemetry should be emitted when no ##vso[ pattern is present');
+        });
+
+        it('detects a ##vso[task.setvariable] command and reports telemetry even when the feature is off', () => {
+            delete process.env[FEATURE_ENV_VAR];
+            const payload = '##vso[task.setvariable variable=ORYX_INJECTED]true';
+
+            const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
+
+            assert.strictEqual(result, payload, 'text must be returned unmodified when the feature is off');
+            const telemetryLine = consoleOutput.find(line => line.includes('telemetry.publish'));
+            assert(telemetryLine, 'telemetry should always be emitted when a ##vso[ command is detected');
+            assert(telemetryLine.includes('area=TaskHub;feature=AzureRmWebAppDeployment'));
+            assert(telemetryLine.includes('"event":"KuduLogVsoCommandsDetected"'));
+            assert(telemetryLine.includes('"enforced":false'));
+            assert(telemetryLine.includes('"commands":"task.setvariable"'));
+        });
+
+        it('neutralizes ##vso[ and leaves the rest of the text intact when the feature is on', () => {
+            process.env[FEATURE_ENV_VAR] = 'true';
+            const payload = 'Oryx build log line one\n##vso[task.setvariable variable=ORYX_INJECTED]true\nOryx build log line two';
+
+            const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
+
+            assert.strictEqual(result.includes('##vso['), false, 'the ##vso[ trigger sequence must be neutralized');
+            assert(result.includes('##_vso[task.setvariable variable=ORYX_INJECTED]true'),
+                'the neutralized text should still be readable/diagnosable in the log');
+            assert(result.includes('Oryx build log line one'));
+            assert(result.includes('Oryx build log line two'));
+
+            const telemetryLine = consoleOutput.find(line => line.includes('telemetry.publish'));
+            assert(telemetryLine, 'telemetry should still be emitted when enforcing');
+            assert(telemetryLine.includes('"event":"KuduLogVsoCommandsSanitized"'));
+            assert(telemetryLine.includes('"enforced":true'));
+        });
+
+        it('also neutralizes a leading ##[ (non-vso) logging command sequence when the feature is on', () => {
+            process.env[FEATURE_ENV_VAR] = 'true';
+            const payload = '##vso[task.setvariable variable=X]y\n##[section]Starting: attacker section';
+
+            const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
+
+            assert.strictEqual(result.includes('##vso['), false);
+            assert.strictEqual(/^##\[/m.test(result), false, 'a leading ##[ sequence must also be neutralized');
+        });
+
+        it('cannot be broken out of the telemetry command envelope by a crafted payload', () => {
+            process.env[FEATURE_ENV_VAR] = 'false';
+            // Attempt to inject a bogus telemetry area/feature or a second ##vso[ command via the
+            // detected "command name" text itself - the command name capture group is bounded to
+            // [a-zA-Z0-9_.]+ so it cannot contain "]" or newlines that could terminate the
+            // ##vso[telemetry.publish ...] envelope early or inject an unrelated command.
+            const payload = '##vso[task.setvariable variable=X]value]##vso[task.setsecret]stolen';
+
+            const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
+
+            assert.strictEqual(result, payload, 'text must be returned unmodified when the feature is off');
+            const telemetryLines = consoleOutput.filter(line => line.includes('telemetry.publish'));
+            assert.strictEqual(telemetryLines.length, 1, 'exactly one telemetry line should be emitted per call');
+            // The telemetry line itself must still be a single well-formed ##vso[telemetry.publish ...] command -
+            // i.e. JSON.parse must succeed on the payload segment, proving the attacker-controlled
+            // command names could not corrupt the envelope.
+            const telemetryLine = telemetryLines[0];
+            const jsonStart = telemetryLine.indexOf(']') + 1;
+            const jsonPayload = telemetryLine.substring(jsonStart);
+            assert.doesNotThrow(() => JSON.parse(jsonPayload), 'telemetry JSON payload must remain well-formed');
+            assert(telemetryLine.includes('"commands":"task.setvariable,task.setsecret"'));
+        });
+
+        it('treats an empty string as a no-op', () => {
+            const result = sanitizeKuduLogForConsole('', 'AzureRmWebAppDeployment');
+            assert.strictEqual(result, '');
+            assert.strictEqual(consoleOutput.length, 0);
+        });
+    });
+}

--- a/common-npm-packages/azure-arm-rest/Tests/L0-kudu-log-sanitizer-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-kudu-log-sanitizer-tests.ts
@@ -9,6 +9,22 @@ import { sanitizeKuduLogForConsole } from '../azure-arm-app-service-kudu';
 // the feature on/off between cases.
 const FEATURE_ENV_VAR = 'DISTRIBUTEDTASK_TASKS_ENABLEKUDULOGVSOCOMMANDSANITIZATION';
 
+// IMPORTANT: mocha's reporter prints `it(...)` titles (and any failed assertion message) to the
+// real process stdout, which - unlike a plain local `mocha`/`node` run - IS scanned by the actual
+// Azure Pipelines agent for the literal "##vso[" (and leading "##[") trigger sequence when this
+// suite runs inside a real CI job. So test titles/assert messages below intentionally avoid ever
+// spelling out that literal sequence (e.g. built up from parts at runtime instead), even though
+// the *payloads passed into sanitizeKuduLogForConsole* safely use the real sequence - those never
+// reach real stdout because console.log is mocked/captured for the duration of each test and
+// restored again in afterEach, before mocha prints the next result line.
+function buildVsoCommand(command: string): string {
+    return '##' + 'vso[' + command;
+}
+
+function buildLeadingBracketCommand(command: string): string {
+    return '##' + '[' + command;
+}
+
 export function KuduLogSanitizerTests() {
     describe('sanitizeKuduLogForConsole', () => {
         let originalFeatureValue: string | undefined;
@@ -44,31 +60,31 @@ export function KuduLogSanitizerTests() {
             assert.strictEqual(
                 consoleOutput.some(line => line.includes('telemetry.publish')),
                 false,
-                'no telemetry should be emitted when no ##vso[ pattern is present');
+                'no telemetry should be emitted for clean input');
         });
 
-        it('detects a ##vso[task.setvariable] command and reports telemetry even when the feature is off', () => {
+        it('detects a task.setvariable logging command and reports telemetry even when the feature is off', () => {
             delete process.env[FEATURE_ENV_VAR];
-            const payload = '##vso[task.setvariable variable=ORYX_INJECTED]true';
+            const payload = buildVsoCommand('task.setvariable variable=ORYX_INJECTED]true');
 
             const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
 
             assert.strictEqual(result, payload, 'text must be returned unmodified when the feature is off');
             const telemetryLine = consoleOutput.find(line => line.includes('telemetry.publish'));
-            assert(telemetryLine, 'telemetry should always be emitted when a ##vso[ command is detected');
+            assert(telemetryLine, 'telemetry should always be emitted when a logging command is detected');
             assert(telemetryLine.includes('area=TaskHub;feature=AzureRmWebAppDeployment'));
             assert(telemetryLine.includes('"event":"KuduLogVsoCommandsDetected"'));
             assert(telemetryLine.includes('"enforced":false'));
             assert(telemetryLine.includes('"commands":"task.setvariable"'));
         });
 
-        it('neutralizes ##vso[ and leaves the rest of the text intact when the feature is on', () => {
+        it('neutralizes the trigger sequence and leaves the rest of the text intact when the feature is on', () => {
             process.env[FEATURE_ENV_VAR] = 'true';
-            const payload = 'Oryx build log line one\n##vso[task.setvariable variable=ORYX_INJECTED]true\nOryx build log line two';
+            const payload = `Oryx build log line one\n${buildVsoCommand('task.setvariable variable=ORYX_INJECTED]true')}\nOryx build log line two`;
 
             const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
 
-            assert.strictEqual(result.includes('##vso['), false, 'the ##vso[ trigger sequence must be neutralized');
+            assert.strictEqual(result.includes(buildVsoCommand('')), false, 'the trigger sequence must be neutralized');
             assert(result.includes('##_vso[task.setvariable variable=ORYX_INJECTED]true'),
                 'the neutralized text should still be readable/diagnosable in the log');
             assert(result.includes('Oryx build log line one'));
@@ -80,31 +96,31 @@ export function KuduLogSanitizerTests() {
             assert(telemetryLine.includes('"enforced":true'));
         });
 
-        it('also neutralizes a leading ##[ (non-vso) logging command sequence when the feature is on', () => {
+        it('also neutralizes a leading bracket (non task-prefixed) logging command sequence when the feature is on', () => {
             process.env[FEATURE_ENV_VAR] = 'true';
-            const payload = '##vso[task.setvariable variable=X]y\n##[section]Starting: attacker section';
+            const payload = `${buildVsoCommand('task.setvariable variable=X]y')}\n${buildLeadingBracketCommand('section]Starting: attacker section')}`;
 
             const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
 
-            assert.strictEqual(result.includes('##vso['), false);
-            assert.strictEqual(/^##\[/m.test(result), false, 'a leading ##[ sequence must also be neutralized');
+            assert.strictEqual(result.includes(buildVsoCommand('')), false);
+            assert.strictEqual(/^##\[/m.test(result), false, 'a leading bracket sequence must also be neutralized');
         });
 
         it('cannot be broken out of the telemetry command envelope by a crafted payload', () => {
             process.env[FEATURE_ENV_VAR] = 'false';
-            // Attempt to inject a bogus telemetry area/feature or a second ##vso[ command via the
+            // Attempt to inject a bogus telemetry area/feature or a second logging command via the
             // detected "command name" text itself - the command name capture group is bounded to
             // [a-zA-Z0-9_.]+ so it cannot contain "]" or newlines that could terminate the
-            // ##vso[telemetry.publish ...] envelope early or inject an unrelated command.
-            const payload = '##vso[task.setvariable variable=X]value]##vso[task.setsecret]stolen';
+            // emitted telemetry envelope early or inject an unrelated command.
+            const payload = `${buildVsoCommand('task.setvariable variable=X]value]')}${buildVsoCommand('task.setsecret]stolen')}`;
 
             const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
 
             assert.strictEqual(result, payload, 'text must be returned unmodified when the feature is off');
             const telemetryLines = consoleOutput.filter(line => line.includes('telemetry.publish'));
             assert.strictEqual(telemetryLines.length, 1, 'exactly one telemetry line should be emitted per call');
-            // The telemetry line itself must still be a single well-formed ##vso[telemetry.publish ...] command -
-            // i.e. JSON.parse must succeed on the payload segment, proving the attacker-controlled
+            // The telemetry line itself must still be a single well-formed logging command - i.e.
+            // JSON.parse must succeed on the payload segment, proving the attacker-controlled
             // command names could not corrupt the envelope.
             const telemetryLine = telemetryLines[0];
             const jsonStart = telemetryLine.indexOf(']') + 1;

--- a/common-npm-packages/azure-arm-rest/Tests/L0.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0.ts
@@ -7,6 +7,7 @@ import { AksServiceTests } from "./L0-azure-arm-aks-service-tests";
 import { AzureCliUtilityTests } from "./L0-azure-cli-utility-tests";
 import { OpenSSLCheck } from "./L0-azure-cli-openssl-check";
 import { AzureAppServiceUtilityTests } from "./L0-azure-app-service-utility-tests";
+import { KuduLogSanitizerTests } from "./L0-kudu-log-sanitizer-tests";
 
 const DEFAULT_TIMEOUT = 1000 * 20;
 
@@ -21,4 +22,5 @@ describe("AzureARMRestTests", function () {
     describe("Azure Cli Utility Tests", AzureCliUtilityTests.bind(AzureCliUtilityTests, DEFAULT_TIMEOUT));
     describe("Azure Cli OpenSSL check", OpenSSLCheck.bind(OpenSSLCheck, DEFAULT_TIMEOUT));
     describe("AzureAppServiceUtility Tests", AzureAppServiceUtilityTests.bind(AzureAppServiceUtilityTests, DEFAULT_TIMEOUT));
+    describe("Kudu log VSO-command sanitizer Tests", KuduLogSanitizerTests);
 });

--- a/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
@@ -842,14 +842,24 @@ export class Kudu {
 // If no ##vso[...] pattern is present in the text, this is a no-op (no telemetry emitted for
 // clean logs).
 
-const VSO_COMMAND_REGEX = /##vso\[([a-zA-Z0-9_.]+)/gi;
+// Used only to decide whether there is anything to do at all (telemetry and/or enforcement).
+// Intentionally NOT restricted to any command-name charset, so the kill switch below does not
+// depend on the agent's current command-name parsing rules - any "##vso[" (or leading "##[")
+// occurrence is treated as something to neutralize when enforcement is on.
+const VSO_COMMAND_PRESENCE_REGEX = /##vso\[/i;
+
+// Used only to name detected commands for telemetry. This charset is a best-effort label and
+// intentionally must NOT be used to decide whether enforcement/telemetry should run - see
+// VSO_COMMAND_PRESENCE_REGEX above for that gate.
+const VSO_COMMAND_NAME_REGEX = /##vso\[([a-zA-Z0-9_.]+)/gi;
 const KUDU_LOG_SANITIZER_TELEMETRY_AREA = 'TaskHub';
 const KUDU_LOG_SANITIZER_ENFORCE_PIPELINE_FEATURE = 'EnableKuduLogVsoCommandSanitization';
 
+// For telemetry naming only - see comment on VSO_COMMAND_NAME_REGEX above.
 function findVsoCommands(text: string): string[] {
     const found = new Set<string>();
     let match: RegExpExecArray | null;
-    const regex = new RegExp(VSO_COMMAND_REGEX);
+    const regex = new RegExp(VSO_COMMAND_NAME_REGEX);
     while ((match = regex.exec(text)) !== null) {
         found.add(match[1].toLowerCase());
     }
@@ -891,18 +901,16 @@ function emitKuduLogSanitizerDetectionTelemetry(feature: string, enforced: boole
  *   "##[") trigger sequences so the agent can no longer parse them as logging commands.
  */
 export function sanitizeKuduLogForConsole(text: string, telemetryFeature: string): string {
-    if (!text) {
-        return text;
-    }
-
-    const detectedCommands = findVsoCommands(text);
-    if (detectedCommands.length === 0) {
+    if (!text || !VSO_COMMAND_PRESENCE_REGEX.test(text)) {
         return text;
     }
 
     const activate = tl.getPipelineFeature(KUDU_LOG_SANITIZER_ENFORCE_PIPELINE_FEATURE);
 
-    emitKuduLogSanitizerDetectionTelemetry(telemetryFeature, activate, detectedCommands);
+    // Command names are extracted purely for telemetry labeling - see comment on
+    // VSO_COMMAND_NAME_REGEX/findVsoCommands above. Whether we got here (and whether we
+    // enforce below) is decided solely by VSO_COMMAND_PRESENCE_REGEX.
+    emitKuduLogSanitizerDetectionTelemetry(telemetryFeature, activate, findVsoCommands(text));
 
     if (!activate) {
         // Telemetry-only: report above, but do not touch the text that gets printed.

--- a/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
@@ -801,3 +801,113 @@ export class Kudu {
         tl.debug('Kudu warmup failed after all retries, proceeding without warmup');
     }
 }
+
+// Fix for MSRC 125166 / ICM 31000000654080.
+//
+// Consuming tasks (AzureRmWebAppDeployment, AzureWebApp, AzureFunctionApp and their container
+// variants) echo remote, cross-trust-boundary content fetched via Kudu.getFileContent /
+// Kudu.getDeploymentLogs (Kudu/Oryx deployment build logs, post-deployment script stdout/stderr)
+// verbatim via console.log() before printing. The Azure Pipelines agent scans ALL task stdout
+// for the literal sequence "##vso[" and executes any matching logging command it finds,
+// regardless of which line of code produced it. Because the Oryx build log is populated by
+// whatever the application's build (e.g. npm install -> postinstall) prints - content that may
+// be authored by a lower-trust party than the pipeline definition (external contributors,
+// transitive npm dependencies) - an attacker who only controls the app SOURCE can get arbitrary
+// ##vso commands (task.setvariable, task.setsecret, task.setendpoint, ...) executed at full
+// pipeline/agent trust, without ever touching the pipeline YAML.
+//
+// IMPORTANT: this helper is intentionally NOT applied inside Kudu.getFileContent /
+// Kudu.getDeploymentLogs themselves. Those methods are generic file/log fetchers reused by
+// callers for non-print, data-purpose reads too (e.g. manifest file contents, active deployment
+// IDs compared for equality, script return codes compared to '0'). Mutating the returned string
+// at that layer would risk corrupting those comparisons/parses. Sanitization must be applied by
+// each caller only at the point where fetched content is about to be printed to the console.
+// It is kept in this file (rather than a separate module) so it stays co-located with the Kudu
+// class whose output it exists to sanitize.
+//
+// Enforcement rollout is gated behind a pipeline feature (checked via tl.getPipelineFeature,
+// which reads the "DistributedTask.Tasks.<name>" pipeline variable) - tl.getBoolFeatureFlag is
+// deprecated in favor of tl.getPipelineFeature and is intentionally not used here:
+//   EnableKuduLogVsoCommandSanitization -> ENFORCE: neutralize the "##vso[" trigger sequence
+//                                          before printing, so the content can no longer be
+//                                          parsed as a logging command by the agent.
+//
+// Detection telemetry is NOT feature-gated: whenever a ##vso[...] command is detected in
+// remote log content, it is always reported via telemetry.publish (regardless of the feature
+// above), so real-world impact/prevalence can be measured before and after enforcement ramps.
+// This is safe to always emit unconditionally because the telemetry payload itself is fully
+// controlled by this code (fixed keys, command names extracted from a bounded regex) - it is
+// not remote/attacker content.
+//
+// If no ##vso[...] pattern is present in the text, this is a no-op (no telemetry emitted for
+// clean logs).
+
+const VSO_COMMAND_REGEX = /##vso\[([a-zA-Z0-9_.]+)/gi;
+const KUDU_LOG_SANITIZER_TELEMETRY_AREA = 'TaskHub';
+const KUDU_LOG_SANITIZER_ENFORCE_PIPELINE_FEATURE = 'EnableKuduLogVsoCommandSanitization';
+
+function findVsoCommands(text: string): string[] {
+    const found = new Set<string>();
+    let match: RegExpExecArray | null;
+    const regex = new RegExp(VSO_COMMAND_REGEX);
+    while ((match = regex.exec(text)) !== null) {
+        found.add(match[1].toLowerCase());
+    }
+    return Array.from(found);
+}
+
+// Emits telemetry using the same "##vso[telemetry.publish ...]" channel as
+// azure-pipelines-tasks-utility-common/telemetry, without adding a new dependency to this
+// package for a small, self-issued payload.
+function emitKuduLogSanitizerDetectionTelemetry(feature: string, enforced: boolean, commands: string[]): void {
+    try {
+        const payload = {
+            event: enforced ? 'KuduLogVsoCommandsSanitized' : 'KuduLogVsoCommandsDetected',
+            enforced: enforced,
+            commandCount: commands.length,
+            commands: commands.join(',')
+        };
+        console.log(`##vso[telemetry.publish area=${KUDU_LOG_SANITIZER_TELEMETRY_AREA};feature=${feature}]${JSON.stringify(payload)}`);
+    } catch (err) {
+        tl.debug(`sanitizeKuduLogForConsole: failed to emit telemetry: ${err}`);
+    }
+}
+
+/**
+ * Pipeline-feature gated sanitizer for remote Kudu/Oryx log content, to be called by task code
+ * immediately before printing content obtained from Kudu.getFileContent / Kudu.getDeploymentLogs
+ * (see the comment above for the full rationale and feature name).
+ *
+ * @param text the raw remote log content about to be printed to the console.
+ * @param telemetryFeature the `feature` value to tag emitted telemetry with - callers should
+ *        pass a value identifying their own task (e.g. 'AzureRmWebAppDeployment',
+ *        'AzureFunctionApp') so telemetry can be attributed correctly.
+ *
+ * - Detection telemetry always runs: if `text` contains any ##vso[...] command sequence, it is
+ *   always reported via telemetry.publish, regardless of the pipeline feature state.
+ * - EnableKuduLogVsoCommandSanitization off (default today): text is returned completely
+ *   unmodified - telemetry-only, zero behavior change for customers.
+ * - EnableKuduLogVsoCommandSanitization on: enforce. Neutralizes the "##vso[" (and leading
+ *   "##[") trigger sequences so the agent can no longer parse them as logging commands.
+ */
+export function sanitizeKuduLogForConsole(text: string, telemetryFeature: string): string {
+    if (!text) {
+        return text;
+    }
+
+    const detectedCommands = findVsoCommands(text);
+    if (detectedCommands.length === 0) {
+        return text;
+    }
+
+    const activate = tl.getPipelineFeature(KUDU_LOG_SANITIZER_ENFORCE_PIPELINE_FEATURE);
+
+    emitKuduLogSanitizerDetectionTelemetry(telemetryFeature, activate, detectedCommands);
+
+    if (!activate) {
+        // Telemetry-only: report above, but do not touch the text that gets printed.
+        return text;
+    }
+
+    return text.replace(/##vso\[/gi, '##_vso[').replace(/^##\[/gm, '##_[');
+}

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.277.0",
+    "version": "3.277.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azure-arm-rest",
-            "version": "3.277.0",
+            "version": "3.277.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^4.13.1",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.277.0",
+    "version": "3.277.1",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### **Description**
Fixes ICM 31000000654080 / MSRC 125166: `KuduServiceUtility` echoes remote Kudu/Oryx deployment and build log lines via `console.log` without sanitization. The Azure Pipelines agent scans all task stdout for `##vso[` and executes matching logging commands, so an attacker-controlled `##vso[...]` command embedded in application **source** (e.g. surfaced through an Oryx server-side build log via an `npm` postinstall script) executes on the agent at the pipeline's trust level — without the attacker ever needing pipeline access.

Adds `sanitizeKuduLogForConsole` (+ helpers `findVsoCommands`, `emitKuduLogSanitizerDetectionTelemetry`) to `azure-arm-app-service-kudu.ts`, directly after the `Kudu` class. Consuming tasks (AzureRmWebAppDeployment@3-5, AzureWebApp@1, AzureWebAppContainer@1, AzureFunctionApp@1/@2, AzureFunctionAppContainer@1) will be updated in a follow-up PR to reference this package (via a packed tgz) instead of their own local copy of the sanitizer.

Behavior is gated by the `getPipelineFeature('EnableKuduLogVsoCommandSanitization')` pipeline feature:
- **Feature disabled (default):** detection-only. Suspicious `##vso[...]` patterns are detected and reported via `telemetry.publish` (`event=KuduLogVsoCommandsDetected`, `enforced=false`) so real-world impact can be measured before enforcing.
- **Feature enabled:** matched `##vso[...]` patterns are neutralized before the line reaches `console.log`, and telemetry reports `enforced=true`.

E2E-validated in a live Azure DevOps pipeline against all 8 consuming task versions (uploaded as private builds): the sanitizer correctly detects and reports the injected `##vso` commands from server-side Oryx build logs in dry-run (telemetry-only) mode with the feature flag off, exactly as designed.

---

### **Package Name**
`azure-pipelines-tasks-azure-arm-rest`

---

### **Risk Assessment** (Low / Medium / High)
**Low.** New exported functions only; no existing exports or `Kudu` class behavior changed. Default-disabled feature flag means no behavior change until the flag is explicitly enabled per-pipeline. Telemetry-only by default.

---

### **Unit Tests Added or Updated**
- [ ] Unit tests added or updated
- [x] Manual tests performed

_No package-level unit test suite exists for `azure-arm-rest` (no `test` script in `package.json`). Verified with `npm run build` (clean `tsc` compile) and end-to-end pipeline testing described above._

---

### **Additional Testing Performed**
Packed this package as a `.tgz` and referenced it via `file:` in all 8 consuming tasks, rebuilt each task, uploaded private builds to a test Azure DevOps organization, and ran a purpose-built E2E repro pipeline that plants a malicious `##vso[...]` command in application source deployed through App Service Oryx builds. Confirmed via task logs that the new sanitizer correctly detects the injected commands and publishes `KuduLogVsoCommandsDetected` telemetry with `enforced=false` while the feature flag is off (default/dry-run state).

---

### **Documentation Changes Required** (Yes / No)
No.

---

### **Dependencies**
None added.

---

### **Checklist**
- [x] Related issue linked (if applicable) — ICM 31000000654080 / MSRC 125166
- [x] Package version was bumped — see [versioning guide](https://semver.org/) (3.277.0 → 3.277.1)
- [x] Verified the package behaves as expected
- [ ] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)
