### PR TITLE
Update utility-common js-yaml to patched versions

### DIFF
--- a/common-npm-packages/utility-common/package-lock.json
+++ b/common-npm-packages/utility-common/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "azure-pipelines-tasks-utility-common",
-    "version": "3.272.0",
+    "version": "3.279.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-utility-common",
-            "version": "3.272.0",
+            "version": "3.279.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.18.0",
                 "azure-pipelines-task-lib": "^5.2.8",
                 "azure-pipelines-tool-lib": "^2.0.12",
-                "js-yaml": "^3.14.2",
+                "js-yaml": "^3.15.1",
                 "semver": "^5.7.2",
                 "typed-rest-client": "2.2.0"
             },
@@ -1083,9 +1083,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha1-d0hc4d1/M8Bh/RsW7OojtV/LBLA=",
+            "version": "3.15.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha1-JLyVAo82HNqqhHRbBqEJxEhnc8A=",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -1285,10 +1285,20 @@
             }
         },
         "node_modules/mocha/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
+            "version": "4.3.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -2719,9 +2729,9 @@
             "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU="
         },
         "js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha1-d0hc4d1/M8Bh/RsW7OojtV/LBLA=",
+            "version": "3.15.1",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha1-JLyVAo82HNqqhHRbBqEJxEhnc8A=",
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -2858,9 +2868,9 @@
                     }
                 },
                 "js-yaml": {
-                    "version": "4.1.1",
-                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.1.tgz",
-                    "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
+                    "version": "4.3.1",
+                    "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+                    "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
                     "dev": true,
                     "requires": {
                         "argparse": "^2.0.1"

--- a/common-npm-packages/utility-common/package.json
+++ b/common-npm-packages/utility-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-utility-common",
-    "version": "3.272.0",
+    "version": "3.279.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",
@@ -21,7 +21,7 @@
         "@types/node": "^16.18.0",
         "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tool-lib": "^2.0.12",
-        "js-yaml": "^3.14.2",
+        "js-yaml": "^3.15.1",
         "semver": "^5.7.2",
         "typed-rest-client": "2.2.0"
     },


### PR DESCRIPTION
### **Description**
Upgrades `js-yaml` in utility-common from `3.14.2` to patched version `3.15.1` to address CVE-2026-59869. The Mocha development dependency's nested `js-yaml` resolution is also updated from `4.1.1` to `4.3.1`.

Bumps `azure-pipelines-tasks-utility-common` from `3.272.0` to `3.279.0` for publication and downstream task consumption.

Related issue: https://github.com/microsoft/azure-pipelines-tasks/issues/22391

---

### **Package Name**
`azure-pipelines-tasks-utility-common`

---

### **Risk Assessment** (Low / Medium / High)
Low. This is a patch-level dependency update that preserves the existing `js-yaml` 3.x API used by utility-common.

---

### **Unit Tests Added or Updated**
- [ ] Unit tests added or updated 
- [ ] Manual tests performed 

---

### **Additional Testing Performed**
Completed a clean `npm ci`, TypeScript build, and the existing utility-common test suite (93 passing tests).

---

### **Documentation Changes Required** (Yes / No)
No. This dependency security update does not change the public API or usage.

---

### **Dependencies**
- `js-yaml`: `^3.14.2` → `^3.15.1`
- Mocha's nested `js-yaml`: `4.1.1` → `4.3.1`

---

### **Checklist**
- [x] Related issue linked
- [x] Package version was bumped — see [versioning guide](https://semver.org/)
- [x] Verified the package behaves as expected
- [x] CLA signed

---