### PR TITLE
docker-common: export sanitizeDockerOutput / createSanitizedOutputStream / createSanitizedExecOptions

### DIFF
--- a/common-npm-packages/docker-common/dockercommandutils.ts
+++ b/common-npm-packages/docker-common/dockercommandutils.ts
@@ -463,7 +463,7 @@ const trailingPartialMarker = /#+(?:v(?:s(?:o)?)?)?$/i;
  * The replacement preserves the text for human readability while making it
  * invisible to the agent's command parser.
  */
-function sanitizeDockerOutput(data: string): string {
+export function sanitizeDockerOutput(data: string): string {
     return data.replace(vsoCommandPattern, "#vso[");
 }
 
@@ -478,7 +478,7 @@ function sanitizeDockerOutput(data: string): string {
  * is used to avoid mojibake when a multibyte UTF-8 sequence is split across
  * chunk boundaries.
  */
-function createSanitizedOutputStream(destination: NodeJS.WritableStream): NodeJS.WritableStream {
+export function createSanitizedOutputStream(destination: NodeJS.WritableStream): NodeJS.WritableStream {
     const decoder = new StringDecoder('utf8');
     let pending = "";
 
@@ -517,7 +517,7 @@ function createSanitizedOutputStream(destination: NodeJS.WritableStream): NodeJS
 // Creates fresh exec options for each docker command invocation.
 // Each call returns new stream instances so that stateful carry-over buffers
 // don't leak across commands and streams can be properly ended.
-function createSanitizedExecOptions(): { outStream: NodeJS.WritableStream; errStream: NodeJS.WritableStream } {
+export function createSanitizedExecOptions(): { outStream: NodeJS.WritableStream; errStream: NodeJS.WritableStream } {
     return {
         outStream: createSanitizedOutputStream(process.stdout),
         errStream: createSanitizedOutputStream(process.stderr)

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.279.0",
+    "version": "2.280.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### **Description**
Export the Docker output sanitization helpers from docker-common so they can be reused by other Docker task variants.

PR #630 added sanitizeDockerOutput / createSanitizedOutputStream / createSanitizedExecOptions in dockercommandutils.ts to neutralize `##vso[` logging-command injection in Docker output (MSRC 122404). Those functions were left private, wired in only for the file's own wrapper functions (uild/command/push/start/stop), so tasks such as `Docker@0`, `Docker@1`, `DockerCompose@0`, `DockerCompose@1` — which call `connection.execCommand()` directly instead of going through those wrappers — could not reuse this logic and have to duplicate an equivalent implementation locally (see microsoft/azure-pipelines-tasks#22477).

This PR makes no behavior change — it only adds the `export` keyword to the three existing functions so they become part of the package's public API and can be imported directly by any consumer.

### **Package Name**
`azure-pipelines-tasks-docker-common`

### **Risk Assessment** (Low / Medium / High)
**Low** — purely additive; no logic changed, only visibility (`export`) of three existing functions. Fully backward compatible.

### **Unit Tests Added or Updated**
- [ ] Unit tests added or updated
- [x] Manual tests performed (`tsc --noEmit` compiles cleanly)

No behavior changed, so existing tests from #630 continue to cover these functions unmodified.

### **Additional Testing Performed**
Compiled the package locally with `npx tsc --noEmit -p tsconfig.json` — no errors.

### **Documentation Changes Required** (Yes / No)
No — internal helper visibility change, no public-facing docs affected.

### **Dependencies**
None.

### **Checklist**
- [x] Related issue linked (if applicable) — see microsoft/azure-pipelines-tasks#22477
- [ ] Package version was bumped — see [versioning guide](https://semver.org/)
- [x] Verified the package behaves as expected
- [ ] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)
