### PR TITLE
Kudu-scoped tokens: App Service-audience Entra tokens for Kudu/SCM (ADO 2401907)

### DIFF
--- a/common-npm-packages/azure-arm-rest/Tests/L0-scope-token-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-scope-token-tests.ts
@@ -12,10 +12,16 @@ export function ScopeTokenTests(defaultTimeout = 2000) {
             .then(() => {
                 assert(tr.succeeded, "scope-token-tests should have passed but failed.");
 
+                console.log("\tvalidating scoped token success");
+                scopedTokenSuccess(tr);
+                console.log("\tvalidating scoped token success on Node <16 (MSAL path)");
+                scopedTokenSuccessOnLegacyNode(tr);
                 console.log("\tvalidating fallback when the feature is disabled");
                 fallbackWhenFeatureDisabled(tr);
                 console.log("\tvalidating fallback (with warning) when the scope is unmapped");
                 fallbackWhenScopeUnmapped(tr);
+                console.log("\tvalidating scoped token acquisition failure");
+                scopedTokenFailure(tr);
 
                 done();
             })
@@ -25,6 +31,22 @@ export function ScopeTokenTests(defaultTimeout = 2000) {
                 done(error);
             });
     });
+}
+
+function scopedTokenSuccess(tr: ttm.MockTestRunner) {
+    assert(tr.stdOutContained('SCOPED_TOKEN: DUMMY_APPSERVICE_TOKEN'),
+        'Should have returned the App Service-audience token when the scope is mapped');
+    assert(tr.stdOutContained('"requestedAudience":"AppService"'),
+        'Scoped telemetry should record the App Service audience');
+    assert(tr.stdOutContained('"outcome":"scoped"'),
+        'Should have emitted telemetry with outcome scoped');
+}
+
+function scopedTokenSuccessOnLegacyNode(tr: ttm.MockTestRunner) {
+    assert(tr.stdOutContained('SCOPED_TOKEN_LEGACY_NODE: DUMMY_APPSERVICE_TOKEN_VIA_MSAL'),
+        'Should have returned the App Service-audience token via MSAL when @azure/identity is unavailable (Node <16)');
+    assert(tr.stdOutContained('using MSAL to acquire scoped token instead of @azure/identity'),
+        'Should have logged that MSAL is used instead of @azure/identity');
 }
 
 // Feature disabled: returns the ARM-audience token, records outcome "fallbackDisabled", no warning.
@@ -47,4 +69,13 @@ function fallbackWhenScopeUnmapped(tr: ttm.MockTestRunner) {
         'Should have emitted telemetry with outcome fallbackUnmapped');
     assert(tr.stdOutContained('"requestedAudience":"ARM"'),
         'Fallback telemetry should record the ARM audience');
+}
+
+function scopedTokenFailure(tr: ttm.MockTestRunner) {
+    assert(tr.stdOutContained('SCOPED_TOKEN_ERROR:'),
+        'Should have surfaced the scoped token acquisition failure');
+    assert(tr.stdOutContained('"requestedAudience":"None"'),
+        'Failure telemetry should not report an ARM audience');
+    assert(tr.stdOutContained('"outcome":"error"'),
+        'Should have emitted telemetry with outcome error');
 }

--- a/common-npm-packages/azure-arm-rest/Tests/L0-scope-token-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-scope-token-tests.ts
@@ -1,0 +1,50 @@
+import assert = require("assert");
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import * as path from 'path';
+
+export function ScopeTokenTests(defaultTimeout = 2000) {
+    it('acquireTokenForScope falls back to an ARM-audience token and emits telemetry', function (done: Mocha.Done) {
+        this.timeout(defaultTimeout);
+        let tp = path.join(__dirname, 'scope-token-tests.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.runAsync()
+            .then(() => {
+                assert(tr.succeeded, "scope-token-tests should have passed but failed.");
+
+                console.log("\tvalidating fallback when the feature is disabled");
+                fallbackWhenFeatureDisabled(tr);
+                console.log("\tvalidating fallback (with warning) when the scope is unmapped");
+                fallbackWhenScopeUnmapped(tr);
+
+                done();
+            })
+            .catch((error) => {
+                console.log(tr.stdout);
+                console.log(tr.stderr);
+                done(error);
+            });
+    });
+}
+
+// Feature disabled: returns the ARM-audience token, records outcome "fallbackDisabled", no warning.
+function fallbackWhenFeatureDisabled(tr: ttm.MockTestRunner) {
+    assert(tr.stdOutContained('FALLBACK_DISABLED_TOKEN: DUMMY_ACCESS_TOKEN'),
+        'Should have returned the ARM-audience token when the feature is disabled');
+    assert(tr.stdOutContained('"outcome":"fallbackDisabled"'),
+        'Should have emitted telemetry with outcome fallbackDisabled');
+    assert(tr.stdOutContained('feature=KuduScopeLevelToken'),
+        'Should have emitted KuduScopeLevelToken telemetry');
+}
+
+// Feature enabled but no scope mapped: warns, then returns the ARM-audience token, outcome "fallbackUnmapped".
+function fallbackWhenScopeUnmapped(tr: ttm.MockTestRunner) {
+    assert(tr.stdOutContained('FALLBACK_UNMAPPED_TOKEN: DUMMY_ACCESS_TOKEN'),
+        'Should have returned the ARM-audience token when the scope is unmapped');
+    assert(tr.stdOutContained('falling back to an ARM-audience token'),
+        'Should have warned when the feature is enabled but the scope is unmapped');
+    assert(tr.stdOutContained('"outcome":"fallbackUnmapped"'),
+        'Should have emitted telemetry with outcome fallbackUnmapped');
+    assert(tr.stdOutContained('"requestedAudience":"ARM"'),
+        'Fallback telemetry should record the ARM audience');
+}

--- a/common-npm-packages/azure-arm-rest/Tests/L0-scope-token-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-scope-token-tests.ts
@@ -16,6 +16,12 @@ export function ScopeTokenTests(defaultTimeout = 2000) {
                 scopedTokenSuccess(tr);
                 console.log("\tvalidating scoped token success on Node <16 (MSAL path)");
                 scopedTokenSuccessOnLegacyNode(tr);
+                console.log("\tvalidating Managed Identity scope resource selection");
+                managedIdentityScopeResource(tr);
+                console.log("\tvalidating federated token file cleanup");
+                federatedTokenFileCleanup(tr);
+                console.log("\tvalidating unknown Kudu auth mode");
+                unknownKuduAuthMode(tr);
                 console.log("\tvalidating fallback when the feature is disabled");
                 fallbackWhenFeatureDisabled(tr);
                 console.log("\tvalidating fallback (with warning) when the scope is unmapped");
@@ -47,6 +53,27 @@ function scopedTokenSuccessOnLegacyNode(tr: ttm.MockTestRunner) {
         'Should have returned the App Service-audience token via MSAL when @azure/identity is unavailable (Node <16)');
     assert(tr.stdOutContained('using MSAL to acquire scoped token instead of @azure/identity'),
         'Should have logged that MSAL is used instead of @azure/identity');
+}
+
+function managedIdentityScopeResource(tr: ttm.MockTestRunner) {
+    assert(tr.stdOutContained('MSI_SCOPE_RESOURCE: https://appservice'),
+        'Managed Identity should request the App Service resource for an App Service scope');
+}
+
+function federatedTokenFileCleanup(tr: ttm.MockTestRunner) {
+    assert(tr.stdOutContained('FEDERATED_TOKEN_CLEANUP_TEST: completed'),
+        'Federated token file cleanup test should have completed');
+    assert(tr.stdOutContained('feature=FederatedTokenFileCleanup]{"outcome":"deleted"}'),
+        'Successful federated token file cleanup should emit telemetry');
+    assert(tr.stdOutContained('feature=FederatedTokenFileCleanup]{"outcome":"error"}'),
+        'Failed federated token file cleanup should emit telemetry');
+}
+
+function unknownKuduAuthMode(tr: ttm.MockTestRunner) {
+    assert(tr.stdOutContained('KUDU_AUTH_UNKNOWN: emitted'),
+        'Unknown Kudu auth mode test should have completed');
+    assert(tr.stdOutContained('"authMode":"unknown"'),
+        'Missing scope metadata should be classified as unknown');
 }
 
 // Feature disabled: returns the ARM-audience token, records outcome "fallbackDisabled", no warning.

--- a/common-npm-packages/azure-arm-rest/Tests/L0.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0.ts
@@ -8,6 +8,7 @@ import { AzureCliUtilityTests } from "./L0-azure-cli-utility-tests";
 import { OpenSSLCheck } from "./L0-azure-cli-openssl-check";
 import { AzureAppServiceUtilityTests } from "./L0-azure-app-service-utility-tests";
 import { KuduLogSanitizerTests } from "./L0-kudu-log-sanitizer-tests";
+import { ScopeTokenTests } from "./L0-scope-token-tests";
 
 const DEFAULT_TIMEOUT = 1000 * 20;
 
@@ -23,4 +24,5 @@ describe("AzureARMRestTests", function () {
     describe("Azure Cli OpenSSL check", OpenSSLCheck.bind(OpenSSLCheck, DEFAULT_TIMEOUT));
     describe("AzureAppServiceUtility Tests", AzureAppServiceUtilityTests.bind(AzureAppServiceUtilityTests, DEFAULT_TIMEOUT));
     describe("Kudu log VSO-command sanitizer Tests", KuduLogSanitizerTests);
+    describe("Scope-level token Tests", ScopeTokenTests.bind(ScopeTokenTests, DEFAULT_TIMEOUT));
 });

--- a/common-npm-packages/azure-arm-rest/Tests/scope-token-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/scope-token-tests.ts
@@ -1,5 +1,9 @@
 import { ApplicationTokenCredentials } from '../azure-arm-common';
-import { getMockEndpoint } from './mock_utils';
+import { publishKuduAuthModeTelemetry } from '../azureAppServiceUtility';
+import { getMockEndpoint, nock } from './mock_utils';
+import fs = require('fs');
+import os = require('os');
+import path = require('path');
 import tl = require('azure-pipelines-task-lib/task');
 
 // Installs the ARM (ADAL) nock interceptor that answers the client-credentials token
@@ -29,6 +33,28 @@ function makeCreds(allowScopeLevelToken: boolean, scopes: any): ApplicationToken
         false,       // useMSAL -> ADAL path (served by nock)
         allowScopeLevelToken,
         scopes
+    );
+}
+
+function makeManagedIdentityCreds(): any {
+    return new ApplicationTokenCredentials(
+        "MOCK_SERVICE_CONNECTION",
+        undefined,
+        "MOCK_TENANT_ID",
+        undefined,
+        "https://management.azure.com/",
+        "https://login.windows.net/",
+        "https://management.azure.com/",
+        false,
+        "ManagedServiceIdentity",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        true,
+        { appservice: "https://appservice/.default" }
     );
 }
 
@@ -100,6 +126,91 @@ class ScopeTokenTests {
         }
     }
 
+    // Managed Identity uses the requested scope's resource instead of always requesting ARM.
+    public static async managedIdentityScopeResource() {
+        try {
+            nock("http://169.254.169.254", {
+                reqheaders: {
+                    "Metadata": true
+                }
+            })
+                .get("/metadata/identity/oauth2/token")
+                .query({
+                    "api-version": "2018-02-01",
+                    "resource": "https://appservice"
+                })
+                .reply(200, {
+                    access_token: "DUMMY_APPSERVICE_TOKEN_FROM_MSI",
+                    expires_in: 3600
+                });
+
+            const creds = makeManagedIdentityCreds();
+            const msalClient = await creds.buildMSAL();
+            const result = await msalClient.acquireTokenByClientCredential({
+                scopes: ["https://appservice/.default"]
+            });
+            if (result.accessToken !== "DUMMY_APPSERVICE_TOKEN_FROM_MSI") {
+                throw new Error(`unexpected Managed Identity token: ${result.accessToken}`);
+            }
+            console.log('MSI_SCOPE_RESOURCE: https://appservice');
+        } catch (error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'managedIdentityScopeResource should have passed but failed');
+        }
+    }
+
+    public static async federatedTokenFileCleanup() {
+        let tempDirectory: string;
+        let cleanupFailurePath: string;
+        try {
+            const creds: any = makeCreds(true, { appservice: "https://appservice/.default" });
+            tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'azure-arm-rest-'));
+            const tokenFilePath = path.join(tempDirectory, 'token.jwt');
+            fs.writeFileSync(tokenFilePath, 'DUMMY_OIDC_TOKEN');
+            creds.deleteFederatedTokenFile(tokenFilePath);
+            if (fs.existsSync(tokenFilePath)) {
+                throw new Error('federated token file was not deleted');
+            }
+
+            cleanupFailurePath = path.join(tempDirectory, 'undeletable-directory');
+            fs.mkdirSync(cleanupFailurePath);
+            creds.deleteFederatedTokenFile(cleanupFailurePath);
+            console.log('FEDERATED_TOKEN_CLEANUP_TEST: completed');
+        } catch (error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'federatedTokenFileCleanup should have passed but failed');
+        } finally {
+            if (cleanupFailurePath && fs.existsSync(cleanupFailurePath)) {
+                fs.rmdirSync(cleanupFailurePath);
+            }
+            if (tempDirectory && fs.existsSync(tempDirectory)) {
+                fs.rmdirSync(tempDirectory);
+            }
+        }
+    }
+
+    public static async unknownKuduAuthMode() {
+        try {
+            publishKuduAuthModeTelemetry({
+                authMethod: "Bearer",
+                source: "test",
+                credentials: {
+                    getLastScopeTokenTelemetry: () => ({
+                        requestedAudience: undefined,
+                        outcome: undefined,
+                        allowScopeLevelToken: true,
+                        scheme: "ServicePrincipal",
+                        authorityHost: "login.windows.net"
+                    })
+                }
+            });
+            console.log('KUDU_AUTH_UNKNOWN: emitted');
+        } catch (error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'unknownKuduAuthMode should have passed but failed');
+        }
+    }
+
     // Feature enabled and scope mapped, but scoped token acquisition fails -> fails without ARM fallback.
     public static async scopedTokenFailure() {
         try {
@@ -122,6 +233,9 @@ class ScopeTokenTests {
 async function RUNTESTS() {
     await ScopeTokenTests.scopedTokenSuccess();
     await ScopeTokenTests.scopedTokenSuccessOnLegacyNode();
+    await ScopeTokenTests.managedIdentityScopeResource();
+    await ScopeTokenTests.federatedTokenFileCleanup();
+    await ScopeTokenTests.unknownKuduAuthMode();
     await ScopeTokenTests.fallbackWhenFeatureDisabled();
     await ScopeTokenTests.fallbackWhenScopeUnmapped();
     await ScopeTokenTests.scopedTokenFailure();

--- a/common-npm-packages/azure-arm-rest/Tests/scope-token-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/scope-token-tests.ts
@@ -1,0 +1,66 @@
+import { ApplicationTokenCredentials } from '../azure-arm-common';
+import { getMockEndpoint } from './mock_utils';
+import tl = require('azure-pipelines-task-lib/task');
+
+// Installs the ARM (ADAL) nock interceptor that answers the client-credentials token
+// request with "DUMMY_ACCESS_TOKEN". This is the ARM-audience token that acquireTokenForScope
+// must return whenever it falls back (feature disabled or scope unmapped).
+getMockEndpoint();
+
+// Builds a Service Principal (key) credential wired to the same tenant/authority/secret the
+// mock nock interceptor expects. useMSAL=false forces the ADAL path so getToken() is served
+// by nock rather than a real network/MSAL call.
+function makeCreds(allowScopeLevelToken: boolean, scopes: any): ApplicationTokenCredentials {
+    return new ApplicationTokenCredentials(
+        "MOCK_SERVICE_CONNECTION",
+        "MOCK_SPN_ID",
+        "MOCK_TENANT_ID",
+        "MOCK_SPN_KEY",
+        "https://management.azure.com/",
+        "https://login.windows.net/",
+        "https://management.azure.com/",
+        false,
+        undefined,   // scheme -> ServicePrincipal
+        undefined,   // msiClientId
+        undefined,   // authType -> servicePrincipalKey
+        undefined,   // certFilePath
+        undefined,   // isADFSEnabled
+        undefined,   // access_token
+        false,       // useMSAL -> ADAL path (served by nock)
+        allowScopeLevelToken,
+        scopes
+    );
+}
+
+class ScopeTokenTests {
+    // Feature disabled -> returns the ARM-audience token, no warning.
+    public static async fallbackWhenFeatureDisabled() {
+        try {
+            const creds = makeCreds(false, undefined);
+            const token = await creds.acquireTokenForScope("appservice");
+            console.log('FALLBACK_DISABLED_TOKEN: ' + token);
+        } catch (error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'fallbackWhenFeatureDisabled should have passed but failed');
+        }
+    }
+
+    // Feature enabled but no scope mapped for this environment -> warns, then falls back to ARM.
+    public static async fallbackWhenScopeUnmapped() {
+        try {
+            const creds = makeCreds(true, {}); // no 'appservice' key
+            const token = await creds.acquireTokenForScope("appservice");
+            console.log('FALLBACK_UNMAPPED_TOKEN: ' + token);
+        } catch (error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'fallbackWhenScopeUnmapped should have passed but failed');
+        }
+    }
+}
+
+async function RUNTESTS() {
+    await ScopeTokenTests.fallbackWhenFeatureDisabled();
+    await ScopeTokenTests.fallbackWhenScopeUnmapped();
+}
+
+RUNTESTS();

--- a/common-npm-packages/azure-arm-rest/Tests/scope-token-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/scope-token-tests.ts
@@ -33,6 +33,28 @@ function makeCreds(allowScopeLevelToken: boolean, scopes: any): ApplicationToken
 }
 
 class ScopeTokenTests {
+    // Feature enabled and scope mapped -> returns the App Service-audience token.
+    public static async scopedTokenSuccess() {
+        try {
+            const creds: any = makeCreds(true, { appservice: "https://appservice/.default" });
+            creds.buildCredentialByScheme = async () => ({
+                credential: {
+                    getToken: async (scope: string) => {
+                        if (scope !== "https://appservice/.default") {
+                            throw new Error("unexpected scope");
+                        }
+                        return { token: "DUMMY_APPSERVICE_TOKEN" };
+                    }
+                }
+            });
+            const token = await creds.acquireTokenForScope("appservice");
+            console.log('SCOPED_TOKEN: ' + token);
+        } catch (error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'scopedTokenSuccess should have passed but failed');
+        }
+    }
+
     // Feature disabled -> returns the ARM-audience token, no warning.
     public static async fallbackWhenFeatureDisabled() {
         try {
@@ -56,11 +78,53 @@ class ScopeTokenTests {
             tl.setResult(tl.TaskResult.Failed, 'fallbackWhenScopeUnmapped should have passed but failed');
         }
     }
+
+    // Feature enabled and scope mapped, but running on Node <16 (@azure/identity unavailable) ->
+    // uses MSAL (getMSALToken) with the mapped scope instead, still returns the App
+    // Service-audience token, no ARM compromise.
+    public static async scopedTokenSuccessOnLegacyNode() {
+        try {
+            const creds: any = makeCreds(true, { appservice: "https://appservice/.default" });
+            creds.supportsModernIdentity = () => false;
+            creds.getMSALToken = async (_force: boolean, _retryCount: number, _retryWaitMS: number, scopeOverride: string) => {
+                if (scopeOverride !== "https://appservice/.default") {
+                    throw new Error("unexpected scope passed to getMSALToken");
+                }
+                return "DUMMY_APPSERVICE_TOKEN_VIA_MSAL";
+            };
+            const token = await creds.acquireTokenForScope("appservice");
+            console.log('SCOPED_TOKEN_LEGACY_NODE: ' + token);
+        } catch (error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'scopedTokenSuccessOnLegacyNode should have passed but failed');
+        }
+    }
+
+    // Feature enabled and scope mapped, but scoped token acquisition fails -> fails without ARM fallback.
+    public static async scopedTokenFailure() {
+        try {
+            const creds: any = makeCreds(true, { appservice: "https://appservice/.default" });
+            creds.buildCredentialByScheme = async () => ({
+                credential: {
+                    getToken: async () => {
+                        throw new Error("scoped token unavailable");
+                    }
+                }
+            });
+            await creds.acquireTokenForScope("appservice");
+            tl.setResult(tl.TaskResult.Failed, 'scopedTokenFailure should have failed');
+        } catch (error) {
+            console.log('SCOPED_TOKEN_ERROR: ' + error.message);
+        }
+    }
 }
 
 async function RUNTESTS() {
+    await ScopeTokenTests.scopedTokenSuccess();
+    await ScopeTokenTests.scopedTokenSuccessOnLegacyNode();
     await ScopeTokenTests.fallbackWhenFeatureDisabled();
     await ScopeTokenTests.fallbackWhenScopeUnmapped();
+    await ScopeTokenTests.scopedTokenFailure();
 }
 
 RUNTESTS();

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -582,9 +582,12 @@ export class ApplicationTokenCredentials {
             case AzureModels.Scheme.WorkloadIdentityFederation:
                 tl.debug('Using WorkloadIdentityCredential for OIDC');
                 const federatedToken = await this.getFederatedToken();
+                // Use a unique file name per invocation. A fixed 'token.jwt' name races when
+                // multiple credentials are built concurrently in the same job (e.g. parallel
+                // slot deployments), where one write can clobber another's federated token.
                 const tokenFilePath = path.join(
                     tl.getVariable('Agent.TempDirectory') || tl.getVariable('system.DefaultWorkingDirectory'),
-                    'token.jwt'
+                    `token-${crypto.randomBytes(16).toString('hex')}.jwt`
                 );
                 fs.writeFileSync(tokenFilePath, federatedToken);
 

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -65,6 +65,12 @@ export class ApplicationTokenCredentials {
     private scopes: any;
     private allowScopeLevelToken: boolean;
 
+    // Records the audience/outcome of the most recent acquireTokenForScope call so callers
+    // (e.g. the Kudu auth layer) can emit a single unified auth-mode telemetry event without
+    // re-deriving the scoped-vs-broad decision. Non-sensitive metadata only - never a token.
+    private _lastRequestedAudience: string = undefined;
+    private _lastScopeOutcome: string = undefined;
+
     private readonly tokenMutex: Mutex;
 
     constructor(
@@ -582,6 +588,10 @@ export class ApplicationTokenCredentials {
     // metadata is recorded - never a token, secret, or credential material. authorityHost is a
     // public Entra login endpoint used to identify the cloud.
     private publishScopeTokenTelemetry(scopeKind: string, requestedAudience: string, outcome: string): void {
+        // Remember the most recent decision so getLastScopeTokenTelemetry() can expose it to the
+        // Kudu auth layer for the unified KuduAuthMode event. Existing events below are unchanged.
+        this._lastRequestedAudience = requestedAudience;
+        this._lastScopeOutcome = outcome;
         try {
             let authorityHost = "";
             try {
@@ -620,6 +630,26 @@ export class ApplicationTokenCredentials {
         } catch (e) {
             tl.debug(`Failed to publish scope token telemetry: ${e}`);
         }
+    }
+
+    // Exposes non-sensitive metadata about the most recent scoped-token decision so the Kudu auth
+    // layer can publish a single, unified auth-mode telemetry event (basic vs scoped vs broad).
+    // requestedAudience/outcome are undefined until acquireTokenForScope has run (e.g. the Basic
+    // auth path never calls it); allowScopeLevelToken/scheme/authorityHost are always meaningful.
+    public getLastScopeTokenTelemetry(): { requestedAudience: string, outcome: string, allowScopeLevelToken: boolean, scheme: string, authorityHost: string } {
+        let authorityHost = "";
+        try {
+            authorityHost = this.authorityUrl ? new URL(this.authorityUrl).host : "";
+        } catch (e) {
+            authorityHost = "";
+        }
+        return {
+            requestedAudience: this._lastRequestedAudience,
+            outcome: this._lastScopeOutcome,
+            allowScopeLevelToken: !!this.allowScopeLevelToken,
+            scheme: this.scheme === undefined ? "ServicePrincipal" : AzureModels.Scheme[this.scheme],
+            authorityHost: authorityHost
+        };
     }
 
     private async buildCredentialByScheme(): Promise<any> {

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -567,6 +567,13 @@ export class ApplicationTokenCredentials {
             throw new Error(`@azure/identity is not supported on Node ${nodeVersion}. Please use Node 16 or higher for this authentication scheme.`);
         }
 
+        // Point @azure/identity credentials at the service connection's Entra authority so that
+        // scope-level tokens are requested from the correct (sovereign) cloud instead of the
+        // public login.microsoftonline.com default. this.authorityUrl carries the per-cloud
+        // authority (e.g. login.microsoftonline.us / login.chinacloudapi.cn) and is the same
+        // value the ARM/MSAL path derives its authority from (see buildMSAL).
+        const credentialOptions = { authorityHost: this.authorityUrl };
+
         switch (this.scheme) {
             case AzureModels.Scheme.ManagedServiceIdentity:
                 tl.debug('Using ManagedIdentityCredential for MSI');
@@ -582,6 +589,7 @@ export class ApplicationTokenCredentials {
                 fs.writeFileSync(tokenFilePath, federatedToken);
 
                 return new azureIdentity.WorkloadIdentityCredential({
+                    ...credentialOptions,
                     tenantId: this.tenantId,
                     clientId: this.clientId,
                     tokenFilePath: tokenFilePath
@@ -592,10 +600,10 @@ export class ApplicationTokenCredentials {
                 tl.debug('Using specific credential for Service Principal');
                 if (this.authType === constants.AzureServicePrinicipalAuthentications.servicePrincipalKey) {
                     tl.debug('Using ClientSecretCredential for key-based SPN');
-                    return new azureIdentity.ClientSecretCredential(this.tenantId, this.clientId, this.secret);
+                    return new azureIdentity.ClientSecretCredential(this.tenantId, this.clientId, this.secret, credentialOptions);
                 } else {
                     tl.debug('Using ClientCertificateCredential for certificate-based SPN');
-                    return new azureIdentity.ClientCertificateCredential(this.tenantId, this.clientId, this.certFilePath);
+                    return new azureIdentity.ClientCertificateCredential(this.tenantId, this.clientId, this.certFilePath, credentialOptions);
                 }
         }
     }

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -551,7 +551,17 @@ export class ApplicationTokenCredentials {
                 const tokenResponse = await credential.getToken(this.scopes[scopeKind]);
                 return tokenResponse.token;
             } else {
-                tl.debug(`allowScopeLevelToken is disabbled`);
+                if (this.allowScopeLevelToken && (!this.scopes || !this.scopes[scopeKind])) {
+                    // The scope-level token feature is enabled but no scope is mapped for this
+                    // cloud/scopeKind (e.g. an unregistered sovereign cloud). We deliberately fall
+                    // back to the ARM-audience token to preserve deployment functionality, but log
+                    // a warning so this is observable - a Kudu call receiving an ARM-audience token
+                    // is exactly what this feature aims to eliminate. authorityUrl (a public login
+                    // endpoint, not a secret) is logged to help identify the cloud.
+                    tl.warning(`acquireTokenForScope: no '${scopeKind}' scope is mapped for this environment (authority: ${this.authorityUrl}); falling back to an ARM-audience token.`);
+                } else {
+                    tl.debug(`allowScopeLevelToken is disabled`);
+                }
                 return await this.getToken();
             }
         } catch (error) {

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -549,8 +549,10 @@ export class ApplicationTokenCredentials {
                 tl.debug(`allowScopeLevelToken is enabled, using scope: ${this.scopes[scopeKind]}`);
                 const credential = await this.buildCredentialByScheme();
                 const tokenResponse = await credential.getToken(this.scopes[scopeKind]);
+                this.publishScopeTokenTelemetry(scopeKind, "AppService", "scoped");
                 return tokenResponse.token;
             } else {
+                let outcome: string;
                 if (this.allowScopeLevelToken && (!this.scopes || !this.scopes[scopeKind])) {
                     // The scope-level token feature is enabled but no scope is mapped for this
                     // cloud/scopeKind (e.g. an unregistered sovereign cloud). We deliberately fall
@@ -559,14 +561,49 @@ export class ApplicationTokenCredentials {
                     // is exactly what this feature aims to eliminate. authorityUrl (a public login
                     // endpoint, not a secret) is logged to help identify the cloud.
                     tl.warning(`acquireTokenForScope: no '${scopeKind}' scope is mapped for this environment (authority: ${this.authorityUrl}); falling back to an ARM-audience token.`);
+                    outcome = "fallbackUnmapped";
                 } else {
                     tl.debug(`allowScopeLevelToken is disabled`);
+                    outcome = "fallbackDisabled";
                 }
-                return await this.getToken();
+                const token = await this.getToken();
+                this.publishScopeTokenTelemetry(scopeKind, "ARM", outcome);
+                return token;
             }
         } catch (error) {
             tl.debug(`acquireTokenForScopes - error: ${error}`);
+            this.publishScopeTokenTelemetry(scopeKind, "None", "error");
             throw new Error(tl.loc('CouldNotFetchAccessTokenforAzureStatusCode', error.errorCode, error.errorMessage));
+        }
+    }
+
+    // Emits non-sensitive telemetry so we can prove Kudu/SCM calls request an App Service-audience
+    // token (and detect any ARM-audience fallback) once ALLOWSCOPELEVELTOKEN is rolled out. Only
+    // metadata is recorded - never a token, secret, or credential material. authorityHost is a
+    // public Entra login endpoint used to identify the cloud.
+    private publishScopeTokenTelemetry(scopeKind: string, requestedAudience: string, outcome: string): void {
+        try {
+            let authorityHost = "";
+            try {
+                authorityHost = this.authorityUrl ? new URL(this.authorityUrl).host : "";
+            } catch (e) {
+                authorityHost = "";
+            }
+            const payload = {
+                scopeKind: scopeKind,
+                requestedAudience: requestedAudience,
+                outcome: outcome,
+                allowScopeLevelToken: !!this.allowScopeLevelToken,
+                // this.scheme is undefined for the service-principal case (the constructor maps
+                // the endpoint's "ServicePrincipal" scheme against an enum that only defines
+                // ManagedServiceIdentity/SPN/WorkloadIdentityFederation), so default to
+                // "ServicePrincipal" instead of emitting an empty field.
+                scheme: this.scheme === undefined ? "ServicePrincipal" : AzureModels.Scheme[this.scheme],
+                authorityHost: authorityHost
+            };
+            console.log(`##vso[telemetry.publish area=TaskDeploymentMethod;feature=KuduScopeLevelToken]${JSON.stringify(payload)}`);
+        } catch (e) {
+            tl.debug(`Failed to publish scope token telemetry: ${e}`);
         }
     }
 

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -389,16 +389,19 @@ export class ApplicationTokenCredentials {
     }
 
     private configureMSALWithMSI(msalConfig: any /*msal.Configuration*/): any /*msal.ConfidentialClientApplication*/ {
-        let resourceId = this.activeDirectoryResourceId;
         let accessTokenProvider: any /*msal.IAppTokenProvider*/ = (appTokenProviderParameters: any /*msal.AppTokenProviderParameters*/): Promise<any> /*Promise<msal.AppTokenProviderResult>*/ => {
 
             tl.debug("MSAL - ManagedIdentity is used.");
 
-            let providerResultPromise = new Promise<any>/*Promise<msal.AppTokenProviderResult>*/(function (resolve, reject) {
+            let providerResultPromise = new Promise<any>/*Promise<msal.AppTokenProviderResult>*/((resolve, reject) => {
                 // same for MSAL
                 let webRequest = new webClient.WebRequest();
                 webRequest.method = "GET";
                 let apiVersion = "2018-02-01";
+                let requestedScope = appTokenProviderParameters && appTokenProviderParameters.scopes
+                    ? appTokenProviderParameters.scopes[0]
+                    : undefined;
+                let resourceId = this.getResourceIdFromScope(requestedScope);
                 webRequest.uri = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=" + apiVersion + "&resource=" + resourceId;
                 webRequest.headers = {
                     "Metadata": true
@@ -430,6 +433,13 @@ export class ApplicationTokenCredentials {
         let msalInstance = new msal.ConfidentialClientApplication(msalConfig);
         msalInstance.SetAppTokenProvider(accessTokenProvider);
         return msalInstance;
+    }
+
+    private getResourceIdFromScope(scope?: string): string {
+        const defaultScopeSuffix = "/.default";
+        return scope && scope.endsWith(defaultScopeSuffix)
+            ? scope.substring(0, scope.length - defaultScopeSuffix.length)
+            : this.activeDirectoryResourceId;
     }
 
     private configureMSALWithSP(msalConfig: any /*msal.Configuration*/): any /*msal.ConfidentialClientApplication*/ {
@@ -750,8 +760,19 @@ export class ApplicationTokenCredentials {
 
         try {
             fs.unlinkSync(tokenFilePath);
+            this.publishFederatedTokenFileCleanupTelemetry("deleted");
         } catch (error) {
+            tl.warning("Failed to delete the federated token file after token acquisition.");
             tl.debug(`Failed to delete federated token file '${tokenFilePath}': ${error}`);
+            this.publishFederatedTokenFileCleanupTelemetry("error");
+        }
+    }
+
+    private publishFederatedTokenFileCleanupTelemetry(outcome: string): void {
+        try {
+            console.log(`##vso[telemetry.publish area=TaskDeploymentMethod;feature=FederatedTokenFileCleanup]${JSON.stringify({ outcome: outcome })}`);
+        } catch (error) {
+            tl.debug(`Failed to publish federated token file cleanup telemetry: ${error}`);
         }
     }
 

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -602,6 +602,21 @@ export class ApplicationTokenCredentials {
                 authorityHost: authorityHost
             };
             console.log(`##vso[telemetry.publish area=TaskDeploymentMethod;feature=KuduScopeLevelToken]${JSON.stringify(payload)}`);
+
+            // Dedicated, stable signal for a production monitor. Whenever a Kudu/SCM call still
+            // receives an ARM-audience token we emit KuduArmTokenDeprecated so adoption of the
+            // scoped path can be measured (and the ARM path safely retired) later. Kept silent -
+            // no customer-facing warning - because the ARM fallback is still the expected behavior
+            // while ALLOWSCOPELEVELTOKEN is rolling out; a warning here would be noise.
+            if (requestedAudience === "ARM") {
+                const deprecationPayload = {
+                    source: "azure-arm-rest",
+                    reason: outcome,
+                    authorityHost: authorityHost
+                };
+                console.log(`##vso[telemetry.publish area=TaskDeploymentMethod;feature=KuduArmTokenDeprecated]${JSON.stringify(deprecationPayload)}`);
+                tl.debug(`[deprecation] Kudu/SCM received an ARM-audience token (reason=${outcome}). This path is deprecated and will be removed once ALLOWSCOPELEVELTOKEN is fully enabled.`);
+            }
         } catch (e) {
             tl.debug(`Failed to publish scope token telemetry: ${e}`);
         }

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -583,13 +583,13 @@ export class ApplicationTokenCredentials {
                     // Node 10 agents get a genuine App Service-scoped token, not a compromise.
                     tl.debug(`Node ${nodeVersion} detected; using MSAL to acquire scoped token instead of @azure/identity.`);
                     const token = await this.getMSALToken(false, 3, 2000, this.scopes[scopeKind]);
-                    this.publishScopeTokenTelemetry(scopeKind, "AppService", "scoped");
+                    this.publishScopeTokenTelemetry(scopeKind, this.getAudienceLabel(scopeKind), "scoped");
                     return token;
                 }
                 const credentialInfo = await this.buildCredentialByScheme();
                 try {
                     const tokenResponse = await credentialInfo.credential.getToken(this.scopes[scopeKind]);
-                    this.publishScopeTokenTelemetry(scopeKind, "AppService", "scoped");
+                    this.publishScopeTokenTelemetry(scopeKind, this.getAudienceLabel(scopeKind), "scoped");
                     return tokenResponse.token;
                 } finally {
                     this.deleteFederatedTokenFile(credentialInfo.tokenFilePath);
@@ -618,6 +618,32 @@ export class ApplicationTokenCredentials {
             this.publishScopeTokenTelemetry(scopeKind, "None", "error");
             throw new Error(tl.loc('CouldNotFetchAccessTokenforAzureStatusCode', error.errorCode, error.errorMessage));
         }
+    }
+
+    // Maps a scopeKind key (from the _azureScopes map built in azure-arm-endpoint.ts, e.g.
+    // 'appservice') to the human-readable audience label used in telemetry. 'appservice' is the
+    // only scopeKind acquireTokenForScope is called with today, so this always resolves to
+    // "AppService" in practice - but deriving it here (instead of hardcoding "AppService" at each
+    // call site) keeps requestedAudience honest if another scopeKind is ever wired in.
+    private static readonly scopeKindAudienceLabels: { [key: string]: string } = {
+        appservice: "AppService",
+        resourcemanager: "ARM",
+        storage: "Storage",
+        keyvalut: "KeyVault",
+        sqldatabase: "SqlDatabase",
+        cosmosdb: "CosmosDB",
+        servicebus: "ServiceBus",
+        eventhubs: "EventHubs",
+        eventgrid: "EventGrid",
+        cognitiveservices: "CognitiveServices",
+        containerregistry: "ContainerRegistry",
+        devops: "DevOps",
+        batch: "Batch",
+        datafactory: "DataFactory"
+    };
+
+    private getAudienceLabel(scopeKind: string): string {
+        return ApplicationTokenCredentials.scopeKindAudienceLabels[scopeKind] || scopeKind;
     }
 
     // Emits non-sensitive telemetry so we can prove Kudu/SCM calls request an App Service-audience

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -269,6 +269,12 @@ export class ApplicationTokenCredentials {
         }
     }
 
+    // Extracted as its own (overridable) method purely so tests can simulate the Node <16 branch
+    // of acquireTokenForScope without needing an actual Node 10 runtime.
+    private supportsModernIdentity(): boolean {
+        return nodeVersion >= 16;
+    }
+
     private async getMSAL(): Promise<any> /*Promise<msal.ConfidentialClientApplication>*/ {
         // use same instance if it already exists
         if (!this.msalInstance) {
@@ -513,7 +519,14 @@ export class ApplicationTokenCredentials {
         return msalInstance;
     }
 
-    private async getMSALToken(force?: boolean, retryCount: number = 3, retryWaitMS: number = 2000): Promise<string> {
+    // scopeOverride lets callers (e.g. acquireTokenForScope on Node <16, where @azure/identity is
+    // unavailable) request a specific scope/audience via MSAL instead of the default ARM audience.
+    // Callers must always pass one of our own hardcoded per-cloud entries from the `scopes` map
+    // built in azure-arm-endpoint.ts (getScopesByEnvironment) - e.g. appservice:
+    // 'https://appservice.azure.com/.default'. Those literals already include the "/.default"
+    // suffix, so it is NOT appended again here (unlike the default activeDirectoryResourceId case
+    // below, which is a bare resource URI and still needs the suffix).
+    private async getMSALToken(force?: boolean, retryCount: number = 3, retryWaitMS: number = 2000, scopeOverride?: string): Promise<string> {
         tl.debug(`MSAL - getMSALToken called. force=${force}`);
         const msalApp: any /*msal.ConfidentialClientApplication*/ = await this.getMSAL();
         if (force) {
@@ -521,7 +534,7 @@ export class ApplicationTokenCredentials {
         }
         try {
             const request: any /*msal.ClientCredentialRequest*/ = {
-                scopes: [this.activeDirectoryResourceId + "/.default"]
+                scopes: [scopeOverride || (this.activeDirectoryResourceId + "/.default")]
             };
             const response = await msalApp.acquireTokenByClientCredential(request);
             tl.debug(`MSAL - retrieved token - isFromCache?: ${response.fromCache}`);
@@ -532,7 +545,7 @@ export class ApplicationTokenCredentials {
                 tl.debug(`MSAL - retrying getMSALToken - remaining attempts: ${retryCount}`);
 
                 await new Promise(r => setTimeout(r, Math.min(retryWaitMS, MAX_CREATE_AAD_TOKEN_BACKOFF_TIMEOUT)));
-                return await this.getMSALToken(force, (retryCount - 1), retryWaitMS * 2);
+                return await this.getMSALToken(force, (retryCount - 1), retryWaitMS * 2, scopeOverride);
             }
 
             if (error.errorMessage && error.errorMessage.toString().startsWith("7000222")) {
@@ -553,10 +566,24 @@ export class ApplicationTokenCredentials {
         try {
             if (this.allowScopeLevelToken && this.scopes && this.scopes[scopeKind]) {
                 tl.debug(`allowScopeLevelToken is enabled, using scope: ${this.scopes[scopeKind]}`);
-                const credential = await this.buildCredentialByScheme();
-                const tokenResponse = await credential.getToken(this.scopes[scopeKind]);
-                this.publishScopeTokenTelemetry(scopeKind, "AppService", "scoped");
-                return tokenResponse.token;
+                if (!this.supportsModernIdentity()) {
+                    // @azure/identity requires Node 16+, but MSAL (msalv1) already supports SPN,
+                    // MSI, and WIF client-credential flows on Node 10. Request the same mapped
+                    // scope/audience through MSAL instead of falling back to the ARM audience, so
+                    // Node 10 agents get a genuine App Service-scoped token, not a compromise.
+                    tl.debug(`Node ${nodeVersion} detected; using MSAL to acquire scoped token instead of @azure/identity.`);
+                    const token = await this.getMSALToken(false, 3, 2000, this.scopes[scopeKind]);
+                    this.publishScopeTokenTelemetry(scopeKind, "AppService", "scoped");
+                    return token;
+                }
+                const credentialInfo = await this.buildCredentialByScheme();
+                try {
+                    const tokenResponse = await credentialInfo.credential.getToken(this.scopes[scopeKind]);
+                    this.publishScopeTokenTelemetry(scopeKind, "AppService", "scoped");
+                    return tokenResponse.token;
+                } finally {
+                    this.deleteFederatedTokenFile(credentialInfo.tokenFilePath);
+                }
             } else {
                 let outcome: string;
                 if (this.allowScopeLevelToken && (!this.scopes || !this.scopes[scopeKind])) {
@@ -669,7 +696,9 @@ export class ApplicationTokenCredentials {
         switch (this.scheme) {
             case AzureModels.Scheme.ManagedServiceIdentity:
                 tl.debug('Using ManagedIdentityCredential for MSI');
-                return new azureIdentity.ManagedIdentityCredential(this.msiClientId);
+                return {
+                    credential: new azureIdentity.ManagedIdentityCredential(this.msiClientId)
+                };
 
             case AzureModels.Scheme.WorkloadIdentityFederation:
                 tl.debug('Using WorkloadIdentityCredential for OIDC');
@@ -681,25 +710,48 @@ export class ApplicationTokenCredentials {
                     tl.getVariable('Agent.TempDirectory') || tl.getVariable('system.DefaultWorkingDirectory'),
                     `token-${crypto.randomBytes(16).toString('hex')}.jwt`
                 );
-                fs.writeFileSync(tokenFilePath, federatedToken);
-
-                return new azureIdentity.WorkloadIdentityCredential({
-                    ...credentialOptions,
-                    tenantId: this.tenantId,
-                    clientId: this.clientId,
-                    tokenFilePath: tokenFilePath
-                });
+                try {
+                    fs.writeFileSync(tokenFilePath, federatedToken);
+                    return {
+                        credential: new azureIdentity.WorkloadIdentityCredential({
+                            ...credentialOptions,
+                            tenantId: this.tenantId,
+                            clientId: this.clientId,
+                            tokenFilePath: tokenFilePath
+                        }),
+                        tokenFilePath: tokenFilePath
+                    };
+                } catch (error) {
+                    this.deleteFederatedTokenFile(tokenFilePath);
+                    throw error;
+                }
 
             case AzureModels.Scheme.SPN:
             default:
                 tl.debug('Using specific credential for Service Principal');
                 if (this.authType === constants.AzureServicePrinicipalAuthentications.servicePrincipalKey) {
                     tl.debug('Using ClientSecretCredential for key-based SPN');
-                    return new azureIdentity.ClientSecretCredential(this.tenantId, this.clientId, this.secret, credentialOptions);
+                    return {
+                        credential: new azureIdentity.ClientSecretCredential(this.tenantId, this.clientId, this.secret, credentialOptions)
+                    };
                 } else {
                     tl.debug('Using ClientCertificateCredential for certificate-based SPN');
-                    return new azureIdentity.ClientCertificateCredential(this.tenantId, this.clientId, this.certFilePath, credentialOptions);
+                    return {
+                        credential: new azureIdentity.ClientCertificateCredential(this.tenantId, this.clientId, this.certFilePath, credentialOptions)
+                    };
                 }
+        }
+    }
+
+    private deleteFederatedTokenFile(tokenFilePath?: string): void {
+        if (!tokenFilePath || !fs.existsSync(tokenFilePath)) {
+            return;
+        }
+
+        try {
+            fs.unlinkSync(tokenFilePath);
+        } catch (error) {
+            tl.debug(`Failed to delete federated token file '${tokenFilePath}': ${error}`);
         }
     }
 

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -628,6 +628,10 @@ export class ApplicationTokenCredentials {
     private static readonly scopeKindAudienceLabels: { [key: string]: string } = {
         appservice: "AppService",
         resourcemanager: "ARM",
+        // AzureCloud/AzureUSGovernment key this same scope 'resoucemanager' (pre-existing typo in
+        // azure-arm-endpoint.ts's _azureScopes map) - map both spellings so the label still
+        // resolves correctly if this scopeKind is ever wired in against one of those clouds.
+        resoucemanager: "ARM",
         storage: "Storage",
         keyvalut: "KeyVault",
         sqldatabase: "SqlDatabase",

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -583,13 +583,16 @@ export class ApplicationTokenCredentials {
                     // Node 10 agents get a genuine App Service-scoped token, not a compromise.
                     tl.debug(`Node ${nodeVersion} detected; using MSAL to acquire scoped token instead of @azure/identity.`);
                     const token = await this.getMSALToken(false, 3, 2000, this.scopes[scopeKind]);
-                    this.publishScopeTokenTelemetry(scopeKind, this.getAudienceLabel(scopeKind), "scoped");
+                    // acquireTokenForScope is only ever called for the App Service/Kudu scenario
+                    // (scopeKind is always "appservice"), so telemetry only needs to distinguish
+                    // this narrow case - not every possible _azureScopes key.
+                    this.publishScopeTokenTelemetry(scopeKind, "AppService", "scoped");
                     return token;
                 }
                 const credentialInfo = await this.buildCredentialByScheme();
                 try {
                     const tokenResponse = await credentialInfo.credential.getToken(this.scopes[scopeKind]);
-                    this.publishScopeTokenTelemetry(scopeKind, this.getAudienceLabel(scopeKind), "scoped");
+                    this.publishScopeTokenTelemetry(scopeKind, "AppService", "scoped");
                     return tokenResponse.token;
                 } finally {
                     this.deleteFederatedTokenFile(credentialInfo.tokenFilePath);
@@ -618,36 +621,6 @@ export class ApplicationTokenCredentials {
             this.publishScopeTokenTelemetry(scopeKind, "None", "error");
             throw new Error(tl.loc('CouldNotFetchAccessTokenforAzureStatusCode', error.errorCode, error.errorMessage));
         }
-    }
-
-    // Maps a scopeKind key (from the _azureScopes map built in azure-arm-endpoint.ts, e.g.
-    // 'appservice') to the human-readable audience label used in telemetry. 'appservice' is the
-    // only scopeKind acquireTokenForScope is called with today, so this always resolves to
-    // "AppService" in practice - but deriving it here (instead of hardcoding "AppService" at each
-    // call site) keeps requestedAudience honest if another scopeKind is ever wired in.
-    private static readonly scopeKindAudienceLabels: { [key: string]: string } = {
-        appservice: "AppService",
-        resourcemanager: "ARM",
-        // AzureCloud/AzureUSGovernment key this same scope 'resoucemanager' (pre-existing typo in
-        // azure-arm-endpoint.ts's _azureScopes map) - map both spellings so the label still
-        // resolves correctly if this scopeKind is ever wired in against one of those clouds.
-        resoucemanager: "ARM",
-        storage: "Storage",
-        keyvalut: "KeyVault",
-        sqldatabase: "SqlDatabase",
-        cosmosdb: "CosmosDB",
-        servicebus: "ServiceBus",
-        eventhubs: "EventHubs",
-        eventgrid: "EventGrid",
-        cognitiveservices: "CognitiveServices",
-        containerregistry: "ContainerRegistry",
-        devops: "DevOps",
-        batch: "Batch",
-        datafactory: "DataFactory"
-    };
-
-    private getAudienceLabel(scopeKind: string): string {
-        return ApplicationTokenCredentials.scopeKindAudienceLabels[scopeKind] || scopeKind;
     }
 
     // Emits non-sensitive telemetry so we can prove Kudu/SCM calls request an App Service-audience

--- a/common-npm-packages/azure-arm-rest/azure-arm-endpoint.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-endpoint.ts
@@ -71,21 +71,52 @@ export class AzureRMEndpoint {
             batch: 'https://batch.core.usgovcloudapi.net/.default',
             datafactory: 'https://datafactory.azure.us/.default'
         },
+        // BEST-EFFORT / UPFRONT SUPPORT: AzureGermanCloud now maps to the S3NS/SAP "Delos"
+        // sovereign cloud (Germany), the successor to the retired Microsoft Cloud Deutschland.
+        // Endpoints use the sovcloud-api.de root domain. Only 'appservice' and 'resourcemanager'
+        // are authoritative (from the App Service team's cloud.definitions); the remaining
+        // audiences are pattern-derived, dormant placeholders (only 'appservice' is consumed
+        // today) added ahead of full platform enablement to keep the map shape consistent
+        // across clouds. Reconcile the non-appservice audiences against Delos ARM
+        // /metadata/endpoints and confirm the platform's SC environment string before any
+        // other feature relies on them.
         AzureGermanCloud: {
-            resoucemanager: 'https://management.microsoftazure.de/.default',
-            appservice: 'https://appservice.azure.de/.default',
-            storage: 'https://storage.azure.de/.default',
-            keyvalut: 'https://vault.azure.de/.default',
-            sqldatabase: 'https://database.cloudapi.de/.default',
-            cosmosdb: 'https://cosmos.azure.de/.default',
-            servicebus: 'https://servicebus.azure.de/.default',
-            eventhubs: 'https://eventhubs.azure.de/.default',
-            eventgrid: 'https://eventgrid.azure.de/.default',
-            cognitiveservices: 'https://cognitiveservices.azure.de/.default',
-            containerregistry: 'https://containerregistry.azure.de/.default',
-            devops: 'https://app.vssps.visualstudio.de/.default',
-            batch: 'https://batch.core.cloudapi.de/.default',
-            datafactory: 'https://datafactory.azure.de/.default'
+            resourcemanager: 'https://management.sovcloud-api.de/.default',
+            appservice: 'https://appservice.azure.sovcloud-api.de/.default',
+            storage: 'https://storage.azure.sovcloud-api.de/.default',
+            keyvalut: 'https://vault.azure.sovcloud-api.de/.default',
+            sqldatabase: 'https://database.sovcloud-api.de/.default',
+            cosmosdb: 'https://cosmos.azure.sovcloud-api.de/.default',
+            servicebus: 'https://servicebus.azure.sovcloud-api.de/.default',
+            eventhubs: 'https://eventhubs.azure.sovcloud-api.de/.default',
+            eventgrid: 'https://eventgrid.azure.sovcloud-api.de/.default',
+            cognitiveservices: 'https://cognitiveservices.azure.sovcloud-api.de/.default',
+            containerregistry: 'https://containerregistry.azure.sovcloud-api.de/.default',
+            devops: 'https://app.vssps.visualstudio.sovcloud-api.de/.default',
+            batch: 'https://batch.core.sovcloud-api.de/.default',
+            datafactory: 'https://datafactory.azure.sovcloud-api.de/.default'
+        },
+        // BEST-EFFORT / UPFRONT SUPPORT: AzureBleuCloud maps to the "Bleu" sovereign cloud
+        // (France), using the sovcloud-api.fr root domain. Same authoritative/placeholder
+        // split as AzureGermanCloud above — added ahead of full ARM + platform enablement
+        // (Bleu is not yet registered in the ADO SC environment enum) so the mapping is in
+        // place when the cloud comes online. Reconcile the non-appservice audiences against
+        // Bleu ARM /metadata/endpoints before any other feature relies on them.
+        AzureBleuCloud: {
+            resourcemanager: 'https://management.sovcloud-api.fr/.default',
+            appservice: 'https://appservice.azure.sovcloud-api.fr/.default',
+            storage: 'https://storage.azure.sovcloud-api.fr/.default',
+            keyvalut: 'https://vault.azure.sovcloud-api.fr/.default',
+            sqldatabase: 'https://database.sovcloud-api.fr/.default',
+            cosmosdb: 'https://cosmos.azure.sovcloud-api.fr/.default',
+            servicebus: 'https://servicebus.azure.sovcloud-api.fr/.default',
+            eventhubs: 'https://eventhubs.azure.sovcloud-api.fr/.default',
+            eventgrid: 'https://eventgrid.azure.sovcloud-api.fr/.default',
+            cognitiveservices: 'https://cognitiveservices.azure.sovcloud-api.fr/.default',
+            containerregistry: 'https://containerregistry.azure.sovcloud-api.fr/.default',
+            devops: 'https://app.vssps.visualstudio.sovcloud-api.fr/.default',
+            batch: 'https://batch.core.sovcloud-api.fr/.default',
+            datafactory: 'https://datafactory.azure.sovcloud-api.fr/.default'
         }
     }
 

--- a/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
+++ b/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
@@ -6,6 +6,68 @@ import { Kudu } from './azure-arm-app-service-kudu';
 import webClient = require('./webClient');
 import { SiteContainer, VolumeMount, EnvironmentVariable } from './SiteContainer';
 
+export interface KuduAuthModeTelemetryParams {
+    // "Basic" | "Bearer" - how the Kudu/SCM request is authenticated.
+    authMethod: string;
+    // Which code path emitted this ("kuduAuthHeader" | "msDeploy" | "publishProfile"), for slicing.
+    source: string;
+    // ApplicationTokenCredentials for token (Bearer) paths - used to read the scoped-vs-broad decision.
+    credentials?: any;
+    // True when SCM basic auth is enabled on the site (only meaningful for the standard REST path).
+    scmBasicAuthEnabled?: boolean;
+    // Per-task identity (the task's telemetry feature name) for per-task breakdown.
+    telemetryFeature?: string;
+}
+
+// Emits the unified, additive `feature=KuduAuthMode` event so a single query can count how many task
+// instances use basic auth vs a tightly-scoped App Service token vs a broad ARM-audience token
+// (fallback). It is intentionally separate from - and does not alter - the pre-existing
+// authMethod / KuduScopeLevelToken / KuduArmTokenDeprecated events, so existing monitors are unaffected.
+// The scoped-vs-broad classification is read back from the credentials' last decision (no duplicated
+// logic). Non-sensitive metadata only - never a token, secret, or credential material.
+export function publishKuduAuthModeTelemetry(params: KuduAuthModeTelemetryParams): void {
+    try {
+        let scope: { requestedAudience: string, outcome: string, allowScopeLevelToken: boolean, scheme: string, authorityHost: string } =
+            { requestedAudience: undefined, outcome: undefined, allowScopeLevelToken: false, scheme: undefined, authorityHost: "" };
+        if (params.credentials && typeof params.credentials.getLastScopeTokenTelemetry === "function") {
+            try {
+                scope = params.credentials.getLastScopeTokenTelemetry();
+            } catch (e) {
+                tl.debug(`KuduAuthMode: failed to read scope token telemetry: ${e}`);
+            }
+        }
+
+        const isBasic = params.authMethod === "Basic";
+        let authMode: string;
+        if (isBasic) {
+            authMode = "basic";
+        } else if (scope.outcome === "scoped") {
+            authMode = "scopedToken";
+        } else if (scope.outcome === "error") {
+            authMode = "error";
+        } else {
+            // fallbackDisabled / fallbackUnmapped => an ARM-audience (broad) token was used for Kudu.
+            authMode = "broadToken";
+        }
+
+        const payload = {
+            authMode: authMode,
+            authMethod: params.authMethod,
+            source: params.source,
+            requestedAudience: isBasic ? "None" : scope.requestedAudience,
+            outcome: isBasic ? "basic" : scope.outcome,
+            allowScopeLevelToken: !!scope.allowScopeLevelToken,
+            scmBasicAuthEnabled: params.scmBasicAuthEnabled,
+            telemetryFeature: params.telemetryFeature,
+            authorityHost: scope.authorityHost,
+            scheme: scope.scheme
+        };
+        console.log(`##vso[telemetry.publish area=TaskDeploymentMethod;feature=KuduAuthMode]${JSON.stringify(payload)}`);
+    } catch (e) {
+        tl.debug(`Failed to publish KuduAuthMode telemetry: ${e}`);
+    }
+}
+
 export class AzureAppServiceUtility {
 
     private readonly _appService: AzureAppService;
@@ -152,6 +214,17 @@ export class AzureAppServiceUtility {
         };
         tl.debug(`Using ${method} authentication method for Kudu service.`);
         console.log(`##vso[telemetry.publish area=TaskDeploymentMethod;feature=${this._telemetryFeature}]${JSON.stringify(authMethodtelemetry)}`);
+
+        // Unified, additive auth-mode signal (feature=KuduAuthMode) - see publishKuduAuthModeTelemetry.
+        // Lets us count basic vs tightly-scoped vs broad(ARM-fallback) token usage per task with a
+        // single query, without touching the pre-existing events above (back-compat preserved).
+        publishKuduAuthModeTelemetry({
+            authMethod: method,
+            source: "kuduAuthHeader",
+            credentials: this._appService._client.getCredentials(),
+            scmBasicAuthEnabled: scmPolicyCheck === true,
+            telemetryFeature: this._telemetryFeature
+        });
 
         return method + " " + token;
     }

--- a/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
+++ b/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
@@ -45,9 +45,12 @@ export function publishKuduAuthModeTelemetry(params: KuduAuthModeTelemetryParams
             authMode = "scopedToken";
         } else if (scope.outcome === "error") {
             authMode = "error";
-        } else {
-            // fallbackDisabled / fallbackUnmapped => an ARM-audience (broad) token was used for Kudu.
+        } else if (scope.outcome === "fallbackDisabled" || scope.outcome === "fallbackUnmapped") {
+            // Only classify known ARM fallback outcomes as broadToken. Missing metadata must not
+            // inflate the broad-token count when package versions or telemetry state are mixed.
             authMode = "broadToken";
+        } else {
+            authMode = "unknown";
         }
 
         const payload = {
@@ -413,4 +416,3 @@ export class AzureAppServiceUtility {
         return await this._appService._getAppServiceInstances();
     }
 }
-

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.277.1",
+    "version": "3.279.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azure-arm-rest",
-            "version": "3.277.1",
+            "version": "3.279.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^4.13.1",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.277.1",
+    "version": "3.279.0",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",

--- a/common-npm-packages/azurermdeploycommon/operations/AzureAppServiceUtility.ts
+++ b/common-npm-packages/azurermdeploycommon/operations/AzureAppServiceUtility.ts
@@ -144,6 +144,13 @@ export class AzureAppServiceUtility {
             token = await this._appService._client.getCredentials().getToken();
             method = "Bearer";
 
+            // Deprecation tripwire: unlike azure-arm-rest, this legacy package was never updated to
+            // acquireTokenForScope, so it sends an ARM-audience token to Kudu/SCM. No in-repo task
+            // consumes it, so this should effectively never fire in production - the telemetry lets a
+            // monitor confirm that (and catch any external/on-prem consumer) before the path is removed.
+            const kuduArmDeprecation = { source: "azurermdeploycommon", reason: "legacyPackage" };
+            console.log("##vso[telemetry.publish area=TaskDeploymentMethod;feature=KuduArmTokenDeprecated]" + JSON.stringify(kuduArmDeprecation));
+            tl.debug("[deprecation] azurermdeploycommon sent an ARM-audience token to Kudu/SCM. This package/path is deprecated; use azure-pipelines-tasks-azure-arm-rest (scoped tokens) instead.");
             
             // Though bearer AuthN is used, lets try to set publish profile password for mask hints to maintain compat with old behavior for MSDEPLOY. 
             // This needs to be cleaned up once MSDEPLOY suppport is reomve. Safe handle the exception setting up mask hint as we dont want to fail here.

--- a/common-npm-packages/azurermdeploycommon/package-lock.json
+++ b/common-npm-packages/azurermdeploycommon/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-azurermdeploycommon",
-    "version": "3.272.0",
+    "version": "3.279.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azurermdeploycommon",
-            "version": "3.272.0",
+            "version": "3.279.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/azurermdeploycommon/package.json
+++ b/common-npm-packages/azurermdeploycommon/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azurermdeploycommon",
-    "version": "3.272.0",
+    "version": "3.279.0",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Description

Implements ADO work item 2401907 in `azure-arm-rest`: Kudu/SCM token requests can use the App Service Entra audience instead of the broad ARM audience, gated by `ALLOWSCOPELEVELTOKEN` (default off).

### What changed

- Added per-cloud App Service scopes and scoped-token acquisition, including Node 10/MSAL support for SPN, WIF, and Managed Identity.
- Preserved ARM fallback when the flag is off or a cloud mapping is unavailable; scoped-token acquisition errors remain visible failures.
- Added non-sensitive `KuduScopeLevelToken`, `KuduArmTokenDeprecated`, and unified `KuduAuthMode` telemetry.
- Classified missing auth metadata as `unknown` rather than inflating `broadToken` counts.
- Added federated-token-file deletion in all relevant paths, with success/failure telemetry and warning visibility on cleanup failure.
- Added Bleu and Delos sovereign-cloud mappings for forward compatibility.

### Risk assessment — Low

The new audience is disabled by default and can be rolled out or stopped with `ALLOWSCOPELEVELTOKEN`. Existing ARM behavior remains available for disabled/unmapped environments. The main behavior change is limited to Kudu/SCM token acquisition when the flag is enabled.

### Testing

- Common package build passed.
- Scoped-token regression tests passed for feature-off fallback, unmapped fallback, scoped acquisition, Node 10/MSAL, Managed Identity resource selection, acquisition failure, auth-mode `unknown`, and federated-token cleanup success/failure signals.
- DevFabric E2E build `20260810.2` passed for Public Azure and Azure China with `ALLOWSCOPELEVELTOKEN=true`; both used App Service-audience tokens and emitted `KuduScopeLevelToken: outcome=scoped`.

### Monitoring and rollback

Monitor `TaskDeploymentMethod` telemetry, especially `KuduAuthMode`, `KuduArmTokenDeprecated`, and scoped-token errors, broken down by task, version, cloud, and source. Roll back by leaving `ALLOWSCOPELEVELTOKEN` disabled; code rollback is the normal package/task PR revert if required.

### Documentation

Wiki draft prepared separately; no generated documentation files are included in this package PR.

### Checklist

- [x] Related ADO work item linked: 2401907
- [x] Unit tests added or updated
- [x] Manual and DevFabric E2E validation completed
- [x] Telemetry and rollout monitoring documented
- [x] Package dependency/version updates included
- [x] CLA — N/A (internal contributor)