### PR TITLE
Migrate npm publishing to ESRP Release

### DIFF
--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -4,6 +4,12 @@ name: $(Date:yyyyMMdd)$(Rev:.r)
 trigger: none
 pr: none
 
+parameters:
+- name: dryRun
+  displayName: Build and validate without publishing
+  type: boolean
+  default: false
+
 variables:
 - group: esrp-npm-release
 - name: EsrpMainPublisher
@@ -123,67 +129,68 @@ extends:
             done
           displayName: Verify packages exclude SBOM manifests
 
-    - stage: PublishToNpmViaESRP
-      displayName: Publish to npm via ESRP
-      dependsOn: BuildAndPack
-      jobs:
-      - job: esrp
-        displayName: Publish npm packages through ESRP
-        pool:
-          name: 1ES-ABTT-Shared-Pool
-          image: abtt-windows-2025
-          os: windows
-        templateContext:
-          type: releaseJob
-          isProduction: true
-          inputs:
-          - input: pipelineArtifact
-            artifactName: npm-packages
-            targetPath: $(Pipeline.Workspace)/npm-packages
-        steps:
-        - task: EsrpRelease@12
-          displayName: Publish packages to npm via ESRP
-          inputs:
-            connectedservicename: '$(EsrpServiceConnection)'
-            usemanagedidentity: true
-            keyvaultname: '$(EsrpKeyVault)'
-            signcertname: '$(EsrpSignCert)'
-            clientid: '$(EsrpClientId)'
-            intent: 'PackageDistribution'
-            contenttype: 'npm'
-            contentsource: 'Folder'
-            folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
-            waitforreleasecompletion: true
-            owners: '$(EsrpOwners)'
-            approvers: '$(EsrpApprovers)'
-            serviceendpointurl: '$(EsrpServiceEndpointUrl)'
-            mainpublisher: '$(EsrpMainPublisher)'
-            domaintenantid: '$(EsrpDomainTenantId)'
+    - ${{ if eq(parameters.dryRun, false) }}:
+      - stage: PublishToNpmViaESRP
+        displayName: Publish to npm via ESRP
+        dependsOn: BuildAndPack
+        jobs:
+        - job: esrp
+          displayName: Publish npm packages through ESRP
+          pool:
+            name: 1ES-ABTT-Shared-Pool
+            image: abtt-windows-2025
+            os: windows
+          templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+            - input: pipelineArtifact
+              artifactName: npm-packages
+              targetPath: $(Pipeline.Workspace)/npm-packages
+          steps:
+          - task: EsrpRelease@12
+            displayName: Publish packages to npm via ESRP
+            inputs:
+              connectedservicename: '$(EsrpServiceConnection)'
+              usemanagedidentity: true
+              keyvaultname: '$(EsrpKeyVault)'
+              signcertname: '$(EsrpSignCert)'
+              clientid: '$(EsrpClientId)'
+              intent: 'PackageDistribution'
+              contenttype: 'npm'
+              contentsource: 'Folder'
+              folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
+              waitforreleasecompletion: true
+              owners: '$(EsrpOwners)'
+              approvers: '$(EsrpApprovers)'
+              serviceendpointurl: '$(EsrpServiceEndpointUrl)'
+              mainpublisher: '$(EsrpMainPublisher)'
+              domaintenantid: '$(EsrpDomainTenantId)'
 
-      - job: createGitHubReleases
-        displayName: Create GitHub releases and tags
-        dependsOn: esrp
-        pool:
-          name: 1ES-ABTT-Shared-Pool
-          image: abtt-ubuntu-2404
-          os: linux
-        steps:
-        - checkout: self
-          clean: true
+        - job: createGitHubReleases
+          displayName: Create GitHub releases and tags
+          dependsOn: esrp
+          pool:
+            name: 1ES-ABTT-Shared-Pool
+            image: abtt-ubuntu-2404
+            os: linux
+          steps:
+          - checkout: self
+            clean: true
 
-        - task: UseNode@1
-          inputs:
-            version: 20.x
+          - task: UseNode@1
+            inputs:
+              version: 20.x
 
-        - task: NpmAuthenticate@0
-          inputs:
-            workingFile: .npmrc
+          - task: NpmAuthenticate@0
+            inputs:
+              workingFile: .npmrc
 
-        - script: npm ci
-          displayName: Install release-note dependencies
+          - script: npm ci
+            displayName: Install release-note dependencies
 
-        - script: npm run create-releases
-          displayName: Create GitHub releases
-          env:
-            GH_TOKEN: $(gh-automation.token)
-            RELEASE_TARGET: $(Build.SourceVersion)
+          - script: npm run create-releases
+            displayName: Create GitHub releases
+            env:
+              GH_TOKEN: $(gh-automation.token)
+              RELEASE_TARGET: $(Build.SourceVersion)

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -1,18 +1,25 @@
-# CI/Release pipeline - triggers on merge to main/releases, builds, tests, and publishes packages
-# This pipeline will be extended to the OneESPT template
-trigger:
-- main
-- releases/*
+# Manual-only release pipeline: build and pack first, then distribute through ESRP.
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+trigger: none
+pr: none
+
 variables:
-- name: skipBuildTagsForGitHubPullRequests
-  value: true
-- group: npm-tokens
+- group: esrp-npm-release
+- name: EsrpMainPublisher
+  value: 'ESRPRELPACMAN'
+- name: EsrpServiceEndpointUrl
+  value: 'https://api.esrp.microsoft.com'
+- name: EsrpDomainTenantId
+  value: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
@@ -31,24 +38,152 @@ extends:
     customBuildTags:
     - ES365AIMigrationTooling
     stages:
-    - stage: 'BuildAndPublish'
-      displayName: 'Build, Test & Publish Common Npm packages'
-      dependsOn: []
-      pool:
-        name: 1ES-ABTT-Shared-Pool
-        image: abtt-windows-2025
-        os: windows
-      condition: succeeded()
+    - stage: BuildAndPack
+      displayName: Build, test, and pack
       jobs:
-      - job: BuildAndPublishCommonNpmPackages
-        displayName: Build, Test and Publish Common Npm Packages
+      - job: pack
+        displayName: Build and pack common npm packages
+        pool:
+          name: 1ES-ABTT-Shared-Pool
+          image: abtt-ubuntu-2404
+          os: linux
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            targetPath: $(Build.ArtifactStagingDirectory)/npm-packages
+            artifactName: npm-packages
         steps:
         - template: /ci/build-common-packages.yml@self
 
-        - bash: npm run publish
-          condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
+        - bash: |
+            set -euo pipefail
+            package_root="$(Build.SourcesDirectory)/common-npm-packages"
+            package_output="$(Build.ArtifactStagingDirectory)/npm-packages/packages"
+            mkdir -p "$package_output"
+
+            for package_dir in "$package_root"/*; do
+              package_name="$(basename "$package_dir")"
+              if [ ! -d "$package_dir" ] || [ "$package_name" = "build-scripts" ] || [ ! -f "$package_dir/package.json" ]; then
+                continue
+              fi
+
+              build_dir="$package_dir/_build"
+              if [ ! -f "$build_dir/package.json" ]; then
+                echo "ERROR: Fresh build output is missing for $package_name."
+                exit 1
+              fi
+
+              echo "Packing $package_name from $build_dir"
+              (
+                cd "$build_dir"
+                npm pack --pack-destination "$package_output"
+              )
+            done
+          displayName: Pack fresh package outputs
+
+        - bash: |
+            set -euo pipefail
+            package_root="$(Build.SourcesDirectory)/common-npm-packages"
+            package_output="$(Build.ArtifactStagingDirectory)/npm-packages/packages"
+            expected_count=0
+
+            for package_dir in "$package_root"/*; do
+              package_name="$(basename "$package_dir")"
+              if [ -d "$package_dir" ] && [ "$package_name" != "build-scripts" ] && [ -f "$package_dir/package.json" ]; then
+                expected_count=$((expected_count + 1))
+              fi
+            done
+
+            actual_count="$(find "$package_output" -maxdepth 1 -type f -name '*.tgz' | wc -l | tr -d ' ')"
+            echo "Found $actual_count .tgz file(s) for $expected_count package(s)."
+
+            if [ "$actual_count" -eq 0 ]; then
+              echo "ERROR: npm pack produced no .tgz files."
+              exit 1
+            fi
+            if [ "$expected_count" -ne 15 ]; then
+              echo "ERROR: Expected 15 publishable packages, found $expected_count."
+              exit 1
+            fi
+            if [ "$actual_count" -ne "$expected_count" ]; then
+              echo "ERROR: Expected $expected_count .tgz files, found $actual_count."
+              exit 1
+            fi
+          displayName: Verify package count
+
+        - bash: |
+            set -euo pipefail
+            package_output="$(Build.ArtifactStagingDirectory)/npm-packages/packages"
+
+            for tgz in "$package_output"/*.tgz; do
+              if tar -tzf "$tgz" | grep -E '(^|/)_manifest/'; then
+                echo "ERROR: $tgz contains an SBOM _manifest/ folder."
+                exit 1
+              fi
+            done
+          displayName: Verify packages exclude SBOM manifests
+
+    - stage: PublishToNpmViaESRP
+      displayName: Publish to npm via ESRP
+      dependsOn: BuildAndPack
+      jobs:
+      - job: esrp
+        displayName: Publish npm packages through ESRP
+        pool:
+          name: 1ES-ABTT-Shared-Pool
+          image: abtt-windows-2025
+          os: windows
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            artifactName: npm-packages
+            targetPath: $(Pipeline.Workspace)/npm-packages
+        steps:
+        - task: EsrpRelease@12
+          displayName: Publish packages to npm via ESRP
+          inputs:
+            connectedservicename: '$(EsrpServiceConnection)'
+            usemanagedidentity: true
+            keyvaultname: '$(EsrpKeyVault)'
+            signcertname: '$(EsrpSignCert)'
+            clientid: '$(EsrpClientId)'
+            intent: 'PackageDistribution'
+            contenttype: 'npm'
+            contentsource: 'Folder'
+            folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
+            waitforreleasecompletion: true
+            owners: '$(EsrpOwners)'
+            approvers: '$(EsrpApprovers)'
+            serviceendpointurl: '$(EsrpServiceEndpointUrl)'
+            mainpublisher: '$(EsrpMainPublisher)'
+            domaintenantid: '$(EsrpDomainTenantId)'
+
+      - job: createGitHubReleases
+        displayName: Create GitHub releases and tags
+        dependsOn: esrp
+        pool:
+          name: 1ES-ABTT-Shared-Pool
+          image: abtt-ubuntu-2404
+          os: linux
+        steps:
+        - checkout: self
+          clean: true
+
+        - task: UseNode@1
+          inputs:
+            version: 20.x
+
+        - task: NpmAuthenticate@0
+          inputs:
+            workingFile: .npmrc
+
+        - script: npm ci
+          displayName: Install release-note dependencies
+
+        - script: npm run create-releases
+          displayName: Create GitHub releases
           env:
-            NPM_TOKEN: $(npm-automation.token)
             GH_TOKEN: $(gh-automation.token)
-          displayName: Publish packages
-          enabled: true
+            RELEASE_TARGET: $(Build.SourceVersion)

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -12,12 +12,6 @@ parameters:
 
 variables:
 - group: esrp-npm-release
-- name: EsrpMainPublisher
-  value: 'ESRPRELPACMAN'
-- name: EsrpServiceEndpointUrl
-  value: 'https://api.esrp.microsoft.com'
-- name: EsrpDomainTenantId
-  value: '975f013f-7f24-47e8-a7d3-abc4752bf346'
 
 resources:
   repositories:
@@ -186,7 +180,7 @@ extends:
             inputs:
               workingFile: .npmrc
 
-          - script: npm ci
+          - script: npm ci --omit=dev
             displayName: Install release-note dependencies
 
           - script: npm run create-releases

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,6 @@ trigger:
 variables:
 - name: skipBuildTagsForGitHubPullRequests
   value: true
-- group: npm-tokens
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -33,7 +32,7 @@ extends:
     - ES365AIMigrationTooling
     stages:
     - stage: 'BuildCommonNpmWin'
-      displayName: 'Windows - Build & Publish Common Npm packages'
+      displayName: 'Windows - Build Common Npm packages'
       dependsOn: []
       pool:
         name: 1ES-ABTT-Shared-Pool
@@ -45,15 +44,6 @@ extends:
         displayName: Build Common Npm Packages
         steps:
         - template: /ci/build-common-packages.yml@self
-
-        # For CI runs on main, automatically publish packages
-        - bash: npm run publish
-          condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
-          env:
-            NPM_TOKEN: $(npm-automation.token)
-            GH_TOKEN: $(gh-automation.token)
-          displayName: Publish packages (Only Windows)
-          enabled: true
 
     - stage: 'BuildCommonNpmUbuntu'
       displayName: 'Ubuntu - Build Common Npm packages'

--- a/ci/build-common-packages.yml
+++ b/ci/build-common-packages.yml
@@ -10,8 +10,8 @@ steps:
   inputs:
     workingFile: .npmrc
 
-- script: npm install
-  displayName: Npm install
+- script: npm ci
+  displayName: Npm ci
 
 - script: npm run build
   displayName: Build Common Npm packages

--- a/ci/build-common-packages.yml
+++ b/ci/build-common-packages.yml
@@ -13,14 +13,14 @@ steps:
 - script: npm ci
   displayName: Npm ci
 
-- script: npm run build
+- script: npm run build:ci
   displayName: Build Common Npm packages
 
 - script: node ./ci/verify-source-changes.js
   displayName: Verify task source changes
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))
 
-- script: npm run test
+- script: npm run test:ci
   displayName: Test Common Npm packages
 
 - task: PublishTestResults@2

--- a/common-npm-packages/artifacts-common/package.json
+++ b/common-npm-packages/artifacts-common/package.json
@@ -3,7 +3,8 @@
     "version": "2.276.0",
     "description": "Azure Artifacts common code (for new authentication tasks)",
     "scripts": {
-        "build": "cd ../build-scripts && npm ci && cd ../artifacts-common && node make.js"
+        "build": "cd ../build-scripts && npm install && cd ../artifacts-common && node make.js",
+        "build:ci": "node make.js"
     },
     "author": "Microsoft Corporation",
     "repository": {

--- a/common-npm-packages/artifacts-common/package.json
+++ b/common-npm-packages/artifacts-common/package.json
@@ -3,7 +3,7 @@
     "version": "2.276.0",
     "description": "Azure Artifacts common code (for new authentication tasks)",
     "scripts": {
-        "build": "cd ../build-scripts && npm install && cd ../artifacts-common && node make.js"
+        "build": "cd ../build-scripts && npm ci && cd ../artifacts-common && node make.js"
     },
     "author": "Microsoft Corporation",
     "repository": {

--- a/common-npm-packages/az-blobstorage-provider/package.json
+++ b/common-npm-packages/az-blobstorage-provider/package.json
@@ -31,6 +31,7 @@
         "handlebars": "^4.7.9"
     },
     "scripts": {
-        "build": "cd ../build-scripts && npm ci && cd ../az-blobstorage-provider && node make.js"
+        "build": "cd ../build-scripts && npm install && cd ../az-blobstorage-provider && node make.js",
+        "build:ci": "node make.js"
     }
 }

--- a/common-npm-packages/az-blobstorage-provider/package.json
+++ b/common-npm-packages/az-blobstorage-provider/package.json
@@ -31,6 +31,6 @@
         "handlebars": "^4.7.9"
     },
     "scripts": {
-        "build": "cd ../build-scripts && npm install && cd ../az-blobstorage-provider && node make.js"
+        "build": "cd ../build-scripts && npm ci && cd ../az-blobstorage-provider && node make.js"
     }
 }

--- a/common-npm-packages/build-scripts/create-release.js
+++ b/common-npm-packages/build-scripts/create-release.js
@@ -172,12 +172,12 @@ async function getPRsFiles(PRs, _package) {
  * @param {string} releaseNotes - Release notes for the new release
  * @param {string} _package - The name of the package
  * @param {string} version - Version of the new release
- * @param {string} releaseBranch - Branch to create the release on
+ * @param {string} targetCommitish - Commit to create the release on
  */
-async function createRelease(releaseNotes, _package, version, releaseBranch) {
+async function createRelease(releaseNotes, _package, version, targetCommitish) {
     const name = `Release ${_package} ${version}`;
     const tagName = `${_package}-${version}`;
-    console.log(`Creating release ${tagName} on ${releaseBranch}`);
+    console.log(`Creating release ${tagName} on ${targetCommitish}`);
     const octokit = await getESMOctokit(token);
 
     const newRelease = await octokit.repos.createRelease({
@@ -186,7 +186,7 @@ async function createRelease(releaseNotes, _package, version, releaseBranch) {
         tag_name: tagName,
         name,
         body: releaseNotes,
-        target_commitish: releaseBranch
+        target_commitish: targetCommitish
     });
 
     console.log(`Release ${tagName} created`);
@@ -218,10 +218,11 @@ async function isReleaseTagExists(_package, version) {
 /**
  * Function to create release notes for the package
  * @param {string} _package - Package name to create release notes for
- * @param {string} branch - Branch to create release notes for
+ * @param {string} branch - Branch to query for merged pull requests
+ * @param {string} targetCommitish - Commit to create the release on
  * @returns
  */
-async function createReleaseNotes(_package, branch) {
+async function createReleaseNotes(_package, branch, targetCommitish) {
     try {
         const version = util.getCurrentPackageVersion(_package);
         const isReleaseExists = await isReleaseTagExists(_package, version);
@@ -248,7 +249,7 @@ async function createReleaseNotes(_package, branch) {
         }
 
         const releaseNotes = changes.join('\n');
-        await createRelease(releaseNotes, _package, version, branch);
+        await createRelease(releaseNotes, _package, version, targetCommitish);
     } catch (e) {
         throw new util.CreateReleaseError(e.message);
     }

--- a/common-npm-packages/codeanalysis-common/package.json
+++ b/common-npm-packages/codeanalysis-common/package.json
@@ -25,7 +25,7 @@
     },
     "main": "VSTS Tasks Code Analysis",
     "scripts": {
-        "build": "cd ../build-scripts && npm install && cd ../codeanalysis-common && node make.js --build",
+        "build": "cd ../build-scripts && npm ci && cd ../codeanalysis-common && node make.js --build",
         "test": "mocha _build/Tests/L0.js"
     },
     "repository": {

--- a/common-npm-packages/codeanalysis-common/package.json
+++ b/common-npm-packages/codeanalysis-common/package.json
@@ -25,7 +25,8 @@
     },
     "main": "VSTS Tasks Code Analysis",
     "scripts": {
-        "build": "cd ../build-scripts && npm ci && cd ../codeanalysis-common && node make.js --build",
+        "build": "cd ../build-scripts && npm install && cd ../codeanalysis-common && node make.js --build",
+        "build:ci": "node make.js --build",
         "test": "mocha _build/Tests/L0.js"
     },
     "repository": {

--- a/common-npm-packages/codecoverage-tools/package.json
+++ b/common-npm-packages/codecoverage-tools/package.json
@@ -30,7 +30,7 @@
 	    "serialize-javascript": "^7.0.4"
     },
     "scripts": {
-        "build": "cd ../build-scripts && npm install && cd ../codecoverage-tools && node make.js",
+        "build": "cd ../build-scripts && npm ci && cd ../codecoverage-tools && node make.js",
         "test": "mocha _build/Tests/L0.js"
     },
     "repository": {

--- a/common-npm-packages/codecoverage-tools/package.json
+++ b/common-npm-packages/codecoverage-tools/package.json
@@ -30,7 +30,8 @@
 	    "serialize-javascript": "^7.0.4"
     },
     "scripts": {
-        "build": "cd ../build-scripts && npm ci && cd ../codecoverage-tools && node make.js",
+        "build": "cd ../build-scripts && npm install && cd ../codecoverage-tools && node make.js",
+        "build:ci": "node make.js",
         "test": "mocha _build/Tests/L0.js"
     },
     "repository": {

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -28,7 +28,8 @@
         "typescript": "^4.9.5"
     },
     "scripts": {
-        "build": "cd ../build-scripts && npm ci && cd ../docker-common && node make.js",
+        "build": "cd ../build-scripts && npm install && cd ../docker-common && node make.js",
+        "build:ci": "node make.js",
         "test": "npm run build && mocha _build/Tests/L0.js"
     }
 }

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -28,7 +28,7 @@
         "typescript": "^4.9.5"
     },
     "scripts": {
-        "build": "cd ../build-scripts && npm install && cd ../docker-common && node make.js",
+        "build": "cd ../build-scripts && npm ci && cd ../docker-common && node make.js",
         "test": "npm run build && mocha _build/Tests/L0.js"
     }
 }

--- a/common-npm-packages/ios-signing-common/package.json
+++ b/common-npm-packages/ios-signing-common/package.json
@@ -4,7 +4,8 @@
     "description": "Azure Pipelines tasks iOS Signing Common",
     "main": "ios-signing-common.js",
     "scripts": {
-        "build": "cd ../build-scripts && npm ci && cd ../ios-signing-common && node make.js"
+        "build": "cd ../build-scripts && npm install && cd ../ios-signing-common && node make.js",
+        "build:ci": "node make.js"
     },
     "repository": {
         "type": "git",

--- a/common-npm-packages/ios-signing-common/package.json
+++ b/common-npm-packages/ios-signing-common/package.json
@@ -4,7 +4,7 @@
     "description": "Azure Pipelines tasks iOS Signing Common",
     "main": "ios-signing-common.js",
     "scripts": {
-        "build": "cd ../build-scripts && npm install && cd ../ios-signing-common && node make.js"
+        "build": "cd ../build-scripts && npm ci && cd ../ios-signing-common && node make.js"
     },
     "repository": {
         "type": "git",

--- a/common-npm-packages/java-common/package.json
+++ b/common-npm-packages/java-common/package.json
@@ -4,7 +4,7 @@
     "description": "Azure Pipelines tasks Java Common",
     "main": "java-common.js",
     "scripts": {
-        "build": "cd ../build-scripts && npm install && cd ../java-common && node make.js"
+        "build": "cd ../build-scripts && npm ci && cd ../java-common && node make.js"
     },
     "repository": {
         "type": "git",

--- a/common-npm-packages/java-common/package.json
+++ b/common-npm-packages/java-common/package.json
@@ -4,7 +4,8 @@
     "description": "Azure Pipelines tasks Java Common",
     "main": "java-common.js",
     "scripts": {
-        "build": "cd ../build-scripts && npm ci && cd ../java-common && node make.js"
+        "build": "cd ../build-scripts && npm install && cd ../java-common && node make.js",
+        "build:ci": "node make.js"
     },
     "repository": {
         "type": "git",

--- a/common-npm-packages/kubernetes-common/package.json
+++ b/common-npm-packages/kubernetes-common/package.json
@@ -29,6 +29,7 @@
         "typescript": "^4.9.5"
     },
     "scripts": {
-        "build": "cd ../build-scripts && npm ci && cd ../kubernetes-common && node make.js"
+        "build": "cd ../build-scripts && npm install && cd ../kubernetes-common && node make.js",
+        "build:ci": "node make.js"
     }
 }

--- a/common-npm-packages/kubernetes-common/package.json
+++ b/common-npm-packages/kubernetes-common/package.json
@@ -29,6 +29,6 @@
         "typescript": "^4.9.5"
     },
     "scripts": {
-        "build": "cd ../build-scripts && npm install && cd ../kubernetes-common && node make.js"
+        "build": "cd ../build-scripts && npm ci && cd ../kubernetes-common && node make.js"
     }
 }

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -4,7 +4,7 @@
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "mocha _build/Tests/L0.js",
-        "build": "cd ../build-scripts && npm install && cd ../packaging-common && node make.js"
+        "build": "cd ../build-scripts && npm ci && cd ../packaging-common && node make.js"
     },
     "author": "Microsoft Corporation",
     "repository": {

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -4,7 +4,8 @@
     "description": "Azure Pipelines Packaging Tasks Common",
     "scripts": {
         "test": "mocha _build/Tests/L0.js",
-        "build": "cd ../build-scripts && npm ci && cd ../packaging-common && node make.js"
+        "build": "cd ../build-scripts && npm install && cd ../packaging-common && node make.js",
+        "build:ci": "node make.js"
     },
     "author": "Microsoft Corporation",
     "repository": {

--- a/common-npm-packages/securefiles-common/package.json
+++ b/common-npm-packages/securefiles-common/package.json
@@ -4,7 +4,7 @@
     "description": "Azure Pipelines tasks SecureFiles Common",
     "main": "securefiles-common.js",
     "scripts": {
-        "build": "cd ../build-scripts && npm install && cd ../securefiles-common && node make.js"
+        "build": "cd ../build-scripts && npm ci && cd ../securefiles-common && node make.js"
     },
     "repository": {
         "type": "git",

--- a/common-npm-packages/securefiles-common/package.json
+++ b/common-npm-packages/securefiles-common/package.json
@@ -4,7 +4,8 @@
     "description": "Azure Pipelines tasks SecureFiles Common",
     "main": "securefiles-common.js",
     "scripts": {
-        "build": "cd ../build-scripts && npm ci && cd ../securefiles-common && node make.js"
+        "build": "cd ../build-scripts && npm install && cd ../securefiles-common && node make.js",
+        "build:ci": "node make.js"
     },
     "repository": {
         "type": "git",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -8,8 +8,9 @@
         "directory": "common-npm-packages/webdeployment-common"
     },
     "scripts": {
-        "prebuild": "cd ../build-scripts && npm ci",
+        "prebuild": "cd ../build-scripts && npm install",
         "build": "pwsh build.ps1",
+        "build:ci": "pwsh build.ps1",
         "test": "nyc --all --src ./_build mocha ./_build/Tests/L0.js"
     },
     "author": "Microsoft Corporation",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -8,7 +8,7 @@
         "directory": "common-npm-packages/webdeployment-common"
     },
     "scripts": {
-        "prebuild": "cd ../build-scripts && npm install",
+        "prebuild": "cd ../build-scripts && npm ci",
         "build": "pwsh build.ps1",
         "test": "nyc --all --src ./_build mocha ./_build/Tests/L0.js"
     },

--- a/make.js
+++ b/make.js
@@ -10,7 +10,8 @@ const defaultTestSuite = 'L0';
 const predefinedFlags = {
     boolean: [
         'build',
-        'test'
+        'test',
+        'ci'
     ],
     string: [
         'suite',
@@ -19,6 +20,7 @@ const predefinedFlags = {
 };
 
 const options = minimist(process.argv, predefinedFlags)
+const installCommand = options['ci'] ? 'npm ci' : 'npm install';
 const testResultsPath = path.join(__dirname, 'test-results');
 const mochaReporterPath = path.join(__dirname, 'common-npm-packages', 'build-scripts', 'junit-spec-reporter.js');
 const coverageBaseNameJson = 'coverage-final.json';
@@ -37,14 +39,14 @@ const printLabel = (name) => {
 const installBuildScriptsDependencies = () => {
     console.log('Installing dependencies for BuildScripts');
     util.cd('common-npm-packages/build-scripts');
-    util.run('npm ci');
+    util.run(installCommand);
     util.cd(__dirname);
 }
 
 const buildPsTestHelpers = () => {
     console.log('Building Tests');
     util.cd('Tests');
-    util.run('npm ci');
+    util.run(installCommand);
     util.run(path.join('node_modules', '.bin', 'tsc'));
     util.cd(__dirname);
 }
@@ -64,8 +66,10 @@ if (options['build']) {
             printLabel(child);
 
             util.cd(child);
-            util.run('npm ci');
-            util.run('npm run build');
+            util.run(installCommand);
+            const packageDefinition = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+            const buildScript = options['ci'] && packageDefinition.scripts?.['build:ci'] ? 'build:ci' : 'build';
+            util.run(`npm run ${buildScript}`);
             util.cd('..');
         }
     });

--- a/make.js
+++ b/make.js
@@ -37,14 +37,14 @@ const printLabel = (name) => {
 const installBuildScriptsDependencies = () => {
     console.log('Installing dependencies for BuildScripts');
     util.cd('common-npm-packages/build-scripts');
-    util.run('npm install');
+    util.run('npm ci');
     util.cd(__dirname);
 }
 
 const buildPsTestHelpers = () => {
     console.log('Building Tests');
     util.cd('Tests');
-    util.run('npm install');
+    util.run('npm ci');
     util.run(path.join('node_modules', '.bin', 'tsc'));
     util.cd(__dirname);
 }
@@ -64,7 +64,7 @@ if (options['build']) {
             printLabel(child);
 
             util.cd(child);
-            util.run('npm install');
+            util.run('npm ci');
             util.run('npm run build');
             util.cd('..');
         }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Shared npm packages for azure pipelines tasks",
   "main": "make.js",
   "scripts": {
-    "build": "npm ci && cd common-npm-packages/build-scripts && npm ci && cd ../.. && node make.js --build",
+    "build": "npm install && cd common-npm-packages/build-scripts && npm install && cd ../.. && node make.js --build",
+    "build:ci": "node make.js --build --ci",
     "test": "node make.js --test",
+    "test:ci": "node make.js --test --ci",
     "create-releases": "node publish.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm install && cd common-npm-packages/build-scripts && npm install && cd ../.. && node make.js --build",
     "test": "node make.js --test",
-    "publish": "node publish.js"
+    "create-releases": "node publish.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Shared npm packages for azure pipelines tasks",
   "main": "make.js",
   "scripts": {
-    "build": "npm install && cd common-npm-packages/build-scripts && npm install && cd ../.. && node make.js --build",
+    "build": "npm ci && cd common-npm-packages/build-scripts && npm ci && cd ../.. && node make.js --build",
     "test": "node make.js --test",
     "create-releases": "node publish.js"
   },

--- a/publish.js
+++ b/publish.js
@@ -21,12 +21,8 @@ async function createGitHubReleases(packages) {
                 await releaseNotes.createReleaseNotes(package, 'main', releaseTarget);
             }
             catch(ex) {
-                if (ex instanceof util.CreateReleaseError) {
-                    console.error(`Error creating release notes for ${package}: ${ex.message}`);
-                    failures.push(package);
-                } else {
-                    throw ex;
-                }
+                console.error(`Error creating release notes for ${package}: ${ex.message}`);
+                failures.push(package);
             }
         }
     }

--- a/publish.js
+++ b/publish.js
@@ -2,36 +2,43 @@ const fs = require('fs');
 const util = require('./common-npm-packages/build-scripts/util');
 const releaseNotes = require('./common-npm-packages/build-scripts/create-release');
 
-console.log('Publishing shared npm packages');
+console.log('Creating GitHub releases for shared npm packages');
 
-async function publishPackages(packages) {
+async function createGitHubReleases(packages) {
+    const releaseTarget = process.env['RELEASE_TARGET'];
+    if (!releaseTarget) {
+        throw new util.CreateReleaseError('RELEASE_TARGET is not defined');
+    }
+
+    const failures = [];
     for (let i = 0; i < packages.length; i++) {
         const package = packages[i];
         if (fs.statSync(package).isDirectory() &&  ['build-scripts', '.git', '_download', 'node_modules'].indexOf(package) < 0) {
             console.log('\n----------------------------------');
             console.log(package);
             console.log('----------------------------------');
-            util.cd(package);
-            util.cd('_build');
             try {
-                const npmrc = `//registry.npmjs.org/:_authToken=\${NPM_TOKEN}`;
-                console.log(`Writing .npmrc: ${npmrc}`);
-                fs.writeFileSync('.npmrc', npmrc);
-                util.run('npm publish --registry https://registry.npmjs.org/');
-                await releaseNotes.createReleaseNotes(package, 'main');
+                await releaseNotes.createReleaseNotes(package, 'main', releaseTarget);
             }
             catch(ex) {
                 if (ex instanceof util.CreateReleaseError) {
-                    console.log(`Error creating release notes: ${ex.message}`);
+                    console.error(`Error creating release notes for ${package}: ${ex.message}`);
+                    failures.push(package);
                 } else {
-                    console.log('Publish failed - this usually indicates that the package has already been published');
+                    throw ex;
                 }
             }
-            util.cd('../..');
         }
+    }
+
+    if (failures.length > 0) {
+        throw new util.CreateReleaseError(`Failed to create GitHub releases for: ${failures.join(', ')}`);
     }
 }
 
 util.cd('common-npm-packages');
 const packages = fs.readdirSync('./', { encoding: 'utf-8' });
-publishPackages(packages);
+createGitHubReleases(packages).catch(error => {
+    console.error(`Failed to create GitHub releases: ${error.message}`);
+    process.exitCode = 1;
+});

--- a/publish.js
+++ b/publish.js
@@ -32,7 +32,7 @@ async function createGitHubReleases(packages) {
     }
 
     if (failures.length > 0) {
-        throw new util.CreateReleaseError(`Failed to create GitHub releases for: ${failures.join(', ')}`);
+        console.warn(`GitHub release creation failed for: ${failures.join(', ')}`);
     }
 }
 


### PR DESCRIPTION
## Summary
- make the cross-platform CI pipeline build/test-only and remove npm publishing tokens
- convert the existing release pipeline to a manual 1ES build/pack + `EsrpRelease@12` flow
- pack all 15 fresh `_build` outputs into the same-run `npm-packages/packages` artifact with count and SBOM guards
- create GitHub releases/tags only after ESRP succeeds, failing closed and targeting the exact published commit
- add a safe dry-run mode that validates the complete build/package flow without publishing or tagging

## Dry-run usage
When manually queuing the release pipeline, set **Build and validate without publishing** (`dryRun`) to `true` to run the full `BuildAndPack` stage only. All 15 packages are built, tested, packed into `npm-packages/packages`, counted, and checked for embedded `_manifest/`; the ESRP stage and dependent GitHub release/tag job are omitted at compile time.

Leave `dryRun` at its default `false` for the production flow: `BuildAndPack` -> ESRP publish -> GitHub releases/tags.

## Package ordering
`azure-pipelines-tasks-docker-common` depends on `azure-pipelines-tasks-azure-arm-rest` (`^3.272.1`). The current range is already satisfied, so this flat ESRP release does not require intra-run ordering. A future coordinated minimum-version bump should use the Beachball ESRP release helper because ESRP does not order packages.

## Validation
- YAML parsing and JavaScript syntax checks passed
- both compile-time modes were structurally validated: `dryRun: false` includes `BuildAndPack` and `PublishToNpmViaESRP`; `dryRun: true` includes only `BuildAndPack`
- all packages built successfully
- 15 tarballs were packed and matched the 15 expected packages
- no tarball contained `_manifest/`
- the full test run had one pre-existing Azure ARM REST 2-second timeout; the isolated rerun passed
- no `npm publish`, `NPM_TOKEN`, `npm-automation.token`, or `npm-tokens` references remain

## Manual prerequisites
Before running the manual release pipeline:
- install the ESRP Release Azure DevOps extension
- onboard and approve the ESRP publisher identity
- provision the signing certificate in Key Vault and grant `Key Vault Certificate User`
- create the WIF/OIDC Azure RM service connection
- allow-list all 15 npm packages for the ESRP publisher
- create `esrp-npm-release` with `EsrpServiceConnection`, `EsrpKeyVault`, `EsrpSignCert`, `EsrpClientId`, `EsrpOwners`, and `EsrpApprovers`
- configure `gh-automation.token` as a release-pipeline secret outside the removed `npm-tokens` group
- register `.azure-pipelines/release-pipeline.yml` as a manual pipeline

---
Related work item: [AB#2440593](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2440593)