### PR TITLE
Add shared isValidDatabaseName validation helper to webdeployment-common

### DIFF
--- a/common-npm-packages/webdeployment-common/Tests/L0.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0.ts
@@ -9,6 +9,7 @@ import { runL1JsonVarSubV2Tests } from "./L1JsonVarSubV2";
 import { runL1ValidateFileEncodingTests } from "./L1ValidateFileEncoding";
 import { runParameterParserUtilityTests } from "./L0ParameterParserUtility";
 import { runL1ZipUtilityTests } from "./L1ZipUtility";
+import { runValidateDatabaseNameTests } from "./L0ValidateDatabaseName";
 
 describe('Web deployment common tests', () => {
     describe('GetMSDeployCmdArgs tests', runGetMSDeployCmdArgsTests);
@@ -23,4 +24,5 @@ describe('Web deployment common tests', () => {
     describe("L1ValidateFileEncoding tests", runL1ValidateFileEncodingTests);
     describe("ParameterParserUtility tests", runParameterParserUtilityTests);
     describe("ZipUtility tests", runL1ZipUtilityTests);
+    describe("ValidateDatabaseName tests", runValidateDatabaseNameTests);
 });

--- a/common-npm-packages/webdeployment-common/Tests/L0ValidateDatabaseName.ts
+++ b/common-npm-packages/webdeployment-common/Tests/L0ValidateDatabaseName.ts
@@ -1,0 +1,32 @@
+import * as assert from "assert";
+
+export function runValidateDatabaseNameTests(): void {
+    it("Should accept typical alphanumeric database names", async () => {
+        const utility = await import('../utility');
+        assert.strictEqual(utility.isValidDatabaseName('my_database-1'), true);
+        assert.strictEqual(utility.isValidDatabaseName('$special_db'), true);
+    });
+
+    it("Should accept non-ASCII BMP characters", async () => {
+        const utility = await import('../utility');
+        assert.strictEqual(utility.isValidDatabaseName('数据库'), true);
+        assert.strictEqual(utility.isValidDatabaseName('database_€'), true);
+    });
+
+    it("Should reject supplementary-plane characters such as emoji", async () => {
+        const utility = await import('../utility');
+        assert.strictEqual(utility.isValidDatabaseName('db_😀'), false);
+    });
+
+    it("Should reject names containing shell-sensitive characters", async () => {
+        const utility = await import('../utility');
+        assert.strictEqual(utility.isValidDatabaseName('db; DROP TABLE users;'), false);
+        assert.strictEqual(utility.isValidDatabaseName('db`whoami`'), false);
+        assert.strictEqual(utility.isValidDatabaseName('db && echo pwned'), false);
+    });
+
+    it("Should reject an empty database name", async () => {
+        const utility = await import('../utility');
+        assert.strictEqual(utility.isValidDatabaseName(''), false);
+    });
+}

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.279.1",
+    "version": "4.279.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-webdeployment-common",
-            "version": "4.279.1",
+            "version": "4.279.2",
             "license": "MIT",
             "dependencies": {
                 "@types/ltx": "3.0.6",
@@ -63,6 +63,7 @@
             "integrity": "sha1-UoateF33951lbojOhuZQ0Wyl8yI=",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -918,6 +919,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -3982,6 +3984,7 @@
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/core/-/core-7.29.0.tgz",
             "integrity": "sha1-UoateF33951lbojOhuZQ0Wyl8yI=",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -4585,6 +4588,7 @@
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/browserslist/-/browserslist-4.28.1.tgz",
             "integrity": "sha1-f1NFlGKMU8YxAQeeJ+QN5JBFapU=",
             "dev": true,
+            "peer": true,
             "requires": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",

--- a/common-npm-packages/webdeployment-common/package-lock.json
+++ b/common-npm-packages/webdeployment-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.279.2",
+    "version": "4.280.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-webdeployment-common",
-            "version": "4.279.2",
+            "version": "4.280.0",
             "license": "MIT",
             "dependencies": {
                 "@types/ltx": "3.0.6",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.279.2",
+    "version": "4.280.0",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",

--- a/common-npm-packages/webdeployment-common/package.json
+++ b/common-npm-packages/webdeployment-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-webdeployment-common",
-    "version": "4.279.1",
+    "version": "4.279.2",
     "description": "Common Lib for MSDeploy Utility",
     "repository": {
         "type": "git",

--- a/common-npm-packages/webdeployment-common/utility.ts
+++ b/common-npm-packages/webdeployment-common/utility.ts
@@ -3,6 +3,25 @@ import * as os from "os";
 import tl = require('azure-pipelines-task-lib/task');
 import { PackageType } from './packageUtility';
 import zipUtility = require('./ziputility');
+
+// ASCII alnum/_/-/$ plus the full Basic Multilingual Plane (U+0080-U+FFFF), EXCLUDING the
+// UTF-16 surrogate range (U+D800-U+DFFF) so that supplementary-plane characters (U+10000+,
+// e.g. emoji) are rejected -- MySQL never permits those in identifiers, quoted or not.
+const DATABASE_NAME_REGEX = /^[a-zA-Z0-9_\-$\u0080-\uD7FF\uE000-\uFFFF]+$/;
+
+/**
+ * Validates a database name against MySQL's identifier rules, allow-listing the character
+ * set MySQL itself permits in unquoted/quoted identifiers instead of block-listing unsafe
+ * characters, so callers get consistent, safe validation without duplicating this regex.
+ *
+ * @param databaseName Database name to validate
+ *
+ * @return true/false based on whether the name is a valid MySQL identifier.
+ */
+export function isValidDatabaseName(databaseName: string): boolean {
+    return DATABASE_NAME_REGEX.test(databaseName);
+}
+
 /**
  * Validates the input package and finds out input type
  *


### PR DESCRIPTION
## Description

Adds a shared `isValidDatabaseName()` / `DATABASE_NAME_REGEX` export to `webdeployment-common` so tasks that validate MySQL database names can consume one implementation instead of duplicating the same regex.

This was suggested by @wawanawna in a review comment on microsoft/azure-pipelines-tasks#22454, which independently added identical `isValidDatabaseName`/`DATABASE_NAME_REGEX` code (allow-list regex `^[a-zA-Z0-9_\-$\u0080-\uD7FF\uE000-\uFFFF]+$`) to both `AzureMysqlDeploymentV1` and `MysqlDeploymentOnMachineGroupV1` as part of a MySQL database-name injection fix (CWE-89).

## Changes

- `common-npm-packages/webdeployment-common/utility.ts`: new exported `isValidDatabaseName(databaseName: string): boolean` + `DATABASE_NAME_REGEX` constant, with the same allow-list semantics and comment as the duplicated code (ASCII alnum/`_`/`-`/`$` plus BMP Unicode, excluding the UTF-16 surrogate range so supplementary-plane characters like emoji are rejected).
- `common-npm-packages/webdeployment-common/Tests/L0ValidateDatabaseName.ts`: new unit tests (typical names, non-ASCII BMP names, rejected emoji/supplementary-plane characters, rejected shell-sensitive characters, empty string).
- `common-npm-packages/webdeployment-common/Tests/L0.ts`: wired the new test suite in.
- `package.json` / `package-lock.json`: version bump `4.279.1` → `4.279.2`.

## Testing

- `npm install && npm run build` succeeds.
- `npm test` — all 50 tests pass (including the 5 new ones).

## Follow-up (out of scope for this PR)

This PR only *adds* the shared utility to `webdeployment-common`. Once this package version is published, a separate PR in `azure-pipelines-tasks` will bump the `webdeployment-common` dependency in `AzureMysqlDeploymentV1` and `MysqlDeploymentOnMachineGroupV1` and remove their local duplicated `isValidDatabaseName`/`DATABASE_NAME_REGEX` in favor of this shared export.