### PR TITLE
utility-common: preserve nested quotes in shellSplit (fix JSON --extra-vars corruption)

### DIFF
--- a/common-npm-packages/utility-common/Tests/L0.ts
+++ b/common-npm-packages/utility-common/Tests/L0.ts
@@ -1,5 +1,5 @@
 import { runArgsSanitizerTelemetryTests, runArgsSanitizerTests } from './argsSanitizerTests';
-import { runShellQuoteTests, runNeutralizeCommandSubstitutionTests, runShellSplitTests } from './shellEscapingTests';
+import { runShellQuoteTests, runNeutralizeCommandSubstitutionTests, runShellSplitTests, runRealShellExecutionTests } from './shellEscapingTests';
 
 describe('codeanalysis-common suite', () => {
     describe('Args sanitizer tests', runArgsSanitizerTests);
@@ -11,4 +11,6 @@ describe('codeanalysis-common suite', () => {
     describe('neutralizeCommandSubstitution', runNeutralizeCommandSubstitutionTests);
 
     describe('shellSplit', runShellSplitTests);
+
+    describe('shell execution safety (real shell)', runRealShellExecutionTests);
 });

--- a/common-npm-packages/utility-common/Tests/L0.ts
+++ b/common-npm-packages/utility-common/Tests/L0.ts
@@ -1,5 +1,5 @@
 import { runArgsSanitizerTelemetryTests, runArgsSanitizerTests } from './argsSanitizerTests';
-import { runShellQuoteTests, runNeutralizeCommandSubstitutionTests, runShellSplitTests, runRealShellExecutionTests } from './shellEscapingTests';
+import { runShellQuoteTests, runNeutralizeCommandSubstitutionTests, runShellSplitTests, runShellQuoteWorkflowTests } from './shellEscapingTests';
 
 describe('codeanalysis-common suite', () => {
     describe('Args sanitizer tests', runArgsSanitizerTests);
@@ -12,5 +12,5 @@ describe('codeanalysis-common suite', () => {
 
     describe('shellSplit', runShellSplitTests);
 
-    describe('shell execution safety (real shell)', runRealShellExecutionTests);
+    describe('shellQuote command workflow', runShellQuoteWorkflowTests);
 });

--- a/common-npm-packages/utility-common/Tests/shellEscapingTests.ts
+++ b/common-npm-packages/utility-common/Tests/shellEscapingTests.ts
@@ -1,4 +1,6 @@
 import * as assert from 'assert';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
 import { shellQuote, neutralizeCommandSubstitution, shellSplit } from "../shellEscaping";
 export function runShellQuoteTests() {
     it('wraps empty string', () => {
@@ -387,15 +389,93 @@ export function runShellSplitTests() {
         );
     });
 
-    it('workflow keeps JSON --extra-vars intact: split escapes quotes for the shell (regression: extra-vars corruption)', () => {
+    it('workflow keeps JSON --extra-vars intact via shellQuote (regression: extra-vars corruption)', () => {
         // The buggy tokenizer stripped the inner quotes, turning
         // --extra-vars '{"a":"b"}' into --extra-vars {a:b}, which ansible-playbook
-        // silently mis-parsed as YAML. With quote context preserved, the double
-        // quotes survive and neutralizeCommandSubstitution escapes them so the
-        // shell hands the original JSON object back to ansible-playbook.
-        const tokens = shellSplit(`--extra-vars '{"a":"b"}'`);
-        assert.deepEqual(tokens, ['--extra-vars', '{"a":"b"}']);
-        const escaped = tokens.map(t => neutralizeCommandSubstitution(t)!).join(' ');
-        assert.equal(escaped, '--extra-vars {\\"a\\":\\"b\\"}');
+        // silently mis-parsed as YAML. With quote context preserved the double
+        // quotes survive tokenization; wrapping each token with shellQuote then
+        // hands the original JSON object back to the shell as a single literal
+        // argument (and, unlike neutralizeCommandSubstitution, keeps multi-key
+        // JSON safe from brace expansion).
+        const tokens = shellSplit(`--extra-vars '{"a":"b","c":"d"}'`);
+        assert.deepEqual(tokens, ['--extra-vars', '{"a":"b","c":"d"}']);
+        const quoted = tokens.map(t => shellQuote(t)).join(' ');
+        assert.equal(quoted, `'--extra-vars' '{"a":"b","c":"d"}'`);
+    });
+}
+
+/**
+ * Locate a POSIX shell so the neutralized/quoted command lines can be parsed by a
+ * real shell. Returns null when none is available (e.g. a bare Windows agent), in
+ * which case the dependent tests self-skip.
+ */
+function findPosixShell(): string | null {
+    const candidates = process.platform === 'win32'
+        ? [
+            'C:\\Program Files\\Git\\bin\\bash.exe',
+            'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
+            'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+        ]
+        : ['/bin/bash', '/usr/bin/bash', '/bin/sh'];
+
+    for (const candidate of candidates) {
+        try {
+            if (fs.existsSync(candidate)) {
+                return candidate;
+            }
+        } catch {
+            // ignore and try the next candidate
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Run `commandLine` through a real POSIX shell and return the argument vector the
+ * shell actually produced. A NUL delimiter is used so arguments never collide
+ * with the separator.
+ */
+function shellArgv(shell: string, commandLine: string): string[] {
+    const script = `__printer() { for __a in "$@"; do printf '%s\\0' "$__a"; done; }; __printer ${commandLine}`;
+    const out = execFileSync(shell, ['-c', script], { encoding: 'utf8' });
+    const parts = out.split('\0');
+    parts.pop(); // trailing empty element after the last delimiter
+    return parts;
+}
+
+export function runRealShellExecutionTests() {
+    const shell = findPosixShell();
+
+    it('shellQuote workflow: multi-key JSON --extra-vars survives as a single argument', function () {
+        if (!shell) { this.skip(); return; }
+        const input = `--extra-vars '{"a":"b","c":"d"}'`;
+        const commandLine = shellSplit(input).map(t => shellQuote(t)).join(' ');
+        assert.deepEqual(shellArgv(shell, commandLine), ['--extra-vars', '{"a":"b","c":"d"}']);
+    });
+
+    it('shellQuote workflow: nested single- and double-quoted JSON survives intact', function () {
+        if (!shell) { this.skip(); return; }
+        const input = `-e '{"path":"/tmp/*","list":"a,b,c","home":"~"}'`;
+        const commandLine = shellSplit(input).map(t => shellQuote(t)).join(' ');
+        assert.deepEqual(shellArgv(shell, commandLine), ['-e', '{"path":"/tmp/*","list":"a,b,c","home":"~"}']);
+    });
+
+    it('shellQuote workflow: command-injection metacharacters stay literal (no execution)', function () {
+        if (!shell) { this.skip(); return; }
+        const input = `--become-user 'root'; whoami`;
+        const commandLine = shellSplit(input).map(t => shellQuote(t)).join(' ');
+        // whoami must appear verbatim as an argument rather than running as a command.
+        assert.deepEqual(shellArgv(shell, commandLine), ['--become-user', 'root;', 'whoami']);
+    });
+
+    it('neutralizeCommandSubstitution workflow brace-expands multi-key JSON (documents why shellQuote is preferred)', function () {
+        if (!shell) { this.skip(); return; }
+        const input = `--extra-vars '{"a":"b","c":"d"}'`;
+        const commandLine = shellSplit(input).map(t => neutralizeCommandSubstitution(t)!).join(' ');
+        // Regression guard: the neutralize pattern leaves { , } unescaped, so bash
+        // brace-expands the JSON into two words and drops the braces. This is the
+        // exact corruption the Ansible task avoids by using shellQuote instead.
+        assert.deepEqual(shellArgv(shell, commandLine), ['--extra-vars', '"a":"b"', '"c":"d"']);
     });
 }

--- a/common-npm-packages/utility-common/Tests/shellEscapingTests.ts
+++ b/common-npm-packages/utility-common/Tests/shellEscapingTests.ts
@@ -365,4 +365,37 @@ export function runShellSplitTests() {
         const escaped = tokens.map(t => neutralizeCommandSubstitution(t)!);
         assert.equal(escaped.join(' '), '-DFOO=bar -DBAZ=\\$\\(whoami\\)');
     });
+
+    it('preserves double quotes nested inside single quotes (JSON value)', () => {
+        assert.deepEqual(
+            shellSplit(`--extra-vars '{"a":"b"}'`),
+            ['--extra-vars', '{"a":"b"}']
+        );
+    });
+
+    it('preserves nested double quotes for a more complex JSON value', () => {
+        assert.deepEqual(
+            shellSplit(`-e '{"k":"v","n":1}'`),
+            ['-e', '{"k":"v","n":1}']
+        );
+    });
+
+    it('preserves single quotes nested inside double quotes', () => {
+        assert.deepEqual(
+            shellSplit(`--msg "it's fine"`),
+            ['--msg', "it's fine"]
+        );
+    });
+
+    it('workflow keeps JSON --extra-vars intact: split escapes quotes for the shell (regression: extra-vars corruption)', () => {
+        // The buggy tokenizer stripped the inner quotes, turning
+        // --extra-vars '{"a":"b"}' into --extra-vars {a:b}, which ansible-playbook
+        // silently mis-parsed as YAML. With quote context preserved, the double
+        // quotes survive and neutralizeCommandSubstitution escapes them so the
+        // shell hands the original JSON object back to ansible-playbook.
+        const tokens = shellSplit(`--extra-vars '{"a":"b"}'`);
+        assert.deepEqual(tokens, ['--extra-vars', '{"a":"b"}']);
+        const escaped = tokens.map(t => neutralizeCommandSubstitution(t)!).join(' ');
+        assert.equal(escaped, '--extra-vars {\\"a\\":\\"b\\"}');
+    });
 }

--- a/common-npm-packages/utility-common/Tests/shellEscapingTests.ts
+++ b/common-npm-packages/utility-common/Tests/shellEscapingTests.ts
@@ -1,6 +1,4 @@
 import * as assert from 'assert';
-import { execFileSync } from 'child_process';
-import * as fs from 'fs';
 import { shellQuote, neutralizeCommandSubstitution, shellSplit } from "../shellEscaping";
 export function runShellQuoteTests() {
     it('wraps empty string', () => {
@@ -404,78 +402,38 @@ export function runShellSplitTests() {
     });
 }
 
-/**
- * Locate a POSIX shell so the neutralized/quoted command lines can be parsed by a
- * real shell. Returns null when none is available (e.g. a bare Windows agent), in
- * which case the dependent tests self-skip.
- */
-function findPosixShell(): string | null {
-    const candidates = process.platform === 'win32'
-        ? [
-            'C:\\Program Files\\Git\\bin\\bash.exe',
-            'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
-            'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
-        ]
-        : ['/bin/bash', '/usr/bin/bash', '/bin/sh'];
+export function runShellQuoteWorkflowTests() {
+    // These expectations were each verified once by piping the produced command
+    // line through a real POSIX shell (bash -c) and inspecting argv; they are
+    // asserted here as deterministic strings so the suite stays hermetic (no
+    // dependency on an installed shell, no silent skips on shell-less agents).
 
-    for (const candidate of candidates) {
-        try {
-            if (fs.existsSync(candidate)) {
-                return candidate;
-            }
-        } catch {
-            // ignore and try the next candidate
-        }
-    }
-
-    return null;
-}
-
-/**
- * Run `commandLine` through a real POSIX shell and return the argument vector the
- * shell actually produced. A NUL delimiter is used so arguments never collide
- * with the separator.
- */
-function shellArgv(shell: string, commandLine: string): string[] {
-    const script = `__printer() { for __a in "$@"; do printf '%s\\0' "$__a"; done; }; __printer ${commandLine}`;
-    const out = execFileSync(shell, ['-c', script], { encoding: 'utf8' });
-    const parts = out.split('\0');
-    parts.pop(); // trailing empty element after the last delimiter
-    return parts;
-}
-
-export function runRealShellExecutionTests() {
-    const shell = findPosixShell();
-
-    it('shellQuote workflow: multi-key JSON --extra-vars survives as a single argument', function () {
-        if (!shell) { this.skip(); return; }
-        const input = `--extra-vars '{"a":"b","c":"d"}'`;
-        const commandLine = shellSplit(input).map(t => shellQuote(t)).join(' ');
-        assert.deepEqual(shellArgv(shell, commandLine), ['--extra-vars', '{"a":"b","c":"d"}']);
+    it('shellQuote workflow: multi-key JSON --extra-vars stays one single-quoted, inert argument', () => {
+        const commandLine = shellSplit(`--extra-vars '{"a":"b","c":"d"}'`).map(t => shellQuote(t)).join(' ');
+        // Single-quoting the whole JSON keeps the braces/commas literal, so bash
+        // does NOT brace-expand it — it is handed back as one argument.
+        assert.equal(commandLine, `'--extra-vars' '{"a":"b","c":"d"}'`);
     });
 
-    it('shellQuote workflow: nested single- and double-quoted JSON survives intact', function () {
-        if (!shell) { this.skip(); return; }
-        const input = `-e '{"path":"/tmp/*","list":"a,b,c","home":"~"}'`;
-        const commandLine = shellSplit(input).map(t => shellQuote(t)).join(' ');
-        assert.deepEqual(shellArgv(shell, commandLine), ['-e', '{"path":"/tmp/*","list":"a,b,c","home":"~"}']);
+    it('shellQuote workflow: nested quotes, globs, commas and tilde survive intact', () => {
+        const commandLine = shellSplit(`-e '{"path":"/tmp/*","list":"a,b,c","home":"~"}'`).map(t => shellQuote(t)).join(' ');
+        assert.equal(commandLine, `'-e' '{"path":"/tmp/*","list":"a,b,c","home":"~"}'`);
     });
 
-    it('shellQuote workflow: command-injection metacharacters stay literal (no execution)', function () {
-        if (!shell) { this.skip(); return; }
-        const input = `--become-user 'root'; whoami`;
-        const commandLine = shellSplit(input).map(t => shellQuote(t)).join(' ');
-        // whoami must appear verbatim as an argument rather than running as a command.
-        assert.deepEqual(shellArgv(shell, commandLine), ['--become-user', 'root;', 'whoami']);
+    it('shellQuote workflow: command-injection metacharacters are single-quoted, not executable', () => {
+        const commandLine = shellSplit(`--become-user 'root'; whoami`).map(t => shellQuote(t)).join(' ');
+        // The ';' lives inside single quotes and 'whoami' is its own quoted token,
+        // so the shell treats both as literal arguments rather than a new command.
+        assert.equal(commandLine, `'--become-user' 'root;' 'whoami'`);
     });
 
-    it('neutralizeCommandSubstitution workflow brace-expands multi-key JSON (documents why shellQuote is preferred)', function () {
-        if (!shell) { this.skip(); return; }
-        const input = `--extra-vars '{"a":"b","c":"d"}'`;
-        const commandLine = shellSplit(input).map(t => neutralizeCommandSubstitution(t)!).join(' ');
-        // Regression guard: the neutralize pattern leaves { , } unescaped, so bash
-        // brace-expands the JSON into two words and drops the braces. This is the
-        // exact corruption the Ansible task avoids by using shellQuote instead.
-        assert.deepEqual(shellArgv(shell, commandLine), ['--extra-vars', '"a":"b"', '"c":"d"']);
+    it('neutralizeCommandSubstitution leaves brace/comma unescaped for multi-key JSON (documents why shellQuote is preferred)', () => {
+        const commandLine = shellSplit(`--extra-vars '{"a":"b","c":"d"}'`).map(t => neutralizeCommandSubstitution(t)!).join(' ');
+        // Regression guard: neutralize escapes the quotes but NOT { , }, so bash
+        // brace-expands this into two words and drops the braces at runtime. This
+        // is the exact corruption the Ansible task avoids by using shellQuote.
+        assert.equal(commandLine, '--extra-vars {\\"a\\":\\"b\\",\\"c\\":\\"d\\"}');
+        assert.ok(!commandLine.includes('\\{') && !commandLine.includes('\\,'),
+            'neutralize does not escape brace-expansion characters');
     });
 }

--- a/common-npm-packages/utility-common/package-lock.json
+++ b/common-npm-packages/utility-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-utility-common",
-    "version": "3.279.1",
+    "version": "3.279.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-utility-common",
-            "version": "3.279.1",
+            "version": "3.279.2",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.18.0",

--- a/common-npm-packages/utility-common/package.json
+++ b/common-npm-packages/utility-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-utility-common",
-    "version": "3.279.1",
+    "version": "3.279.2",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",

--- a/common-npm-packages/utility-common/shellEscaping.ts
+++ b/common-npm-packages/utility-common/shellEscaping.ts
@@ -48,12 +48,69 @@ export function neutralizeCommandSubstitution(value: string | null | undefined):
 }
 
 /**
+ * Removes one level of POSIX shell quoting from a single, already-tokenized
+ * argument, honouring quote context so that quote characters nested inside a
+ * different quoting style survive as literals.
+ *
+ * Unlike a sequence of independent global regex replacements, this is a single
+ * left-to-right pass, so the double quotes inside a single-quoted JSON value are
+ * preserved: removeShellQuoting(`'{"a":"b"}'`) === `{"a":"b"}`.
+ *
+ * Rules (matching /bin/sh):
+ * - Single quotes '...'  : every character is literal until the next single quote.
+ * - Double quotes "..."  : a backslash only escapes $ ` " \ and newline; every
+ *                          other character (including ') is literal.
+ * - Unquoted backslash   : escapes the following character.
+ */
+function removeShellQuoting(raw: string): string {
+    let result = '';
+    let i = 0;
+
+    while (i < raw.length) {
+        const ch = raw[i];
+
+        if (ch === "'") {
+            i++;
+            while (i < raw.length && raw[i] !== "'") {
+                result += raw[i++];
+            }
+            i++; // consume the closing quote (if present)
+        } else if (ch === '"') {
+            i++;
+            while (i < raw.length && raw[i] !== '"') {
+                if (raw[i] === '\\' && i + 1 < raw.length && '$`"\\\n'.indexOf(raw[i + 1]) !== -1) {
+                    result += raw[i + 1];
+                    i += 2;
+                } else {
+                    result += raw[i++];
+                }
+            }
+            i++; // consume the closing quote (if present)
+        } else if (ch === '\\') {
+            if (i + 1 < raw.length) {
+                result += raw[i + 1];
+                i += 2;
+            } else {
+                i++;
+            }
+        } else {
+            result += raw[i++];
+        }
+    }
+
+    return result;
+}
+
+/**
  * @example
  * shellSplit('-DFOO=bar -DBAZ="hello world"')
  * // → ['-DFOO=bar', '-DBAZ=hello world']
  *
  * shellSplit("-DPATH='/usr/local/my app' -DVER=1.0")
  * // → ['-DPATH=/usr/local/my app', '-DVER=1.0']
+ *
+ * shellSplit(`--extra-vars '{"a":"b"}'`)
+ * // → ['--extra-vars', '{"a":"b"}']   (nested double quotes preserved)
  *
  * // Full workflow for multi-param inputs:
  * shellSplit(args).map(neutralizeCommandSubstitution).join(' ')
@@ -67,14 +124,7 @@ export function shellSplit(value: string | null | undefined): string[] {
     let match: RegExpExecArray | null;
 
     while ((match = tokenRegex.exec(value)) !== null) {
-        const token = match[0]
-            .replace(/'([^']*)'/g, '$1')
-            .replace(/"((?:[^"\\]|\\.)*)"/g, (_: string, content: string) =>
-                content.replace(/\\([$`"\\]|\n)/g, '$1')
-            )
-            .replace(/\\(.)/g, '$1');
-
-        tokens.push(token);
+        tokens.push(removeShellQuoting(match[0]));
     }
 
     return tokens;

--- a/common-npm-packages/utility-common/shellEscaping.ts
+++ b/common-npm-packages/utility-common/shellEscaping.ts
@@ -35,6 +35,15 @@ const SPECIAL_SEQUENCES: Record<string, string> = {
  * neutralizeCommandSubstitution("test;whoami")        // → "test\\;whoami"
  * neutralizeCommandSubstitution("test|curl evil.com") // → "test\\|curl evil.com"
  * neutralizeCommandSubstitution("'; whoami; echo '")  // → "\\'\\;\\ whoami\\;\\ echo\\ \\'"
+ *
+ * NOTE: This function deliberately preserves shell variable expansion ($VAR and
+ * ${VAR}) and therefore does NOT neutralize brace expansion ({a,b} / {1..5}),
+ * pathname globbing (* ? [ ]) or tilde expansion (~). For example bash expands
+ * an unquoted multi-key JSON value '{"a":"b","c":"d"}' via brace expansion into
+ * two words, corrupting the value. When the argument is fully untrusted and no
+ * variable expansion is required (e.g. an Ansible --extra-vars JSON blob), wrap
+ * each token with shellQuote() instead — single quoting keeps the value intact
+ * and inert against every form of shell interpretation.
  */
 export function neutralizeCommandSubstitution(value: string | null | undefined): string | null | undefined {
     if (!value) return value;
@@ -112,8 +121,13 @@ function removeShellQuoting(raw: string): string {
  * shellSplit(`--extra-vars '{"a":"b"}'`)
  * // → ['--extra-vars', '{"a":"b"}']   (nested double quotes preserved)
  *
- * // Full workflow for multi-param inputs:
- * shellSplit(args).map(neutralizeCommandSubstitution).join(' ')
+ * // Safe workflow for fully-untrusted, multi-param inputs — re-quote every token
+ * // so the shell treats each one as a single, literal argument:
+ * shellSplit(args).map(shellQuote).join(' ')
+ *
+ * // Use .map(neutralizeCommandSubstitution) instead only when shell variable
+ * // expansion ($VAR/${VAR}) must be preserved AND the input cannot contain
+ * // brace/glob/tilde metacharacters (see neutralizeCommandSubstitution notes).
  */
 export function shellSplit(value: string | null | undefined): string[] {
     if (!value) return [];


### PR DESCRIPTION
### **Description**

`shellSplit` removed shell quoting using three independent global regex replacements, which did not respect quote context. After the outer single quotes were stripped, the inner double quotes of a value such as `'{"a":"b"}'` were also removed, collapsing the token to `{a:b}`.

Consumers that feed the result through a downstream shell (e.g. the Azure DevOps **Ansible** task, which tokenizes `--additional parameters` and re-composes them for `ansible-playbook`) then passed corrupted JSON, which was silently mis-parsed as YAML — so `--extra-vars '{"a":"b"}'` became a variable named `a:b` set to null and the real `a` was lost.

This PR replaces the regex chain with `removeShellQuoting()`, a single left-to-right pass that honours POSIX quote context so quote characters nested inside a different quoting style survive as literals:

- Single quotes `'...'` — everything literal until the next single quote.
- Double quotes `"..."` — a backslash only escapes `$` `` ` `` `"` `\` and newline; every other character (including `'`) is literal.
- Unquoted backslash — escapes the following character.

Non-nested inputs are unaffected (behaviour is byte-for-byte identical), so this is a strictly-more-correct fix with no expected impact on existing consumers.

This PR also **documents a limitation of `neutralizeCommandSubstitution`**: it deliberately preserves shell variable expansion (`$VAR` / `${VAR}`) and therefore does **not** neutralize brace expansion (`{a,b}` / `{1..5}`), globbing (`* ? [ ]`) or tilde expansion. For example, bash brace-expands an unquoted multi-key JSON value `'{"a":"b","c":"d"}'` into two words, corrupting it. For fully-untrusted, multi-parameter inputs the docstrings now steer callers to `shellSplit(args).map(shellQuote).join(' ')` (single-quoting keeps every token intact and inert against all forms of shell interpretation). The Ansible hardening (microsoft/azure-pipelines-extensions#1516) adopts exactly this `shellQuote`-based composition.

Related: microsoft/azure-pipelines-extensions#1516 (Ansible OS command-injection hardening).

---

### **Package Name**
`azure-pipelines-tasks-utility-common`

---

### **Risk Assessment** (Low / Medium / High)
**Low.** The only runtime change is to `shellSplit`; `shellQuote` and `neutralizeCommandSubstitution` are unchanged (docstring edits only). `shellSplit` now only affects tokens that contain quotes nested inside another quoting style — previously these were corrupted; now they are preserved per POSIX shell rules. All `shellSplit` / `neutralizeCommandSubstitution` / `shellQuote` unit tests pass (**101 total**). Non-nested inputs produce identical output. See **Additional Testing Performed** for a full cross-consumer validation.

---

### **Unit Tests Added or Updated**
- [x] Unit tests added or updated
- [ ] Manual tests performed

- Regression tests for `removeShellQuoting` via `shellSplit`: nested double quotes inside single quotes (JSON value), a more complex multi-key JSON object, and single quotes nested inside double quotes.
- A `shellQuote` command-workflow test group (deterministic string assertions, no external shell dependency) proving: multi-key JSON stays single-quoted and inert; nested quotes / globs / commas / tilde survive intact; injection metacharacters are single-quoted; and a regression guard that `neutralizeCommandSubstitution` still leaves `{ , }` unescaped (documenting why `shellQuote` is required for untrusted brace/glob input).

---

### **Additional Testing Performed**

Compiled `utility-common` with the local `tsc` and ran `mocha _build/Tests/L0.js` — **101 passing**, no regressions.

**Cross-consumer validation** — verified that adopting this fixed library does not break any other pipeline task that consumes the changed functions.

Only `shellSplit` changed at runtime; `shellQuote` and `neutralizeCommandSubstitution` are byte-unchanged. Full consumer inventory (across `azure-pipelines-tasks` and `azure-pipelines-extensions`):

| Task | Function used | Runtime-affected? | Validation |
|------|---------------|-------------------|------------|
| **Ansible** (extensions) | `shellSplit`, `shellQuote` | Yes (`shellSplit`) | Packed this lib to a local `.tgz`, `npm i`'d it into the task, ran L0 → **122 passing** (incl. single-key and multi-key JSON `--extra-vars` and injection scenarios) |
| **CMakeV1** (tasks) | `shellSplit` | Yes | Built the task, swapped in the fixed `shellEscaping.js`, ran L0 → **3 passing**; plus differential harness below |
| **SshV0** (tasks) | `shellQuote` | No (unchanged) | Provably unaffected |
| **CopyFilesOverSSHV0** (tasks) | `shellQuote` | No (unchanged) | Provably unaffected |

**Differential harness** (OLD 3-regex `shellSplit` vs NEW single-pass) over 29 CMake-typical and edge inputs: **all normal inputs tokenize identically** (`..`, `-DCMAKE_BUILD_TYPE=Release`, `C:\tmp`, `C:\a\b\c`, `${HOME}`, `$HOME`, `$(id)`, backticks, `-G "Unix Makefiles"`, plain defines). The **only** differences are cases where the OLD code was buggy and stripped quote characters/backslashes nested inside another quoting style, corrupting the value — e.g. `-DWIN_PATH="C:\Program Files\app"` → OLD `C:Program Filesapp`, NEW correct `C:\Program Files\app`; and quoted JSON defines. Every difference is the NEW code being more POSIX-correct, never a regression. For CMakeV1 this means quoted defines now reach `cmake` intact instead of mangled.

---

### **Documentation Changes Required** (Yes / No)
No.

---

### **Dependencies**
None.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Package version was bumped — `3.279.1` -> `3.279.2`
- [x] Verified the package behaves as expected
- [ ] CLA signed (if applicable)
