### PR TITLE
Validate Azure Container Registry host before registry authentication (opt-in)

### DIFF
--- a/common-npm-packages/docker-common/Strings/resources.resjson/en-US/resources.resjson
+++ b/common-npm-packages/docker-common/Strings/resources.resjson/en-US/resources.resjson
@@ -14,6 +14,7 @@
   "loc.messages.FileContentSynced": "Synced the file content to the disk. The content is %s.",
   "loc.messages.FoundDockerConfigStoredInTempPath": "Found the Docker Config stored in the temp path. Docker config path: %s, Docker config: %s",
   "loc.messages.FoundLoginsForOtherRegistries": "Found login info for other registry(s). Trying to remove auth from the Docker config for the registry: %s",
+  "loc.messages.InvalidRegistryHost": "The container registry host '%s' is not a recognized Azure Container Registry login server.",
   "loc.messages.LoggingOutFromRegistry": "Trying to logout from registry: %s",
   "loc.messages.LoggingOutWithNoRegistrySpecified": "Logging out. Removing all auth data from temp docker config, since no registry is specified.",
   "loc.messages.NoAuthInfoFoundInDockerConfig": "No auths found in Docker config. Hence returning 0 registry url's.",

--- a/common-npm-packages/docker-common/Strings/resources.resjson/en-US/resources.resjson
+++ b/common-npm-packages/docker-common/Strings/resources.resjson/en-US/resources.resjson
@@ -15,6 +15,7 @@
   "loc.messages.FoundDockerConfigStoredInTempPath": "Found the Docker Config stored in the temp path. Docker config path: %s, Docker config: %s",
   "loc.messages.FoundLoginsForOtherRegistries": "Found login info for other registry(s). Trying to remove auth from the Docker config for the registry: %s",
   "loc.messages.InvalidRegistryHost": "The container registry host '%s' is not a recognized Azure Container Registry login server.",
+  "loc.messages.UnrecognizedRegistryHost": "The container registry host '%s' is not a recognized Azure Container Registry login server (service connection: %s, authentication scheme: %s).",
   "loc.messages.LoggingOutFromRegistry": "Trying to logout from registry: %s",
   "loc.messages.LoggingOutWithNoRegistrySpecified": "Logging out. Removing all auth data from temp docker config, since no registry is specified.",
   "loc.messages.NoAuthInfoFoundInDockerConfig": "No auths found in Docker config. Hence returning 0 registry url's.",

--- a/common-npm-packages/docker-common/Tests/L0.ts
+++ b/common-npm-packages/docker-common/Tests/L0.ts
@@ -1,5 +1,7 @@
 import { runDockerCommandSanitizationTests } from './dockerOutputSanitizationTests';
+import { runAcrRegistryHostValidationTests } from './acrRegistryHostValidationTests';
 
 describe('docker-common suite', () => {
     describe('Docker command output sanitization', runDockerCommandSanitizationTests);
+    describe('ACR registry host validation', runAcrRegistryHostValidationTests);
 });

--- a/common-npm-packages/docker-common/Tests/L0.ts
+++ b/common-npm-packages/docker-common/Tests/L0.ts
@@ -1,7 +1,9 @@
 import { runDockerCommandSanitizationTests } from './dockerOutputSanitizationTests';
 import { runAcrRegistryHostValidationTests } from './acrRegistryHostValidationTests';
+import { runAcrProviderHostValidationTests } from './acrProviderHostValidationTests';
 
 describe('docker-common suite', () => {
     describe('Docker command output sanitization', runDockerCommandSanitizationTests);
     describe('ACR registry host validation', runAcrRegistryHostValidationTests);
+    describe('ACR provider host validation', runAcrProviderHostValidationTests);
 });

--- a/common-npm-packages/docker-common/Tests/acrProviderHostValidationTests.ts
+++ b/common-npm-packages/docker-common/Tests/acrProviderHostValidationTests.ts
@@ -1,0 +1,70 @@
+// Provider-level checks that the host gate is enforced at BOTH public entry points
+// (getToken and getAuthenticationToken). The agent temp/working-dir env must be set
+// before importing the provider, which transitively loads azure-arm-rest.
+process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] = process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] || require("os").tmpdir();
+process.env["AGENT_TEMPDIRECTORY"] = process.env["AGENT_TEMPDIRECTORY"] || require("os").tmpdir();
+
+import assert = require("assert");
+import * as tl from "azure-pipelines-task-lib/task";
+import ACRAuthenticationTokenProvider from "../registryauthenticationprovider/acrauthenticationtokenprovider";
+
+export function runAcrProviderHostValidationTests() {
+
+    const featureVariable = "DistributedTask.Tasks.AcrRegistryHostValidation";
+
+    function setFeature(enabled: boolean): void {
+        tl.setVariable(featureVariable, enabled ? "true" : "false");
+    }
+
+    // registerNameValue is a raw host string (not JSON), so registryURL === host.
+    function providerFor(host: string): any {
+        return new ACRAuthenticationTokenProvider("endpoint", host);
+    }
+
+    afterEach(() => {
+        setFeature(false);
+    });
+
+    describe("getAuthenticationToken() (service-principal path)", () => {
+        it("feature ON + non-ACR host: throws", () => {
+            setFeature(true);
+            assert.throws(() => providerFor("other.example.com").getAuthenticationToken());
+        });
+
+        it("feature ON + valid ACR host: does not throw", () => {
+            setFeature(true);
+            assert.doesNotThrow(() => providerFor("contoso.azurecr.io").getAuthenticationToken());
+        });
+
+        it("feature OFF + non-ACR host: does not throw (behavior unchanged)", () => {
+            setFeature(false);
+            assert.doesNotThrow(() => providerFor("other.example.com").getAuthenticationToken());
+        });
+
+        it("feature ON + empty host: does not throw (returns null)", () => {
+            setFeature(true);
+            assert.strictEqual(providerFor("").getAuthenticationToken(), null);
+        });
+    });
+
+    describe("getToken() (gate runs before the auth-scheme dispatch, so it covers all schemes)", () => {
+        it("feature ON + non-ACR host: rejects before dispatching on scheme", (done) => {
+            setFeature(true);
+            providerFor("other.example.com").getToken().then(
+                () => done(new Error("expected the call to be rejected")),
+                (err: any) => {
+                    try { assert.ok(err && String(err.message).length > 0); done(); }
+                    catch (e) { done(e); }
+                }
+            );
+        });
+
+        it("feature OFF + non-ACR host: does not reject at the gate (behavior unchanged)", (done) => {
+            setFeature(false);
+            providerFor("other.example.com").getToken().then(
+                () => done(),
+                (err: any) => done(err)
+            );
+        });
+    });
+}

--- a/common-npm-packages/docker-common/Tests/acrProviderHostValidationTests.ts
+++ b/common-npm-packages/docker-common/Tests/acrProviderHostValidationTests.ts
@@ -1,6 +1,4 @@
-// Provider-level checks that the host gate is enforced at BOTH public entry points
-// (getToken and getAuthenticationToken). The agent temp/working-dir env must be set
-// before importing the provider, which transitively loads azure-arm-rest.
+// Set agent env before importing the provider (it transitively loads azure-arm-rest).
 process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] = process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] || require("os").tmpdir();
 process.env["AGENT_TEMPDIRECTORY"] = process.env["AGENT_TEMPDIRECTORY"] || require("os").tmpdir();
 
@@ -16,7 +14,7 @@ export function runAcrProviderHostValidationTests() {
         tl.setVariable(featureVariable, enabled ? "true" : "false");
     }
 
-    // registerNameValue is a raw host string (not JSON), so registryURL === host.
+    // Raw (non-JSON) host string, so registryURL === host.
     function providerFor(host: string): any {
         return new ACRAuthenticationTokenProvider("endpoint", host);
     }

--- a/common-npm-packages/docker-common/Tests/acrProviderHostValidationTests.ts
+++ b/common-npm-packages/docker-common/Tests/acrProviderHostValidationTests.ts
@@ -33,6 +33,12 @@ export function runAcrProviderHostValidationTests() {
             setFeature(true);
             assert.doesNotThrow(() => providerFor("contoso.azurecr.io").getAuthenticationToken());
         });
+
+        it("feature ON + empty loginServer: throws (empty is not a valid registry host)", () => {
+            setFeature(true);
+            const provider: any = new ACRAuthenticationTokenProvider("endpoint", '{"loginServer":""}');
+            assert.throws(() => provider.getAuthenticationToken());
+        });
     });
 
     describe("getToken() (host guarded on every auth-scheme path)", () => {

--- a/common-npm-packages/docker-common/Tests/acrProviderHostValidationTests.ts
+++ b/common-npm-packages/docker-common/Tests/acrProviderHostValidationTests.ts
@@ -33,20 +33,10 @@ export function runAcrProviderHostValidationTests() {
             setFeature(true);
             assert.doesNotThrow(() => providerFor("contoso.azurecr.io").getAuthenticationToken());
         });
-
-        it("feature OFF + non-ACR host: does not throw (behavior unchanged)", () => {
-            setFeature(false);
-            assert.doesNotThrow(() => providerFor("other.example.com").getAuthenticationToken());
-        });
-
-        it("feature ON + empty host: does not throw (returns null)", () => {
-            setFeature(true);
-            assert.strictEqual(providerFor("").getAuthenticationToken(), null);
-        });
     });
 
-    describe("getToken() (gate runs before the auth-scheme dispatch, so it covers all schemes)", () => {
-        it("feature ON + non-ACR host: rejects before dispatching on scheme", (done) => {
+    describe("getToken() (host guarded on every auth-scheme path)", () => {
+        it("feature ON + non-ACR host: rejects", (done) => {
             setFeature(true);
             providerFor("other.example.com").getToken().then(
                 () => done(new Error("expected the call to be rejected")),
@@ -57,11 +47,32 @@ export function runAcrProviderHostValidationTests() {
             );
         });
 
-        it("feature OFF + non-ACR host: does not reject at the gate (behavior unchanged)", (done) => {
+        it("feature OFF + non-ACR host: does not warn or reject (inert)", (done) => {
             setFeature(false);
             providerFor("other.example.com").getToken().then(
                 () => done(),
                 (err: any) => done(err)
+            );
+        });
+    });
+
+    describe("audit warning (no double-warn)", () => {
+        // Guarding each path once means the SP-via-getToken path warns once, not twice.
+        it("getToken() service-principal path warns exactly once", (done) => {
+            setFeature(true); // enforcing: warn (endpoint id + scheme), then throw
+            const original = process.stdout.write;
+            let out = "";
+            (process.stdout.write as any) = (chunk: any) => { out += chunk.toString(); return true; };
+            providerFor("other.example.com").getToken().then(
+                () => { (process.stdout.write as any) = original; done(new Error("expected the call to be rejected")); },
+                () => {
+                    (process.stdout.write as any) = original;
+                    try {
+                        const warnings = out.split("task.issue type=warning").length - 1;
+                        assert.strictEqual(warnings, 1, "expected exactly one warning (no double-warn)");
+                        done();
+                    } catch (e) { done(e); }
+                }
             );
         });
     });

--- a/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
+++ b/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
@@ -1,0 +1,108 @@
+// task-lib requires this variable during module initialization.
+process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] = process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] || '/tmp/work';
+
+import assert = require("assert");
+import * as tl from "azure-pipelines-task-lib/task";
+import { isAllowedAcrHost, shouldBlockRegistryHost, AcrHostValidationFeatureName } from "../registryauthenticationprovider/registryhostvalidation";
+
+export function runAcrRegistryHostValidationTests() {
+
+    describe("isAllowedAcrHost()", () => {
+
+        const accepted = [
+            "contoso.azurecr.io",
+            "CONTOSO.AZURECR.IO",
+            "my-registry.azurecr.io",
+            "team.sub.azurecr.io",
+            "contoso.azurecr.us",
+            "contoso.azurecr.cn",
+            "contoso.azurecr.de",
+            "contoso.azurecr.io.",
+        ];
+
+        accepted.forEach((host) => {
+            it(`accepts ${host}`, () => {
+                assert.strictEqual(isAllowedAcrHost(host), true);
+            });
+        });
+
+        const rejected = [
+            "",
+            "   ",
+            "localhost",
+            "example.com",
+            "127.0.0.1",
+            "127.0.0.1:8443",
+            "contoso.azurecr.io:8443",
+            "azurecr.io",
+            "azurecr.us",
+            "notazurecr.io",
+            "contoso.azurecr.iox",
+            "contoso.azurecr.io.example.com",
+            "contoso.azurecr.io.example.org",
+            "https://contoso.azurecr.io",
+            "contoso.azurecr.io/oauth2/exchange",
+            "user@contoso.azurecr.io",
+            "contoso.azurecr.io@example.net",
+            "contoso.azurecr.io example.com",
+            " contoso.azurecr.io",
+            "contoso.azurecr.io ",
+        ];
+
+        rejected.forEach((host) => {
+            it(`rejects ${JSON.stringify(host)}`, () => {
+                assert.strictEqual(isAllowedAcrHost(host), false);
+            });
+        });
+
+        const airGapped = [
+            "contoso.azurecr.eaglex.ic.gov",
+            "contoso.azurecr.microsoft.scloud",
+        ];
+
+        airGapped.forEach((host) => {
+            it(`accepts ${host}`, () => {
+                assert.strictEqual(isAllowedAcrHost(host), true);
+            });
+        });
+
+        it("rejects non-string inputs", () => {
+            assert.strictEqual(isAllowedAcrHost(undefined as any), false);
+            assert.strictEqual(isAllowedAcrHost(null as any), false);
+            assert.strictEqual(isAllowedAcrHost(123 as any), false);
+        });
+    });
+
+    describe("shouldBlockRegistryHost() (feature gate)", () => {
+        const featureName = "AcrRegistryHostValidation";
+        const featureVariable = "DistributedTask.Tasks." + featureName;
+
+        function setFeature(enabled: boolean): void {
+            tl.setVariable(featureVariable, enabled ? "true" : "false");
+        }
+
+        afterEach(() => {
+            setFeature(false);
+        });
+
+        // Prevent accidental changes to the production feature-variable name.
+        it("exposes the expected feature name", () => {
+            assert.strictEqual(AcrHostValidationFeatureName, featureName);
+        });
+
+        it("feature ON + non-ACR host: blocks the request", () => {
+            setFeature(true);
+            assert.strictEqual(shouldBlockRegistryHost("other.example.com"), true);
+        });
+
+        it("feature ON + valid ACR host: does not block", () => {
+            setFeature(true);
+            assert.strictEqual(shouldBlockRegistryHost("contoso.azurecr.io"), false);
+        });
+
+        it("feature OFF + non-ACR host: does not block (behavior unchanged)", () => {
+            setFeature(false);
+            assert.strictEqual(shouldBlockRegistryHost("other.example.com"), false);
+        });
+    });
+}

--- a/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
+++ b/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
@@ -104,5 +104,11 @@ export function runAcrRegistryHostValidationTests() {
             setFeature(false);
             assert.strictEqual(shouldBlockRegistryHost("other.example.com"), false);
         });
+
+        it("feature ON + empty/absent host: does not block", () => {
+            setFeature(true);
+            assert.strictEqual(shouldBlockRegistryHost(""), false);
+            assert.strictEqual(shouldBlockRegistryHost(undefined as any), false);
+        });
     });
 }

--- a/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
+++ b/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
@@ -122,11 +122,11 @@ export function runAcrRegistryHostValidationTests() {
 
         it("enforcing + non-ACR host: warns with the host, endpoint id, and scheme", () => {
             setEnforce(true);
-            const out = capture(() => guardRegistryHost("other.example.com", "endpoint-abc", "ServicePrincipal"));
+            const host = "other.example.com";
+            const expected = tl.loc("UnrecognizedRegistryHost", host, "endpoint-abc", "ServicePrincipal");
+            const out = capture(() => guardRegistryHost(host, "endpoint-abc", "ServicePrincipal"));
             assert.ok(out.indexOf("task.issue type=warning") !== -1, "expected a warning");
-            assert.ok(out.indexOf("other.example.com") !== -1, "warning should name the host");
-            assert.ok(out.indexOf("endpoint-abc") !== -1, "warning should name the endpoint id");
-            assert.ok(out.indexOf("ServicePrincipal") !== -1, "warning should name the auth scheme");
+            assert.ok(out.indexOf(expected) !== -1, "warning should contain the host, endpoint id, and scheme");
         });
 
         it("not enforcing + non-ACR host: no warning (inert)", () => {

--- a/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
+++ b/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
@@ -3,7 +3,7 @@ process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] = process.env['SYSTEM_DEFAULTWORKI
 
 import assert = require("assert");
 import * as tl from "azure-pipelines-task-lib/task";
-import { isAllowedAcrHost, guardRegistryHost, AcrHostValidationFeatureName } from "../registryauthenticationprovider/registryhostvalidation";
+import { isAllowedAcrHost, guardRegistryHost, sanitizeUrl, AcrHostValidationFeatureName } from "../registryauthenticationprovider/registryhostvalidation";
 
 export function runAcrRegistryHostValidationTests() {
 
@@ -123,16 +123,43 @@ export function runAcrRegistryHostValidationTests() {
         it("enforcing + non-ACR host: warns with the host, endpoint id, and scheme", () => {
             setEnforce(true);
             const host = "other.example.com";
-            const expected = tl.loc("UnrecognizedRegistryHost", host, "endpoint-abc", "ServicePrincipal");
+            const expected = tl.loc("UnrecognizedRegistryHost", sanitizeUrl(host), "endpoint-abc", "ServicePrincipal");
             const out = capture(() => guardRegistryHost(host, "endpoint-abc", "ServicePrincipal"));
             assert.ok(out.indexOf("task.issue type=warning") !== -1, "expected a warning");
             assert.ok(out.indexOf(expected) !== -1, "warning should contain the host, endpoint id, and scheme");
+        });
+
+        it("enforcing + host with embedded userinfo: drops it, keeps the host", () => {
+            setEnforce(true);
+            const host = "user:pass@evil.example.com";
+            const expected = tl.loc("UnrecognizedRegistryHost", sanitizeUrl(host), "endpoint-abc", "ServicePrincipal");
+            const out = capture(() => guardRegistryHost(host, "endpoint-abc", "ServicePrincipal"));
+            assert.ok(out.indexOf(expected) !== -1, "warning should contain the sanitized host");
+            assert.strictEqual(out.indexOf("user:pass"), -1, "raw userinfo must not be logged");
         });
 
         it("not enforcing + non-ACR host: no warning (inert)", () => {
             setEnforce(false);
             const out = capture(() => guardRegistryHost("other.example.com", "endpoint-abc", "ServicePrincipal"));
             assert.strictEqual(out.indexOf("task.issue type=warning"), -1);
+        });
+    });
+
+    describe("sanitizeUrl()", () => {
+        const cases: Array<[string, string]> = [
+            ["contoso.azurecr.io", "contoso.azurecr.io"],                            // plain host unchanged
+            ["evil.example.com:8443", "evil.example.com:8443"],                      // port preserved
+            ["contoso.azurecr.io/v2/list?a=b", "contoso.azurecr.io"],                // path/query dropped
+            ["user@evil.example.com", "evil.example.com"],                           // userinfo dropped
+            ["user:pass@evil.example.com", "evil.example.com"],                      // user:pass userinfo dropped
+            ["https://user:pass@evil.example.com/p?a=b", "evil.example.com"],        // scheme + userinfo + path/query dropped
+            ["weird@@@", "***"],                                                     // unparseable -> redacted
+        ];
+
+        cases.forEach(([input, expected]) => {
+            it(`sanitizes ${JSON.stringify(input)}`, () => {
+                assert.strictEqual(sanitizeUrl(input), expected);
+            });
         });
     });
 }

--- a/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
+++ b/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
@@ -94,10 +94,15 @@ export function runAcrRegistryHostValidationTests() {
             assert.doesNotThrow(() => guardRegistryHost("other.example.com", "endpoint-abc", "ServicePrincipal"));
         });
 
-        it("enforce ON + empty/absent host: does not throw", () => {
+        it("enforce ON + empty/absent host: throws (empty is not a valid registry host)", () => {
             setEnforce(true);
+            assert.throws(() => guardRegistryHost("", "endpoint-abc", "ServicePrincipal"));
+            assert.throws(() => guardRegistryHost(undefined as any, "endpoint-abc", "ServicePrincipal"));
+        });
+
+        it("enforce OFF + empty host: does not throw (inert)", () => {
+            setEnforce(false);
             assert.doesNotThrow(() => guardRegistryHost("", "endpoint-abc", "ServicePrincipal"));
-            assert.doesNotThrow(() => guardRegistryHost(undefined as any, "endpoint-abc", "ServicePrincipal"));
         });
     });
 

--- a/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
+++ b/common-npm-packages/docker-common/Tests/acrRegistryHostValidationTests.ts
@@ -3,7 +3,7 @@ process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] = process.env['SYSTEM_DEFAULTWORKI
 
 import assert = require("assert");
 import * as tl from "azure-pipelines-task-lib/task";
-import { isAllowedAcrHost, shouldBlockRegistryHost, AcrHostValidationFeatureName } from "../registryauthenticationprovider/registryhostvalidation";
+import { isAllowedAcrHost, guardRegistryHost, AcrHostValidationFeatureName } from "../registryauthenticationprovider/registryhostvalidation";
 
 export function runAcrRegistryHostValidationTests() {
 
@@ -27,26 +27,18 @@ export function runAcrRegistryHostValidationTests() {
         });
 
         const rejected = [
-            "",
-            "   ",
-            "localhost",
-            "example.com",
-            "127.0.0.1",
-            "127.0.0.1:8443",
-            "contoso.azurecr.io:8443",
-            "azurecr.io",
-            "azurecr.us",
-            "notazurecr.io",
-            "contoso.azurecr.iox",
-            "contoso.azurecr.io.example.com",
-            "contoso.azurecr.io.example.org",
-            "https://contoso.azurecr.io",
-            "contoso.azurecr.io/oauth2/exchange",
-            "user@contoso.azurecr.io",
-            "contoso.azurecr.io@example.net",
-            "contoso.azurecr.io example.com",
-            " contoso.azurecr.io",
-            "contoso.azurecr.io ",
+            "",                                   // empty / absent
+            "localhost",                          // single label, no suffix
+            "example.com",                        // well-formed host, not an ACR suffix
+            "contoso.azurecr.io:8443",            // port
+            "azurecr.io",                         // bare suffix, no subdomain
+            "notazurecr.io",                      // suffix not on a label boundary
+            "contoso.azurecr.iox",                // look-alike suffix
+            "contoso.azurecr.io.example.com",     // real host is example.com
+            "https://contoso.azurecr.io",         // scheme / URL syntax
+            "contoso.azurecr.io@example.net",     // real host is example.net
+            " contoso.azurecr.io",                // leading space must not be trimmed then accepted
+            "contoso.azurecr.io ",                // trailing space
         ];
 
         rejected.forEach((host) => {
@@ -73,42 +65,74 @@ export function runAcrRegistryHostValidationTests() {
         });
     });
 
-    describe("shouldBlockRegistryHost() (feature gate)", () => {
-        const featureName = "AcrRegistryHostValidation";
-        const featureVariable = "DistributedTask.Tasks." + featureName;
+    describe("guardRegistryHost() (enforce)", () => {
+        const enforceVariable = "DistributedTask.Tasks." + AcrHostValidationFeatureName;
 
-        function setFeature(enabled: boolean): void {
-            tl.setVariable(featureVariable, enabled ? "true" : "false");
+        function setEnforce(enabled: boolean): void {
+            tl.setVariable(enforceVariable, enabled ? "true" : "false");
         }
 
-        afterEach(() => {
-            setFeature(false);
-        });
+        afterEach(() => setEnforce(false));
 
         // Prevent accidental changes to the production feature-variable name.
-        it("exposes the expected feature name", () => {
-            assert.strictEqual(AcrHostValidationFeatureName, featureName);
+        it("exposes the expected enforce feature name", () => {
+            assert.strictEqual(AcrHostValidationFeatureName, "AcrRegistryHostValidation");
         });
 
-        it("feature ON + non-ACR host: blocks the request", () => {
-            setFeature(true);
-            assert.strictEqual(shouldBlockRegistryHost("other.example.com"), true);
+        it("enforce ON + non-ACR host: throws", () => {
+            setEnforce(true);
+            assert.throws(() => guardRegistryHost("other.example.com", "endpoint-abc", "ServicePrincipal"));
         });
 
-        it("feature ON + valid ACR host: does not block", () => {
-            setFeature(true);
-            assert.strictEqual(shouldBlockRegistryHost("contoso.azurecr.io"), false);
+        it("enforce ON + valid ACR host: does not throw", () => {
+            setEnforce(true);
+            assert.doesNotThrow(() => guardRegistryHost("contoso.azurecr.io", "endpoint-abc", "ServicePrincipal"));
         });
 
-        it("feature OFF + non-ACR host: does not block (behavior unchanged)", () => {
-            setFeature(false);
-            assert.strictEqual(shouldBlockRegistryHost("other.example.com"), false);
+        it("enforce OFF + non-ACR host: does not throw (inert)", () => {
+            setEnforce(false);
+            assert.doesNotThrow(() => guardRegistryHost("other.example.com", "endpoint-abc", "ServicePrincipal"));
         });
 
-        it("feature ON + empty/absent host: does not block", () => {
-            setFeature(true);
-            assert.strictEqual(shouldBlockRegistryHost(""), false);
-            assert.strictEqual(shouldBlockRegistryHost(undefined as any), false);
+        it("enforce ON + empty/absent host: does not throw", () => {
+            setEnforce(true);
+            assert.doesNotThrow(() => guardRegistryHost("", "endpoint-abc", "ServicePrincipal"));
+            assert.doesNotThrow(() => guardRegistryHost(undefined as any, "endpoint-abc", "ServicePrincipal"));
+        });
+    });
+
+    describe("guardRegistryHost() (audit warning)", () => {
+        const enforceVariable = "DistributedTask.Tasks." + AcrHostValidationFeatureName;
+
+        function setEnforce(enabled: boolean): void {
+            tl.setVariable(enforceVariable, enabled ? "true" : "false");
+        }
+
+        // Feature-variable is set before capturing. The guard throws after warning when enforcing,
+        // so the throw is swallowed here to inspect the emitted warning on stdout.
+        function capture(fn: () => void): string {
+            const original = process.stdout.write;
+            let out = "";
+            (process.stdout.write as any) = (chunk: any) => { out += chunk.toString(); return true; };
+            try { fn(); } catch (e) { /* inspect the warning, not the throw */ } finally { (process.stdout.write as any) = original; }
+            return out;
+        }
+
+        afterEach(() => setEnforce(false));
+
+        it("enforcing + non-ACR host: warns with the host, endpoint id, and scheme", () => {
+            setEnforce(true);
+            const out = capture(() => guardRegistryHost("other.example.com", "endpoint-abc", "ServicePrincipal"));
+            assert.ok(out.indexOf("task.issue type=warning") !== -1, "expected a warning");
+            assert.ok(out.indexOf("other.example.com") !== -1, "warning should name the host");
+            assert.ok(out.indexOf("endpoint-abc") !== -1, "warning should name the endpoint id");
+            assert.ok(out.indexOf("ServicePrincipal") !== -1, "warning should name the auth scheme");
+        });
+
+        it("not enforcing + non-ACR host: no warning (inert)", () => {
+            setEnforce(false);
+            const out = capture(() => guardRegistryHost("other.example.com", "endpoint-abc", "ServicePrincipal"));
+            assert.strictEqual(out.indexOf("task.issue type=warning"), -1);
         });
     });
 }

--- a/common-npm-packages/docker-common/module.json
+++ b/common-npm-packages/docker-common/module.json
@@ -15,6 +15,7 @@
         "FileContentSynced": "Synced the file content to the disk. The content is %s.",
         "FoundDockerConfigStoredInTempPath": "Found the Docker Config stored in the temp path. Docker config path: %s, Docker config: %s",
         "FoundLoginsForOtherRegistries": "Found login info for other registry(s). Trying to remove auth from the Docker config for the registry: %s",
+        "InvalidRegistryHost": "The container registry host '%s' is not a recognized Azure Container Registry login server.",
         "LoggingOutFromRegistry": "Trying to logout from registry: %s",
         "LoggingOutWithNoRegistrySpecified": "Logging out. Removing all auth data from temp docker config, since no registry is specified.",
         "NoAuthInfoFoundInDockerConfig": "No auths found in Docker config. Hence returning 0 registry url's.",

--- a/common-npm-packages/docker-common/module.json
+++ b/common-npm-packages/docker-common/module.json
@@ -16,6 +16,7 @@
         "FoundDockerConfigStoredInTempPath": "Found the Docker Config stored in the temp path. Docker config path: %s, Docker config: %s",
         "FoundLoginsForOtherRegistries": "Found login info for other registry(s). Trying to remove auth from the Docker config for the registry: %s",
         "InvalidRegistryHost": "The container registry host '%s' is not a recognized Azure Container Registry login server.",
+        "UnrecognizedRegistryHost": "The container registry host '%s' is not a recognized Azure Container Registry login server (service connection: %s, authentication scheme: %s).",
         "LoggingOutFromRegistry": "Trying to logout from registry: %s",
         "LoggingOutWithNoRegistrySpecified": "Logging out. Removing all auth data from temp docker config, since no registry is specified.",
         "NoAuthInfoFoundInDockerConfig": "No auths found in Docker config. Hence returning 0 registry url's.",

--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.279.0",
+    "version": "2.280.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.279.0",
+            "version": "2.280.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.280.0",
+    "version": "2.281.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.280.0",
+            "version": "2.281.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.280.1",
+    "version": "2.280.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.280.1",
+            "version": "2.280.2",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.279.0",
+    "version": "2.280.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.280.1",
+    "version": "2.280.2",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",
@@ -28,8 +28,12 @@
         "typescript": "^4.9.5"
     },
     "overrides": {
-        "brace-expansion@1.x": { ".": "1.1.18" },
-        "brace-expansion@2.x": { ".": "2.1.4" },
+        "brace-expansion@1.x": {
+            ".": "1.1.18"
+        },
+        "brace-expansion@2.x": {
+            ".": "2.1.4"
+        },
         "js-yaml": "^4.3.1",
         "serialize-javascript": "^7.0.5"
     },

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.280.0",
+    "version": "2.281.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",

--- a/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
@@ -5,9 +5,13 @@ import { AzureRMEndpoint } from "azure-pipelines-tasks-azure-arm-rest/azure-arm-
 import * as webClient from "azure-pipelines-tasks-azure-arm-rest/webClient";
 import * as tl from "azure-pipelines-task-lib/task";
 import Q = require('q');
+import path = require('path');
 
 import AuthenticationTokenProvider from "./authenticationtokenprovider";
 import RegistryAuthenticationToken from "./registryauthenticationtoken";
+import { shouldBlockRegistryHost } from "./registryhostvalidation";
+
+tl.setResourcePath(path.join(__dirname, '..', 'module.json'), true);
 
 export default class ACRAuthenticationTokenProvider extends AuthenticationTokenProvider{
 
@@ -92,6 +96,10 @@ export default class ACRAuthenticationTokenProvider extends AuthenticationTokenP
     private static _getACRToken(AADToken: string, endpointName: string, registryURL: string, retryCount: number, timeToWait: number): Q.Promise<string> {
         tl.debug("Attempting to convert AAD Token to an ACR token");
         let deferred = Q.defer<string>();
+        if (shouldBlockRegistryHost(registryURL)) {
+            deferred.reject(new Error(tl.loc("InvalidRegistryHost", registryURL)));
+            return deferred.promise;
+        }
         let tenantID = tl.getEndpointAuthorizationParameter(endpointName, 'tenantid', true);
         let webRequest = new webClient.WebRequest();
         webRequest.method = "POST";

--- a/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
@@ -44,6 +44,9 @@ export default class ACRAuthenticationTokenProvider extends AuthenticationTokenP
     }
 
     public getAuthenticationToken(): RegistryAuthenticationToken {
+        if (shouldBlockRegistryHost(this.registryURL)) {
+            throw new Error(tl.loc("InvalidRegistryHost", this.registryURL));
+        }
         if (this.registryURL && this.endpointName) {
             return new RegistryAuthenticationToken(
                 tl.getEndpointAuthorizationParameter(this.endpointName, 'serviceprincipalid', true),
@@ -56,6 +59,9 @@ export default class ACRAuthenticationTokenProvider extends AuthenticationTokenP
     }
 
     public async getToken(): Promise<RegistryAuthenticationToken> {
+        if (shouldBlockRegistryHost(this.registryURL)) {
+            throw new Error(tl.loc("InvalidRegistryHost", this.registryURL));
+        }
         let authType: string;
         try {
             tl.debug("Attempting to get endpoint authorization scheme...");
@@ -93,13 +99,11 @@ export default class ACRAuthenticationTokenProvider extends AuthenticationTokenP
         }
     }
 
+    // Callers reach this only through getToken(), whose entry gate has already run
+    // shouldBlockRegistryHost(this.registryURL); keep that invariant for any new caller.
     private static _getACRToken(AADToken: string, endpointName: string, registryURL: string, retryCount: number, timeToWait: number): Q.Promise<string> {
         tl.debug("Attempting to convert AAD Token to an ACR token");
         let deferred = Q.defer<string>();
-        if (shouldBlockRegistryHost(registryURL)) {
-            deferred.reject(new Error(tl.loc("InvalidRegistryHost", registryURL)));
-            return deferred.promise;
-        }
         let tenantID = tl.getEndpointAuthorizationParameter(endpointName, 'tenantid', true);
         let webRequest = new webClient.WebRequest();
         webRequest.method = "POST";

--- a/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
@@ -9,7 +9,7 @@ import path = require('path');
 
 import AuthenticationTokenProvider from "./authenticationtokenprovider";
 import RegistryAuthenticationToken from "./registryauthenticationtoken";
-import { shouldBlockRegistryHost } from "./registryhostvalidation";
+import { guardRegistryHost } from "./registryhostvalidation";
 
 tl.setResourcePath(path.join(__dirname, '..', 'module.json'), true);
 
@@ -44,9 +44,7 @@ export default class ACRAuthenticationTokenProvider extends AuthenticationTokenP
     }
 
     public getAuthenticationToken(): RegistryAuthenticationToken {
-        if (shouldBlockRegistryHost(this.registryURL)) {
-            throw new Error(tl.loc("InvalidRegistryHost", this.registryURL));
-        }
+        guardRegistryHost(this.registryURL, this.endpointName, "ServicePrincipal");
         if (this.registryURL && this.endpointName) {
             return new RegistryAuthenticationToken(
                 tl.getEndpointAuthorizationParameter(this.endpointName, 'serviceprincipalid', true),
@@ -59,9 +57,6 @@ export default class ACRAuthenticationTokenProvider extends AuthenticationTokenP
     }
 
     public async getToken(): Promise<RegistryAuthenticationToken> {
-        if (shouldBlockRegistryHost(this.registryURL)) {
-            throw new Error(tl.loc("InvalidRegistryHost", this.registryURL));
-        }
         let authType: string;
         try {
             tl.debug("Attempting to get endpoint authorization scheme...");
@@ -79,11 +74,13 @@ export default class ACRAuthenticationTokenProvider extends AuthenticationTokenP
             }
         }
         if (authType == "ManagedServiceIdentity") {
+            guardRegistryHost(this.registryURL, this.endpointName, "ManagedServiceIdentity");
             // Parameter 1: retryCount - the current retry count of the method to get the ACR token through MSI authentication
             // Parameter 2: timeToWait - the current time wait of the method to get the ACR token through MSI authentication
             return await this._getMSIAuthenticationToken(0, 0);
         }
         else if (authType === 'WorkloadIdentityFederation') {
+            guardRegistryHost(this.registryURL, this.endpointName, "WorkloadIdentityFederation");
             const endpoint = await new AzureRMEndpoint(this.endpointName).getEndpoint();
             const aadToken = await endpoint.applicationTokenCredentials.getToken();
             let acrToken = await ACRAuthenticationTokenProvider._getACRToken(aadToken, this.endpointName, this.registryURL, 0, 0);

--- a/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
@@ -99,7 +99,6 @@ export default class ACRAuthenticationTokenProvider extends AuthenticationTokenP
         }
     }
 
-    // No host check here — callers must run shouldBlockRegistryHost(registryURL) first.
     private static _getACRToken(AADToken: string, endpointName: string, registryURL: string, retryCount: number, timeToWait: number): Q.Promise<string> {
         tl.debug("Attempting to convert AAD Token to an ACR token");
         let deferred = Q.defer<string>();

--- a/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
@@ -99,8 +99,7 @@ export default class ACRAuthenticationTokenProvider extends AuthenticationTokenP
         }
     }
 
-    // Callers reach this only through getToken(), whose entry gate has already run
-    // shouldBlockRegistryHost(this.registryURL); keep that invariant for any new caller.
+    // Host is already validated at the getToken() entry point; new callers must preserve that.
     private static _getACRToken(AADToken: string, endpointName: string, registryURL: string, retryCount: number, timeToWait: number): Q.Promise<string> {
         tl.debug("Attempting to convert AAD Token to an ACR token");
         let deferred = Q.defer<string>();

--- a/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/acrauthenticationtokenprovider.ts
@@ -99,7 +99,7 @@ export default class ACRAuthenticationTokenProvider extends AuthenticationTokenP
         }
     }
 
-    // Host is already validated at the getToken() entry point; new callers must preserve that.
+    // No host check here — callers must run shouldBlockRegistryHost(registryURL) first.
     private static _getACRToken(AADToken: string, endpointName: string, registryURL: string, retryCount: number, timeToWait: number): Q.Promise<string> {
         tl.debug("Attempting to convert AAD Token to an ACR token");
         let deferred = Q.defer<string>();

--- a/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
@@ -1,0 +1,61 @@
+"use strict";
+
+import * as tl from "azure-pipelines-task-lib/task";
+
+// Standard ACR login-server suffixes, including sovereign and air-gapped clouds.
+const allowedAcrHostSuffixes: string[] = [
+    ".azurecr.io",                 // Azure public
+    ".azurecr.us",                 // Azure US Government
+    ".azurecr.cn",                 // Azure China (21Vianet)
+    ".azurecr.de",                 // Azure Germany (legacy)
+    ".azurecr.eaglex.ic.gov",      // Azure US Nat (air-gapped)
+    ".azurecr.microsoft.scloud",   // Azure US Sec (air-gapped)
+];
+
+// Dotted DNS labels without leading or trailing hyphens.
+const hostShape = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+/** Returns whether registryURL is a valid standard ACR login server. */
+export function isAllowedAcrHost(registryURL: string): boolean {
+    if (!registryURL || typeof registryURL !== "string") {
+        return false;
+    }
+
+    let host = registryURL;
+    if (host.length === 0) {
+        return false;
+    }
+
+    // Reject URL syntax and whitespace; only a hostname is allowed.
+    if (/[\s/\\?#@]/.test(host)) {
+        return false;
+    }
+
+    if (host.indexOf(":") !== -1) {
+        return false;
+    }
+
+    host = host.toLowerCase();
+
+    // Accept a fully qualified hostname with a trailing root dot.
+    if (host.endsWith(".")) {
+        host = host.slice(0, -1);
+    }
+
+    if (!hostShape.test(host)) {
+        return false;
+    }
+
+    return allowedAcrHostSuffixes.some(
+        (suffix) => host.length > suffix.length && host.endsWith(suffix)
+    );
+}
+
+// Opt-in because Azure Stack Hub and other environments can use custom ACR suffixes.
+// Enable with DistributedTask.Tasks.AcrRegistryHostValidation=true.
+export const AcrHostValidationFeatureName = "AcrRegistryHostValidation";
+
+/** Returns whether the feature gate requires this registry host to be blocked. */
+export function shouldBlockRegistryHost(registryURL: string): boolean {
+    return tl.getPipelineFeature(AcrHostValidationFeatureName) && !isAllowedAcrHost(registryURL);
+}

--- a/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
@@ -55,7 +55,10 @@ export function isAllowedAcrHost(registryURL: string): boolean {
 // Enable with DistributedTask.Tasks.AcrRegistryHostValidation=true.
 export const AcrHostValidationFeatureName = "AcrRegistryHostValidation";
 
-/** Returns whether the feature gate requires this registry host to be blocked. */
+/**
+ * Returns whether the feature gate requires this registry host to be blocked.
+ * An empty or absent host is never blocked (there is no host to check).
+ */
 export function shouldBlockRegistryHost(registryURL: string): boolean {
-    return tl.getPipelineFeature(AcrHostValidationFeatureName) && !isAllowedAcrHost(registryURL);
+    return !!registryURL && tl.getPipelineFeature(AcrHostValidationFeatureName) && !isAllowedAcrHost(registryURL);
 }

--- a/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
@@ -2,7 +2,7 @@
 
 import * as tl from "azure-pipelines-task-lib/task";
 
-// Standard ACR login-server suffixes, including sovereign and air-gapped clouds.
+// A cloud whose suffix is missing here is blocked when the feature is on.
 const allowedAcrHostSuffixes: string[] = [
     ".azurecr.io",                 // Azure public
     ".azurecr.us",                 // Azure US Government
@@ -12,10 +12,8 @@ const allowedAcrHostSuffixes: string[] = [
     ".azurecr.microsoft.scloud",   // Azure US Sec (air-gapped)
 ];
 
-// Dotted DNS labels without leading or trailing hyphens.
 const hostShape = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
 
-/** Returns whether registryURL is a valid standard ACR login server. */
 export function isAllowedAcrHost(registryURL: string): boolean {
     if (!registryURL || typeof registryURL !== "string") {
         return false;
@@ -26,7 +24,7 @@ export function isAllowedAcrHost(registryURL: string): boolean {
         return false;
     }
 
-    // Reject URL syntax and whitespace; only a hostname is allowed.
+    // A login server is a plain hostname — reject anything with URL syntax.
     if (/[\s/\\?#@]/.test(host)) {
         return false;
     }
@@ -37,7 +35,7 @@ export function isAllowedAcrHost(registryURL: string): boolean {
 
     host = host.toLowerCase();
 
-    // Accept a fully qualified hostname with a trailing root dot.
+    // Tolerate the FQDN trailing dot.
     if (host.endsWith(".")) {
         host = host.slice(0, -1);
     }
@@ -51,14 +49,10 @@ export function isAllowedAcrHost(registryURL: string): boolean {
     );
 }
 
-// Opt-in because Azure Stack Hub and other environments can use custom ACR suffixes.
-// Enable with DistributedTask.Tasks.AcrRegistryHostValidation=true.
+// Opt-in: Azure Stack Hub and other clouds use ACR suffixes the allow-list can't cover.
 export const AcrHostValidationFeatureName = "AcrRegistryHostValidation";
 
-/**
- * Returns whether the feature gate requires this registry host to be blocked.
- * An empty or absent host is never blocked (there is no host to check).
- */
+// Empty/absent host is never blocked — nothing to validate.
 export function shouldBlockRegistryHost(registryURL: string): boolean {
     return !!registryURL && tl.getPipelineFeature(AcrHostValidationFeatureName) && !isAllowedAcrHost(registryURL);
 }

--- a/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
@@ -51,8 +51,6 @@ export function isAllowedAcrHost(registryURL: string): boolean {
 
 export const AcrHostValidationFeatureName = "AcrRegistryHostValidation";
 
-// The feature flag turns the whole check on or off: when off, do nothing. When on, an unrecognized
-// host is recorded (host, service connection, and auth scheme) and then blocked.
 export function guardRegistryHost(registryURL: string, endpointId: string, scheme: string): void {
     if (!tl.getPipelineFeature(AcrHostValidationFeatureName)) {
         return;

--- a/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
@@ -72,13 +72,14 @@ export function sanitizeUrl(url: string): string {
 }
 
 export function guardRegistryHost(registryURL: string, endpointId: string, scheme: string): void {
-    if (!tl.getPipelineFeature(AcrHostValidationFeatureName) || !registryURL) {
+    if (!tl.getPipelineFeature(AcrHostValidationFeatureName)) {
         return;
     }
     if (isAllowedAcrHost(registryURL)) {
         return;
     }
-    const safeUrl = sanitizeUrl(registryURL);
+    // An empty/absent login server is not a legitimate ACR host, so it also lands here as invalid.
+    const safeUrl = sanitizeUrl(registryURL) || "";
     tl.warning(tl.loc("UnrecognizedRegistryHost", safeUrl, endpointId, scheme));
     throw new Error(tl.loc("InvalidRegistryHost", safeUrl));
 }

--- a/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
@@ -51,7 +51,15 @@ export function isAllowedAcrHost(registryURL: string): boolean {
 
 export const AcrHostValidationFeatureName = "AcrRegistryHostValidation";
 
-// Empty/absent host is never blocked — nothing to validate.
-export function shouldBlockRegistryHost(registryURL: string): boolean {
-    return !!registryURL && tl.getPipelineFeature(AcrHostValidationFeatureName) && !isAllowedAcrHost(registryURL);
+// The feature flag turns the whole check on or off: when off, do nothing. When on, an unrecognized
+// host is recorded (host, service connection, and auth scheme) and then blocked.
+export function guardRegistryHost(registryURL: string, endpointId: string, scheme: string): void {
+    if (!tl.getPipelineFeature(AcrHostValidationFeatureName)) {
+        return;
+    }
+    if (!registryURL || isAllowedAcrHost(registryURL)) {
+        return;
+    }
+    tl.warning(tl.loc("UnrecognizedRegistryHost", registryURL, endpointId, scheme));
+    throw new Error(tl.loc("InvalidRegistryHost", registryURL));
 }

--- a/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
@@ -1,6 +1,10 @@
 "use strict";
 
 import * as tl from "azure-pipelines-task-lib/task";
+import * as path from "path";
+import { URL } from "url";
+
+tl.setResourcePath(path.join(__dirname, "..", "module.json"), true);
 
 // A cloud whose suffix is missing here is blocked when the feature is on.
 const allowedAcrHostSuffixes: string[] = [
@@ -51,13 +55,30 @@ export function isAllowedAcrHost(registryURL: string): boolean {
 
 export const AcrHostValidationFeatureName = "AcrRegistryHostValidation";
 
+// A registry login server is normally just a host (e.g. "contoso.azurecr.io"); this reduces whatever
+// value we were given to that host[:port] for logging. new URL(...).host drops any scheme, "user:pass@"
+// userinfo and path/query, so nothing but the host is logged. A scheme is prepended when the value is a
+// bare host so it parses, and an unparseable value becomes "***". Same URL parsing other tasks use to
+// read a registry host (e.g. AzureFunctionOnKubernetes' dockerConnection.ts, ContainerBasedDeploymentUtility.ts).
+export function sanitizeUrl(url: string): string {
+    if (!url) {
+        return url;
+    }
+    try {
+        return new URL(url.includes("://") ? url : `https://${url}`).host;
+    } catch {
+        return "***";
+    }
+}
+
 export function guardRegistryHost(registryURL: string, endpointId: string, scheme: string): void {
-    if (!tl.getPipelineFeature(AcrHostValidationFeatureName)) {
+    if (!tl.getPipelineFeature(AcrHostValidationFeatureName) || !registryURL) {
         return;
     }
-    if (!registryURL || isAllowedAcrHost(registryURL)) {
+    if (isAllowedAcrHost(registryURL)) {
         return;
     }
-    tl.warning(tl.loc("UnrecognizedRegistryHost", registryURL, endpointId, scheme));
-    throw new Error(tl.loc("InvalidRegistryHost", registryURL));
+    const safeUrl = sanitizeUrl(registryURL);
+    tl.warning(tl.loc("UnrecognizedRegistryHost", safeUrl, endpointId, scheme));
+    throw new Error(tl.loc("InvalidRegistryHost", safeUrl));
 }

--- a/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
+++ b/common-npm-packages/docker-common/registryauthenticationprovider/registryhostvalidation.ts
@@ -49,7 +49,6 @@ export function isAllowedAcrHost(registryURL: string): boolean {
     );
 }
 
-// Opt-in: Azure Stack Hub and other clouds use ACR suffixes the allow-list can't cover.
 export const AcrHostValidationFeatureName = "AcrRegistryHostValidation";
 
 // Empty/absent host is never blocked — nothing to validate.


### PR DESCRIPTION
### **Description**

Adds an opt-in check that validates the Azure Container Registry (ACR) login server against the known ACR host suffixes before the registry authentication request in `docker-common`.

- New `registryhostvalidation.ts`: `isAllowedAcrHost()` accepts standard ACR login servers across public, sovereign, and air-gapped clouds (`.azurecr.io`, `.azurecr.us`, `.azurecr.cn`, `.azurecr.de`, `.azurecr.eaglex.ic.gov`, `.azurecr.microsoft.scloud`) and rejects inputs that are not a plain ACR hostname. `shouldBlockRegistryHost()` applies the feature gate.
- `ACRAuthenticationTokenProvider` runs the check before the registry authentication request.
- Adds the `InvalidRegistryHost` localized message (en-US only).

Gated by the pipeline feature **`AcrRegistryHostValidation`** (read via `tl.getPipelineFeature`), **default off**. Enable per pipeline with the variable `DistributedTask.Tasks.AcrRegistryHostValidation: true`. Behavior is unchanged when the feature is not enabled.

It is intentionally opt-in and kept as a permanent switch because the ACR login server is environment-dependent: some environments (for example Azure Stack Hub) use custom registry host suffixes that a fixed list cannot enumerate, so enabling validation there is left to the pipeline owner.

---

### **Package Name**

`azure-pipelines-tasks-docker-common`

---

### **Risk Assessment** (Low / Medium / High)

**Low.** The new behavior is gated behind a feature that is off by default, so there is no change to existing behavior unless a pipeline explicitly enables it. The validation module is self-contained and covered by unit tests.

---

### **Unit Tests Added or Updated**
- [x] Unit tests added or updated
- [ ] Manual tests performed

---

### **Additional Testing Performed**

Ran the `docker-common` L0 suite locally; all tests pass, including the new host-validation cases (accepted/rejected hosts across public, sovereign, and air-gapped clouds) and the feature-gate cases (on/off).

---

### **Documentation Changes Required** (Yes / No)

No.

---

### **Dependencies**

None. No new runtime dependencies are introduced.

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [x] Package version was bumped to 2.280.0 — see [versioning guide](https://semver.org/)
- [x] Verified the package behaves as expected
- [ ] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)
