### PR TITLE
azure-arm-rest: gate all PR #642 Kudu scoped-token changes behind ALLOWSCOPELEVELTOKEN

### DIFF
--- a/common-npm-packages/azure-arm-rest/Tests/L0-scope-token-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-scope-token-tests.ts
@@ -3,7 +3,7 @@ import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import * as path from 'path';
 
 export function ScopeTokenTests(defaultTimeout = 2000) {
-    it('acquireTokenForScope falls back to an ARM-audience token and emits telemetry', function (done: Mocha.Done) {
+    it('acquireTokenForScope honors scoped-token behavior and feature gating', function (done: Mocha.Done) {
         this.timeout(defaultTimeout);
         let tp = path.join(__dirname, 'scope-token-tests.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -18,10 +18,14 @@ export function ScopeTokenTests(defaultTimeout = 2000) {
                 scopedTokenSuccessOnLegacyNode(tr);
                 console.log("\tvalidating Managed Identity scope resource selection");
                 managedIdentityScopeResource(tr);
+                console.log("\tvalidating Managed Identity legacy resource when feature is disabled");
+                managedIdentityLegacyResourceWhenFeatureDisabled(tr);
                 console.log("\tvalidating federated token file cleanup");
                 federatedTokenFileCleanup(tr);
                 console.log("\tvalidating unknown Kudu auth mode");
                 unknownKuduAuthMode(tr);
+                console.log("\tvalidating Kudu auth telemetry is disabled with the feature");
+                kuduAuthModeFeatureDisabled(tr);
                 console.log("\tvalidating fallback when the feature is disabled");
                 fallbackWhenFeatureDisabled(tr);
                 console.log("\tvalidating fallback (with warning) when the scope is unmapped");
@@ -60,6 +64,11 @@ function managedIdentityScopeResource(tr: ttm.MockTestRunner) {
         'Managed Identity should request the App Service resource for an App Service scope');
 }
 
+function managedIdentityLegacyResourceWhenFeatureDisabled(tr: ttm.MockTestRunner) {
+    assert(tr.stdOutContained('MSI_FEATURE_DISABLED_RESOURCE: https://management.azure.com/'),
+        'Managed Identity should preserve the ARM resource when the feature is disabled');
+}
+
 function federatedTokenFileCleanup(tr: ttm.MockTestRunner) {
     assert(tr.stdOutContained('FEDERATED_TOKEN_CLEANUP_TEST: completed'),
         'Federated token file cleanup test should have completed');
@@ -76,14 +85,17 @@ function unknownKuduAuthMode(tr: ttm.MockTestRunner) {
         'Missing scope metadata should be classified as unknown');
 }
 
-// Feature disabled: returns the ARM-audience token, records outcome "fallbackDisabled", no warning.
+function kuduAuthModeFeatureDisabled(tr: ttm.MockTestRunner) {
+    assert(tr.stdOutContained('KUDU_AUTH_DISABLED_TELEMETRY: false'),
+        'Should not emit KuduAuthMode telemetry when the feature is disabled');
+}
+
+// Feature disabled: returns the ARM-audience token and emits no new scope-token telemetry.
 function fallbackWhenFeatureDisabled(tr: ttm.MockTestRunner) {
     assert(tr.stdOutContained('FALLBACK_DISABLED_TOKEN: DUMMY_ACCESS_TOKEN'),
         'Should have returned the ARM-audience token when the feature is disabled');
-    assert(tr.stdOutContained('"outcome":"fallbackDisabled"'),
-        'Should have emitted telemetry with outcome fallbackDisabled');
-    assert(tr.stdOutContained('feature=KuduScopeLevelToken'),
-        'Should have emitted KuduScopeLevelToken telemetry');
+    assert(tr.stdOutContained('FALLBACK_DISABLED_TELEMETRY: false'),
+        'Should not emit KuduScopeLevelToken telemetry when the feature is disabled');
 }
 
 // Feature enabled but no scope mapped: warns, then returns the ARM-audience token, outcome "fallbackUnmapped".

--- a/common-npm-packages/azure-arm-rest/Tests/scope-token-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/scope-token-tests.ts
@@ -6,6 +6,8 @@ import os = require('os');
 import path = require('path');
 import tl = require('azure-pipelines-task-lib/task');
 
+const scopeFeatureVariable = "DISTRIBUTEDTASK_TASKS_ALLOWSCOPELEVELTOKEN";
+
 // Installs the ARM (ADAL) nock interceptor that answers the client-credentials token
 // request with "DUMMY_ACCESS_TOKEN". This is the ARM-audience token that acquireTokenForScope
 // must return whenever it falls back (feature disabled or scope unmapped).
@@ -36,7 +38,7 @@ function makeCreds(allowScopeLevelToken: boolean, scopes: any): ApplicationToken
     );
 }
 
-function makeManagedIdentityCreds(): any {
+function makeManagedIdentityCreds(allowScopeLevelToken = true): any {
     return new ApplicationTokenCredentials(
         "MOCK_SERVICE_CONNECTION",
         undefined,
@@ -53,7 +55,7 @@ function makeManagedIdentityCreds(): any {
         undefined,
         undefined,
         true,
-        true,
+        allowScopeLevelToken,
         { appservice: "https://appservice/.default" }
     );
 }
@@ -62,6 +64,7 @@ class ScopeTokenTests {
     // Feature enabled and scope mapped -> returns the App Service-audience token.
     public static async scopedTokenSuccess() {
         try {
+            process.env[scopeFeatureVariable] = "true";
             const creds: any = makeCreds(true, { appservice: "https://appservice/.default" });
             creds.buildCredentialByScheme = async () => ({
                 credential: {
@@ -83,19 +86,33 @@ class ScopeTokenTests {
 
     // Feature disabled -> returns the ARM-audience token, no warning.
     public static async fallbackWhenFeatureDisabled() {
+        const originalLog = console.log;
+        let emittedScopeTelemetry = false;
         try {
+            process.env[scopeFeatureVariable] = "false";
+            console.log = (...args: any[]) => {
+                if (args.join(" ").indexOf("feature=KuduScopeLevelToken") >= 0) {
+                    emittedScopeTelemetry = true;
+                }
+                originalLog.apply(console, args);
+            };
             const creds = makeCreds(false, undefined);
             const token = await creds.acquireTokenForScope("appservice");
-            console.log('FALLBACK_DISABLED_TOKEN: ' + token);
+            originalLog('FALLBACK_DISABLED_TOKEN: ' + token);
         } catch (error) {
-            console.log(error);
+            originalLog(error);
             tl.setResult(tl.TaskResult.Failed, 'fallbackWhenFeatureDisabled should have passed but failed');
+        } finally {
+            console.log = originalLog;
+            originalLog('FALLBACK_DISABLED_TELEMETRY: ' + emittedScopeTelemetry);
+            process.env[scopeFeatureVariable] = "true";
         }
     }
 
     // Feature enabled but no scope mapped for this environment -> warns, then falls back to ARM.
     public static async fallbackWhenScopeUnmapped() {
         try {
+            process.env[scopeFeatureVariable] = "true";
             const creds = makeCreds(true, {}); // no 'appservice' key
             const token = await creds.acquireTokenForScope("appservice");
             console.log('FALLBACK_UNMAPPED_TOKEN: ' + token);
@@ -110,6 +127,7 @@ class ScopeTokenTests {
     // Service-audience token, no ARM compromise.
     public static async scopedTokenSuccessOnLegacyNode() {
         try {
+            process.env[scopeFeatureVariable] = "true";
             const creds: any = makeCreds(true, { appservice: "https://appservice/.default" });
             creds.supportsModernIdentity = () => false;
             creds.getMSALToken = async (_force: boolean, _retryCount: number, _retryWaitMS: number, scopeOverride: string) => {
@@ -159,10 +177,45 @@ class ScopeTokenTests {
         }
     }
 
+    // Feature disabled -> preserve the previous Managed Identity resource even if MSAL supplies
+    // a different requested scope to the token provider.
+    public static async managedIdentityLegacyResourceWhenFeatureDisabled() {
+        try {
+            nock("http://169.254.169.254", {
+                reqheaders: {
+                    "Metadata": true
+                }
+            })
+                .get("/metadata/identity/oauth2/token")
+                .query({
+                    "api-version": "2018-02-01",
+                    "resource": "https://management.azure.com/"
+                })
+                .reply(200, {
+                    access_token: "DUMMY_ARM_TOKEN_FROM_MSI",
+                    expires_in: 3600
+                });
+
+            const creds = makeManagedIdentityCreds(false);
+            const msalClient = await creds.buildMSAL();
+            const result = await msalClient.acquireTokenByClientCredential({
+                scopes: ["https://appservice/.default"]
+            });
+            if (result.accessToken !== "DUMMY_ARM_TOKEN_FROM_MSI") {
+                throw new Error(`unexpected Managed Identity token: ${result.accessToken}`);
+            }
+            console.log('MSI_FEATURE_DISABLED_RESOURCE: https://management.azure.com/');
+        } catch (error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'managedIdentityLegacyResourceWhenFeatureDisabled should have passed but failed');
+        }
+    }
+
     public static async federatedTokenFileCleanup() {
         let tempDirectory: string;
         let cleanupFailurePath: string;
         try {
+            process.env[scopeFeatureVariable] = "true";
             const creds: any = makeCreds(true, { appservice: "https://appservice/.default" });
             tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'azure-arm-rest-'));
             const tokenFilePath = path.join(tempDirectory, 'token.jwt');
@@ -191,6 +244,7 @@ class ScopeTokenTests {
 
     public static async unknownKuduAuthMode() {
         try {
+            process.env[scopeFeatureVariable] = "true";
             publishKuduAuthModeTelemetry({
                 authMethod: "Bearer",
                 source: "test",
@@ -211,9 +265,35 @@ class ScopeTokenTests {
         }
     }
 
+    public static async kuduAuthModeFeatureDisabled() {
+        const originalLog = console.log;
+        let emittedKuduAuthModeTelemetry = false;
+        try {
+            process.env[scopeFeatureVariable] = "false";
+            console.log = (...args: any[]) => {
+                if (args.join(" ").indexOf("feature=KuduAuthMode") >= 0) {
+                    emittedKuduAuthModeTelemetry = true;
+                }
+                originalLog.apply(console, args);
+            };
+            publishKuduAuthModeTelemetry({
+                authMethod: "Basic",
+                source: "test"
+            });
+        } catch (error) {
+            originalLog(error);
+            tl.setResult(tl.TaskResult.Failed, 'kuduAuthModeFeatureDisabled should have passed but failed');
+        } finally {
+            console.log = originalLog;
+            originalLog('KUDU_AUTH_DISABLED_TELEMETRY: ' + emittedKuduAuthModeTelemetry);
+            process.env[scopeFeatureVariable] = "true";
+        }
+    }
+
     // Feature enabled and scope mapped, but scoped token acquisition fails -> fails without ARM fallback.
     public static async scopedTokenFailure() {
         try {
+            process.env[scopeFeatureVariable] = "true";
             const creds: any = makeCreds(true, { appservice: "https://appservice/.default" });
             creds.buildCredentialByScheme = async () => ({
                 credential: {
@@ -234,8 +314,10 @@ async function RUNTESTS() {
     await ScopeTokenTests.scopedTokenSuccess();
     await ScopeTokenTests.scopedTokenSuccessOnLegacyNode();
     await ScopeTokenTests.managedIdentityScopeResource();
+    await ScopeTokenTests.managedIdentityLegacyResourceWhenFeatureDisabled();
     await ScopeTokenTests.federatedTokenFileCleanup();
     await ScopeTokenTests.unknownKuduAuthMode();
+    await ScopeTokenTests.kuduAuthModeFeatureDisabled();
     await ScopeTokenTests.fallbackWhenFeatureDisabled();
     await ScopeTokenTests.fallbackWhenScopeUnmapped();
     await ScopeTokenTests.scopedTokenFailure();

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -398,10 +398,14 @@ export class ApplicationTokenCredentials {
                 let webRequest = new webClient.WebRequest();
                 webRequest.method = "GET";
                 let apiVersion = "2018-02-01";
-                let requestedScope = appTokenProviderParameters && appTokenProviderParameters.scopes
-                    ? appTokenProviderParameters.scopes[0]
-                    : undefined;
-                let resourceId = this.getResourceIdFromScope(requestedScope);
+                // Preserve the legacy ARM resource unless scoped tokens are enabled.
+                let resourceId = this.activeDirectoryResourceId;
+                if (this.allowScopeLevelToken) {
+                    const requestedScope = appTokenProviderParameters && appTokenProviderParameters.scopes
+                        ? appTokenProviderParameters.scopes[0]
+                        : undefined;
+                    resourceId = this.getResourceIdFromScope(requestedScope);
+                }
                 webRequest.uri = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=" + apiVersion + "&resource=" + resourceId;
                 webRequest.headers = {
                     "Metadata": true
@@ -543,8 +547,10 @@ export class ApplicationTokenCredentials {
             msalApp.clearCache();
         }
         try {
+            // Preserve the legacy ARM scope unless scoped tokens are enabled.
+            const effectiveScopeOverride = this.allowScopeLevelToken ? scopeOverride : undefined;
             const request: any /*msal.ClientCredentialRequest*/ = {
-                scopes: [scopeOverride || (this.activeDirectoryResourceId + "/.default")]
+                scopes: [effectiveScopeOverride || (this.activeDirectoryResourceId + "/.default")]
             };
             const response = await msalApp.acquireTokenByClientCredential(request);
             tl.debug(`MSAL - retrieved token - isFromCache?: ${response.fromCache}`);
@@ -628,6 +634,10 @@ export class ApplicationTokenCredentials {
     // metadata is recorded - never a token, secret, or credential material. authorityHost is a
     // public Entra login endpoint used to identify the cloud.
     private publishScopeTokenTelemetry(scopeKind: string, requestedAudience: string, outcome: string): void {
+        if (!this.allowScopeLevelToken) {
+            return;
+        }
+
         // Remember the most recent decision so getLastScopeTokenTelemetry() can expose it to the
         // Kudu auth layer for the unified KuduAuthMode event. Existing events below are unchanged.
         this._lastRequestedAudience = requestedAudience;
@@ -772,6 +782,10 @@ export class ApplicationTokenCredentials {
     }
 
     private publishFederatedTokenFileCleanupTelemetry(outcome: string): void {
+        if (!this.allowScopeLevelToken) {
+            return;
+        }
+
         try {
             console.log(`##vso[telemetry.publish area=TaskDeploymentMethod;feature=FederatedTokenFileCleanup]${JSON.stringify({ outcome: outcome })}`);
         } catch (error) {

--- a/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
+++ b/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
@@ -195,13 +195,7 @@ export class AzureAppServiceUtility {
         const password = publishingCredentials.properties["publishingPassword"];
 
         if (scmPolicyCheck === false) {
-            const credentials = this._appService._client.getCredentials();
-            if (tl.getPipelineFeature("ALLOWSCOPELEVELTOKEN")) {
-                token = await credentials.acquireTokenForScope("appservice");
-            } else {
-                tl.debug("ALLOWSCOPELEVELTOKEN is disabled; using the legacy ARM-audience token for Kudu.");
-                token = await credentials.getToken();
-            }
+            token = await this._appService._client.getCredentials().acquireTokenForScope("appservice");
             method = "Bearer";
             // Though bearer AuthN is used, lets try to set publish profile password for mask hints to maintain compat with old behavior for MSDEPLOY.
             // This needs to be cleaned up once MSDEPLOY suppport is removed. Safe handle the exception setting up mask hint as we dont want to fail here.

--- a/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
+++ b/common-npm-packages/azure-arm-rest/azureAppServiceUtility.ts
@@ -19,13 +19,15 @@ export interface KuduAuthModeTelemetryParams {
     telemetryFeature?: string;
 }
 
-// Emits the unified, additive `feature=KuduAuthMode` event so a single query can count how many task
-// instances use basic auth vs a tightly-scoped App Service token vs a broad ARM-audience token
-// (fallback). It is intentionally separate from - and does not alter - the pre-existing
-// authMethod / KuduScopeLevelToken / KuduArmTokenDeprecated events, so existing monitors are unaffected.
+// Emits the unified `feature=KuduAuthMode` event while ALLOWSCOPELEVELTOKEN is enabled so a single
+// query can count basic auth vs a tightly-scoped App Service token vs a broad ARM-audience token.
 // The scoped-vs-broad classification is read back from the credentials' last decision (no duplicated
 // logic). Non-sensitive metadata only - never a token, secret, or credential material.
 export function publishKuduAuthModeTelemetry(params: KuduAuthModeTelemetryParams): void {
+    if (!tl.getPipelineFeature("ALLOWSCOPELEVELTOKEN")) {
+        return;
+    }
+
     try {
         let scope: { requestedAudience: string, outcome: string, allowScopeLevelToken: boolean, scheme: string, authorityHost: string } =
             { requestedAudience: undefined, outcome: undefined, allowScopeLevelToken: false, scheme: undefined, authorityHost: "" };
@@ -193,7 +195,13 @@ export class AzureAppServiceUtility {
         const password = publishingCredentials.properties["publishingPassword"];
 
         if (scmPolicyCheck === false) {
-            token = await this._appService._client.getCredentials().acquireTokenForScope("appservice");
+            const credentials = this._appService._client.getCredentials();
+            if (tl.getPipelineFeature("ALLOWSCOPELEVELTOKEN")) {
+                token = await credentials.acquireTokenForScope("appservice");
+            } else {
+                tl.debug("ALLOWSCOPELEVELTOKEN is disabled; using the legacy ARM-audience token for Kudu.");
+                token = await credentials.getToken();
+            }
             method = "Bearer";
             // Though bearer AuthN is used, lets try to set publish profile password for mask hints to maintain compat with old behavior for MSDEPLOY.
             // This needs to be cleaned up once MSDEPLOY suppport is removed. Safe handle the exception setting up mask hint as we dont want to fail here.
@@ -218,7 +226,7 @@ export class AzureAppServiceUtility {
         tl.debug(`Using ${method} authentication method for Kudu service.`);
         console.log(`##vso[telemetry.publish area=TaskDeploymentMethod;feature=${this._telemetryFeature}]${JSON.stringify(authMethodtelemetry)}`);
 
-        // Unified, additive auth-mode signal (feature=KuduAuthMode) - see publishKuduAuthModeTelemetry.
+        // Unified auth-mode signal (feature=KuduAuthMode) - see publishKuduAuthModeTelemetry.
         // Lets us count basic vs tightly-scoped vs broad(ARM-fallback) token usage per task with a
         // single query, without touching the pre-existing events above (back-compat preserved).
         publishKuduAuthModeTelemetry({

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.279.0",
+    "version": "3.279.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azure-arm-rest",
-            "version": "3.279.0",
+            "version": "3.279.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^4.13.1",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.279.0",
+    "version": "3.279.2",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",

--- a/common-npm-packages/azurermdeploycommon/operations/AzureAppServiceUtility.ts
+++ b/common-npm-packages/azurermdeploycommon/operations/AzureAppServiceUtility.ts
@@ -148,9 +148,12 @@ export class AzureAppServiceUtility {
             // acquireTokenForScope, so it sends an ARM-audience token to Kudu/SCM. No in-repo task
             // consumes it, so this should effectively never fire in production - the telemetry lets a
             // monitor confirm that (and catch any external/on-prem consumer) before the path is removed.
-            const kuduArmDeprecation = { source: "azurermdeploycommon", reason: "legacyPackage" };
-            console.log("##vso[telemetry.publish area=TaskDeploymentMethod;feature=KuduArmTokenDeprecated]" + JSON.stringify(kuduArmDeprecation));
-            tl.debug("[deprecation] azurermdeploycommon sent an ARM-audience token to Kudu/SCM. This package/path is deprecated; use azure-pipelines-tasks-azure-arm-rest (scoped tokens) instead.");
+            // Keep the tripwire behind the same rollout feature as the scoped-token implementation.
+            if (tl.getPipelineFeature("ALLOWSCOPELEVELTOKEN")) {
+                const kuduArmDeprecation = { source: "azurermdeploycommon", reason: "legacyPackage" };
+                console.log("##vso[telemetry.publish area=TaskDeploymentMethod;feature=KuduArmTokenDeprecated]" + JSON.stringify(kuduArmDeprecation));
+                tl.debug("[deprecation] azurermdeploycommon sent an ARM-audience token to Kudu/SCM. This package/path is deprecated; use azure-pipelines-tasks-azure-arm-rest (scoped tokens) instead.");
+            }
             
             // Though bearer AuthN is used, lets try to set publish profile password for mask hints to maintain compat with old behavior for MSDEPLOY. 
             // This needs to be cleaned up once MSDEPLOY suppport is reomve. Safe handle the exception setting up mask hint as we dont want to fail here.

--- a/common-npm-packages/azurermdeploycommon/package-lock.json
+++ b/common-npm-packages/azurermdeploycommon/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-azurermdeploycommon",
-    "version": "3.279.0",
+    "version": "3.279.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azurermdeploycommon",
-            "version": "3.279.0",
+            "version": "3.279.1",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/azurermdeploycommon/package.json
+++ b/common-npm-packages/azurermdeploycommon/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azurermdeploycommon",
-    "version": "3.279.0",
+    "version": "3.279.1",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Description

Follow-up to #642 (Kudu-scoped tokens: App Service-audience Entra tokens for Kudu/SCM). That change added scoped-token acquisition and several telemetry signals to `azure-arm-rest`, but some of the additions ran regardless of the `ALLOWSCOPELEVELTOKEN` pipeline feature. This PR strictly gates every new #642 behavior behind that feature so that, when the flag is off, the library behaves exactly as it did before #642 (ARM-audience token for Kudu/SCM, no new telemetry).

## Packages

- `azure-pipelines-tasks-azure-arm-rest`: `3.279.0` -> `3.279.2` (`3.279.1` is already reserved by #644)
- `azure-pipelines-tasks-azurermdeploycommon`: `3.279.0` -> `3.279.1`

## Changes

`azure-arm-rest/azureAppServiceUtility.ts`
- `getKuduAuthHeader` now selects the token explicitly: `acquireTokenForScope("appservice")` when `ALLOWSCOPELEVELTOKEN` is enabled, otherwise the legacy `getToken()`.
- `publishKuduAuthModeTelemetry` returns immediately when the feature is disabled.

`azure-arm-rest/azure-arm-common.ts`
- Managed Identity: the request resource stays `activeDirectoryResourceId` unless the feature is enabled (only then is it derived from the requested scope).
- `getMSALToken`: the scope override is ignored unless the feature is enabled, preserving the legacy ARM scope.
- `publishScopeTokenTelemetry` and `publishFederatedTokenFileCleanupTelemetry` return immediately when the feature is disabled.
- `acquireTokenForScope` and `buildCredentialByScheme` are unchanged versus #642 - all new scoped logic there was already reachable only through the `allowScopeLevelToken` compound condition.

`azurermdeploycommon/operations/AzureAppServiceUtility.ts`
- The `KuduArmTokenDeprecated` tripwire telemetry now runs only when the feature is enabled.

## Feature-flag coverage

With `ALLOWSCOPELEVELTOKEN` disabled, every new element introduced by #642 is either behind an explicit flag check or only reachable from a flag-gated path:
- Explicitly guarded: MSI resource selection, `getMSALToken` scope override, `publishScopeTokenTelemetry`, `publishFederatedTokenFileCleanupTelemetry`, `publishKuduAuthModeTelemetry`, `getKuduAuthHeader` token acquisition, and the legacy-package `KuduArmTokenDeprecated` telemetry.
- Reachable only from a gated path: `supportsModernIdentity`, `buildCredentialByScheme`, `deleteFederatedTokenFile`, `getResourceIdFromScope`, `getLastScopeTokenTelemetry`, and the sovereign-cloud scope map (consumed only via `getScopesByEnvironment`, already gated).

## Testing

- Added L0 coverage in `scope-token-tests` / `L0-scope-token-tests` for the feature-disabled paths: no `KuduScopeLevelToken`/`KuduAuthMode` telemetry is emitted, and Managed Identity keeps the ARM resource when the flag is off.

## Risk

Low. When the flag is off the behavior is identical to the pre-#642 library; when it is on the behavior is identical to #642.

## Dependencies

No new dependencies.
