### PR TITLE
Update openssl 3.5.8

### DIFF
--- a/common-npm-packages/azure-arm-rest/Tests/L0-azure-cli-openssl-check.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-azure-cli-openssl-check.ts
@@ -14,7 +14,7 @@ export function OpenSSLCheck() {
         openSSLVersion: '3.4.2',
         featureFlagValue: false
     }, {
-        openSSLVersion: '3.5.7',
+        openSSLVersion: '3.5.8',
         featureFlagValue: true
     }].forEach(({ openSSLVersion, featureFlagValue }) => {
         it(`azure-arm-rest check openssl path openssl${openSSLVersion}`, (done: Mocha.Done) => {

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -923,7 +923,7 @@ export class ApplicationTokenCredentials {
     public getOpenSSLPath() {
         if (tl.osType().match(/^Win/)) {
             if (tl.getPipelineFeature("UseLatestOpenSSLInAzureArmRest")) {
-                return tl.which(path.join(__dirname, 'openssl3.5.7', 'openssl'));
+                return tl.which(path.join(__dirname, 'openssl3.5.8', 'openssl'));
             } else {
                 return tl.which(path.join(__dirname, 'openssl3.4.2', 'openssl'));
             }

--- a/common-npm-packages/azure-arm-rest/make.js
+++ b/common-npm-packages/azure-arm-rest/make.js
@@ -6,7 +6,7 @@ const { downloadArchive } = require('../build-scripts/downloadArchive');
 
 const buildPath = path.join(__dirname, './_build');
 const openSSLUrls = {
-    'openssl3.5.7': 'https://vstsagenttools.blob.core.windows.net/tools/openssl/3.5.7/M276/openssl.zip',
+    'openssl3.5.8': 'https://vstsagenttools.blob.core.windows.net/tools/openssl/3.5.8/M279/openssl.zip',
     'openssl3.4.2': 'https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.2/M262/openssl.zip'
 };
 

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.279.4",
+    "version": "3.279.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azure-arm-rest",
-            "version": "3.279.4",
+            "version": "3.279.5",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^4.13.1",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.279.4",
+    "version": "3.279.5",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### **Description**
Vulnerabilities reported in openssl 3.5.7 - https://openssl-library.org/news/vulnerabilities-3.5/index.html.
This PR updates the version to 3.5.8 in azure-arm-rest common package.

---

### **Package Name**
azure-arm-rest

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated**   
- [ ] Unit tests added or updated
- [ ] Manual tests performed

---

### **Additional Testing Performed**
_List all other tests performed (manual or automated, including integration, regression, scenario tests, etc.). Include links to test results or logs._

---

### **Documentation Changes Required** (Yes / No)  
_Indicate whether related documentation needs to be updated. Provide links to the updated documentation if applicable._

---

### **Dependencies**

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [x] Package version was bumped — see [versioning guide](https://semver.org/)
- [ ] Verified the package behaves as expected
- [ ] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)

---

