### PR TITLE
azure-arm-rest: make Kudu log sanitizer whitelist-aware (MSRC 125166)

### DIFF
--- a/common-npm-packages/azure-arm-rest/Tests/L0-azure-arm-aks-service-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-azure-arm-aks-service-tests.ts
@@ -3,8 +3,9 @@ import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import tl = require('azure-pipelines-task-lib');
 import * as path from 'path';
 
-export function AksServiceTests() {
-    it('azure-arm-aks-service AksService', (done: Mocha.Done) => {
+export function AksServiceTests(defaultTimeout = 2000) {
+    it('azure-arm-aks-service AksService', function (done: Mocha.Done) {
+        this.timeout(defaultTimeout);
         let tp = path.join(__dirname, 'azure-arm-aks-service-tests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         let passed: boolean = true;

--- a/common-npm-packages/azure-arm-rest/Tests/L0-azure-cli-openssl-check.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-azure-cli-openssl-check.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { MockTestRunner } from 'azure-pipelines-task-lib/mock-test';
 import { existsSync } from 'fs';
 
-export function OpenSSLCheck() {
+export function OpenSSLCheck(defaultTimeout = 2000) {
     if (process.platform !== 'win32') {
         console.log('Skipping OpenSSL tests on non-Windows platform');
         return;
@@ -17,7 +17,8 @@ export function OpenSSLCheck() {
         openSSLVersion: '3.5.8',
         featureFlagValue: true
     }].forEach(({ openSSLVersion, featureFlagValue }) => {
-        it(`azure-arm-rest check openssl path openssl${openSSLVersion}`, (done: Mocha.Done) => {
+        it(`azure-arm-rest check openssl path openssl${openSSLVersion}`, function (done: Mocha.Done) {
+            this.timeout(defaultTimeout);
             process.env['SYSTEM_DEBUG'] = 'true';
             process.env['DISTRIBUTEDTASK_TASKS_USELATESTOPENSSLINAZUREARMREST'] = featureFlagValue.toString();
 

--- a/common-npm-packages/azure-arm-rest/Tests/L0-kudu-log-sanitizer-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-kudu-log-sanitizer-tests.ts
@@ -8,6 +8,7 @@ import { sanitizeKuduLogForConsole } from '../azure-arm-app-service-kudu';
 // folder - no HTTP mocking is needed and env var manipulation is all that's required to flip
 // the feature on/off between cases.
 const FEATURE_ENV_VAR = 'DISTRIBUTEDTASK_TASKS_ENABLEKUDULOGVSOCOMMANDSANITIZATION';
+const ALLOWED_COMMANDS_ENV_VAR = 'AGENT_ALLOWEDLOGGINGCOMMANDS';
 
 // IMPORTANT: mocha's reporter prints `it(...)` titles (and any failed assertion message) to the
 // real process stdout, which - unlike a plain local `mocha`/`node` run - IS scanned by the actual
@@ -28,12 +29,15 @@ function buildLeadingBracketCommand(command: string): string {
 export function KuduLogSanitizerTests() {
     describe('sanitizeKuduLogForConsole', () => {
         let originalFeatureValue: string | undefined;
+        let originalAllowedCommandsValue: string | undefined;
         let originalConsoleLog: (...args: any[]) => void;
         let consoleOutput: string[];
 
         beforeEach(() => {
             originalFeatureValue = process.env[FEATURE_ENV_VAR];
             delete process.env[FEATURE_ENV_VAR];
+            originalAllowedCommandsValue = process.env[ALLOWED_COMMANDS_ENV_VAR];
+            delete process.env[ALLOWED_COMMANDS_ENV_VAR];
 
             consoleOutput = [];
             originalConsoleLog = console.log;
@@ -47,6 +51,11 @@ export function KuduLogSanitizerTests() {
                 delete process.env[FEATURE_ENV_VAR];
             } else {
                 process.env[FEATURE_ENV_VAR] = originalFeatureValue;
+            }
+            if (originalAllowedCommandsValue === undefined) {
+                delete process.env[ALLOWED_COMMANDS_ENV_VAR];
+            } else {
+                process.env[ALLOWED_COMMANDS_ENV_VAR] = originalAllowedCommandsValue;
             }
             console.log = originalConsoleLog;
         });
@@ -78,13 +87,15 @@ export function KuduLogSanitizerTests() {
             assert(telemetryLine.includes('"commands":"task.setvariable"'));
         });
 
-        it('neutralizes the trigger sequence and leaves the rest of the text intact when the feature is on', () => {
+        it('neutralizes a non-whitelisted trigger sequence and leaves the rest of the text intact when the feature is on', () => {
             process.env[FEATURE_ENV_VAR] = 'true';
+            // Whitelist that does NOT contain task.setvariable, so it must be neutralized.
+            process.env[ALLOWED_COMMANDS_ENV_VAR] = 'task.complete';
             const payload = `Oryx build log line one\n${buildVsoCommand('task.setvariable variable=ORYX_INJECTED]true')}\nOryx build log line two`;
 
             const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
 
-            assert.strictEqual(result.includes(buildVsoCommand('')), false, 'the trigger sequence must be neutralized');
+            assert.strictEqual(result.includes(buildVsoCommand('task.setvariable')), false, 'the non-whitelisted trigger sequence must be neutralized');
             assert(result.includes('##_vso[task.setvariable variable=ORYX_INJECTED]true'),
                 'the neutralized text should still be readable/diagnosable in the log');
             assert(result.includes('Oryx build log line one'));
@@ -96,14 +107,60 @@ export function KuduLogSanitizerTests() {
             assert(telemetryLine.includes('"enforced":true'));
         });
 
-        it('also neutralizes a leading bracket (non task-prefixed) logging command sequence when the feature is on', () => {
+        it('preserves whitelisted commands and escapes only non-whitelisted ones when the feature is on', () => {
             process.env[FEATURE_ENV_VAR] = 'true';
+            process.env[ALLOWED_COMMANDS_ENV_VAR] = 'task.setvariable';
+            const payload = `${buildVsoCommand('task.setvariable variable=OK]yes')}\n${buildVsoCommand('task.setsecret]stolen')}`;
+
+            const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
+
+            assert(result.includes(buildVsoCommand('task.setvariable variable=OK]yes')),
+                'whitelisted command (task.setvariable) must be preserved verbatim');
+            assert.strictEqual(result.includes(buildVsoCommand('task.setsecret')), false,
+                'non-whitelisted command (task.setsecret) must be neutralized');
+            assert(result.includes('##_vso[task.setsecret]stolen'),
+                'the neutralized non-whitelisted command should still be readable');
+        });
+
+        it('matches the whitelist case-insensitively', () => {
+            process.env[FEATURE_ENV_VAR] = 'true';
+            // Whitelist delivered upper-cased; injected command is lower-case.
+            process.env[ALLOWED_COMMANDS_ENV_VAR] = 'TASK.SETVARIABLE';
+            const payload = `${buildVsoCommand('task.setvariable variable=OK]yes')}\n${buildVsoCommand('task.complete result=Failed]')}`;
+
+            const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
+
+            assert(result.includes(buildVsoCommand('task.setvariable variable=OK]yes')),
+                'upper-cased whitelist entry must whitelist the lower-case command');
+            assert.strictEqual(result.includes(buildVsoCommand('task.complete')), false,
+                'non-whitelisted command must still be neutralized');
+        });
+
+        it('allows all logging commands when the whitelist is empty even though the feature is on', () => {
+            process.env[FEATURE_ENV_VAR] = 'true';
+            delete process.env[ALLOWED_COMMANDS_ENV_VAR];
+            const payload = `${buildVsoCommand('task.setvariable variable=X]y')}\n${buildVsoCommand('task.setsecret]stolen')}`;
+
+            const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
+
+            assert.strictEqual(result, payload, 'empty whitelist must leave every ##vso[ command untouched (allow all)');
+            const telemetryLine = consoleOutput.find(line => line.includes('telemetry.publish'));
+            assert(telemetryLine, 'detection telemetry is still emitted');
+            assert(telemetryLine.includes('"enforced":true'), 'telemetry still reports the feature as enforced');
+        });
+
+        it('always neutralizes a leading bracket sequence when enforcing, regardless of the whitelist', () => {
+            process.env[FEATURE_ENV_VAR] = 'true';
+            // Even with an empty whitelist (allow all ##vso[), a leading ##[ has no command name and
+            // is always neutralized.
+            delete process.env[ALLOWED_COMMANDS_ENV_VAR];
             const payload = `${buildVsoCommand('task.setvariable variable=X]y')}\n${buildLeadingBracketCommand('section]Starting: attacker section')}`;
 
             const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
 
-            assert.strictEqual(result.includes(buildVsoCommand('')), false);
-            assert.strictEqual(/^##\[/m.test(result), false, 'a leading bracket sequence must also be neutralized');
+            assert(result.includes(buildVsoCommand('task.setvariable variable=X]y')),
+                'empty whitelist leaves the ##vso[ command untouched');
+            assert.strictEqual(/^##\[/m.test(result), false, 'a leading bracket sequence must always be neutralized when enforcing');
         });
 
         it('cannot be broken out of the telemetry command envelope by a crafted payload', () => {

--- a/common-npm-packages/azure-arm-rest/Tests/L0-kudu-log-sanitizer-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-kudu-log-sanitizer-tests.ts
@@ -84,6 +84,8 @@ export function KuduLogSanitizerTests() {
             assert(telemetryLine.includes('area=TaskHub;feature=AzureRmWebAppDeployment'));
             assert(telemetryLine.includes('"event":"KuduLogVsoCommandsDetected"'));
             assert(telemetryLine.includes('"enforced":false'));
+            assert(telemetryLine.includes('"allowlistPresent":false'));
+            assert(telemetryLine.includes('"escapedCount":0'));
             assert(telemetryLine.includes('"commands":"task.setvariable"'));
         });
 
@@ -105,6 +107,8 @@ export function KuduLogSanitizerTests() {
             assert(telemetryLine, 'telemetry should still be emitted when enforcing');
             assert(telemetryLine.includes('"event":"KuduLogVsoCommandsSanitized"'));
             assert(telemetryLine.includes('"enforced":true'));
+            assert(telemetryLine.includes('"allowlistPresent":true'), 'a non-empty allow-list should be reported');
+            assert(telemetryLine.includes('"escapedCount":1'), 'exactly one non-whitelisted sequence was neutralized');
         });
 
         it('preserves whitelisted commands and escapes only non-whitelisted ones when the feature is on', () => {
@@ -147,6 +151,11 @@ export function KuduLogSanitizerTests() {
             const telemetryLine = consoleOutput.find(line => line.includes('telemetry.publish'));
             assert(telemetryLine, 'detection telemetry is still emitted');
             assert(telemetryLine.includes('"enforced":true'), 'telemetry still reports the feature as enforced');
+            // The whole point of allowlistPresent/escapedCount: with the feature on but an empty
+            // allow-list nothing is actually escaped, so the rollout signal must NOT look like
+            // active protection (see PR #659 review).
+            assert(telemetryLine.includes('"allowlistPresent":false'), 'an empty/unset allow-list must be reported as not present');
+            assert(telemetryLine.includes('"escapedCount":0'), 'an allow-all no-op must report zero escaped sequences');
         });
 
         it('always neutralizes a leading bracket sequence when enforcing, regardless of the whitelist', () => {
@@ -161,6 +170,13 @@ export function KuduLogSanitizerTests() {
             assert(result.includes(buildVsoCommand('task.setvariable variable=X]y')),
                 'empty whitelist leaves the ##vso[ command untouched');
             assert.strictEqual(/^##\[/m.test(result), false, 'a leading bracket sequence must always be neutralized when enforcing');
+
+            // Even with an empty allow-list, neutralizing a leading "##[" is real protection, so
+            // escapedCount must reflect it (escapedCount > 0) while allowlistPresent stays false.
+            const telemetryLine = consoleOutput.find(line => line.includes('telemetry.publish'));
+            assert(telemetryLine, 'telemetry should be emitted when enforcing');
+            assert(telemetryLine.includes('"allowlistPresent":false'), 'the empty allow-list must be reported as not present');
+            assert(telemetryLine.includes('"escapedCount":1'), 'neutralizing the leading bracket must count as one escaped sequence');
         });
 
         it('cannot be broken out of the telemetry command envelope by a crafted payload', () => {

--- a/common-npm-packages/azure-arm-rest/Tests/L0-kudu-log-sanitizer-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-kudu-log-sanitizer-tests.ts
@@ -158,25 +158,39 @@ export function KuduLogSanitizerTests() {
             assert(telemetryLine.includes('"escapedCount":0'), 'an allow-all no-op must report zero escaped sequences');
         });
 
-        it('always neutralizes a leading bracket sequence when enforcing, regardless of the whitelist', () => {
+        it('never modifies a leading bracket sequence when enforcing with an empty whitelist', () => {
             process.env[FEATURE_ENV_VAR] = 'true';
-            // Even with an empty whitelist (allow all ##vso[), a leading ##[ has no command name and
-            // is always neutralized.
             delete process.env[ALLOWED_COMMANDS_ENV_VAR];
             const payload = `${buildVsoCommand('task.setvariable variable=X]y')}\n${buildLeadingBracketCommand('section]Starting: attacker section')}`;
 
             const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
 
-            assert(result.includes(buildVsoCommand('task.setvariable variable=X]y')),
-                'empty whitelist leaves the ##vso[ command untouched');
-            assert.strictEqual(/^##\[/m.test(result), false, 'a leading bracket sequence must always be neutralized when enforcing');
+            assert.strictEqual(result, payload,
+                'leading bracket sequences are never touched, and the empty whitelist allows every ##vso[ command through');
+            assert(/^##\[/m.test(result), 'the leading bracket sequence must be left intact');
 
-            // Even with an empty allow-list, neutralizing a leading "##[" is real protection, so
-            // escapedCount must reflect it (escapedCount > 0) while allowlistPresent stays false.
             const telemetryLine = consoleOutput.find(line => line.includes('telemetry.publish'));
             assert(telemetryLine, 'telemetry should be emitted when enforcing');
             assert(telemetryLine.includes('"allowlistPresent":false'), 'the empty allow-list must be reported as not present');
-            assert(telemetryLine.includes('"escapedCount":1'), 'neutralizing the leading bracket must count as one escaped sequence');
+            assert(telemetryLine.includes('"escapedCount":0'), 'nothing is escaped: leading brackets are never touched and the empty allow-list allows all');
+        });
+
+        it('leaves leading bracket sequences untouched even while a whitelist is enforcing', () => {
+            process.env[FEATURE_ENV_VAR] = 'true';
+            process.env[ALLOWED_COMMANDS_ENV_VAR] = 'task.setvariable';
+            const payload = `${buildLeadingBracketCommand('section]Starting: attacker section')}\n${buildVsoCommand('task.setsecret]stolen')}`;
+
+            const result = sanitizeKuduLogForConsole(payload, 'AzureRmWebAppDeployment');
+
+            assert(result.includes(buildLeadingBracketCommand('section]Starting: attacker section')),
+                'leading bracket sequences must never be neutralized');
+            assert(/^##\[/m.test(result), 'the leading bracket sequence must be left intact');
+            assert.strictEqual(result.includes(buildVsoCommand('task.setsecret')), false,
+                'a non-whitelisted ##vso[ command is still neutralized');
+
+            const telemetryLine = consoleOutput.find(line => line.includes('telemetry.publish'));
+            assert(telemetryLine, 'telemetry should be emitted when enforcing');
+            assert(telemetryLine.includes('"escapedCount":1'), 'only the non-whitelisted ##vso[ command counts as escaped; the leading bracket does not');
         });
 
         it('cannot be broken out of the telemetry command envelope by a crafted payload', () => {

--- a/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
@@ -855,6 +855,42 @@ const VSO_COMMAND_NAME_REGEX = /##vso\[([a-zA-Z0-9_.]+)/gi;
 const KUDU_LOG_SANITIZER_TELEMETRY_AREA = 'TaskHub';
 const KUDU_LOG_SANITIZER_ENFORCE_PIPELINE_FEATURE = 'EnableKuduLogVsoCommandSanitization';
 
+// Whitelist-aware neutralization (aligns with azure-pipelines-tasks PR #22451 for AzureFileCopy).
+// The set of logging commands that must NOT be neutralized is delivered by the server as the
+// read-only pipeline variable 'agent.allowedLoggingCommands', surfaced on the agent as the
+// environment variable AGENT_ALLOWEDLOGGINGCOMMANDS (comma-separated, case-insensitive).
+//   - whitelist empty/unset   -> escape nothing; every "##vso[" command is allowed through
+//                                (consistent with AzureFileCopy #22451 feature-off semantics).
+//   - command NOT whitelisted -> its "##vso[" prefix is escaped to "##_vso[" so the agent does
+//                                not execute it (the line is still printed as readable text).
+//   - command whitelisted     -> left unchanged so legitimate usage keeps working.
+// This whitelist only ever narrows the set of "##vso[" commands that get escaped; it is consulted
+// only when enforcement (EnableKuduLogVsoCommandSanitization) is on. Leading "##[" sequences carry
+// no command name to match against the whitelist and are always neutralized when enforcing.
+const KUDU_LOG_SANITIZER_ALLOWED_COMMANDS_ENV_VAR = 'AGENT_ALLOWEDLOGGINGCOMMANDS';
+
+// Captures the command name after "##vso[" so it can be tested against the whitelist. The charset
+// matches VSO_COMMAND_NAME_REGEX; a "##vso[" with no following name yields an empty capture which
+// is never whitelisted (and is therefore escaped when a whitelist is present).
+const VSO_COMMAND_REPLACE_REGEX = /##vso\[([a-zA-Z0-9_.]*)/gi;
+
+// Parses AGENT_ALLOWEDLOGGINGCOMMANDS into a case-insensitive (lower-cased) set of command names.
+// Returns an empty set when the variable is unset/blank, which callers treat as "allow all".
+function getAllowedLoggingCommands(): Set<string> {
+    const allowed = new Set<string>();
+    const raw = process.env[KUDU_LOG_SANITIZER_ALLOWED_COMMANDS_ENV_VAR];
+    if (!raw || !raw.trim()) {
+        return allowed;
+    }
+    for (const command of raw.split(',')) {
+        const trimmed = command.trim().toLowerCase();
+        if (trimmed) {
+            allowed.add(trimmed);
+        }
+    }
+    return allowed;
+}
+
 // For telemetry naming only - see comment on VSO_COMMAND_NAME_REGEX above.
 function findVsoCommands(text: string): string[] {
     const found = new Set<string>();
@@ -897,8 +933,10 @@ function emitKuduLogSanitizerDetectionTelemetry(feature: string, enforced: boole
  *   always reported via telemetry.publish, regardless of the pipeline feature state.
  * - EnableKuduLogVsoCommandSanitization off (default today): text is returned completely
  *   unmodified - telemetry-only, zero behavior change for customers.
- * - EnableKuduLogVsoCommandSanitization on: enforce. Neutralizes the "##vso[" (and leading
- *   "##[") trigger sequences so the agent can no longer parse them as logging commands.
+ * - EnableKuduLogVsoCommandSanitization on: enforce, but whitelist-aware. Any leading "##["
+ *   sequence is neutralized. "##vso[" commands are neutralized only when they are NOT on the
+ *   allow-list delivered via AGENT_ALLOWEDLOGGINGCOMMANDS (agent.allowedLoggingCommands); when the
+ *   allow-list is empty/unset, no "##vso[" command is neutralized (allow all).
  */
 export function sanitizeKuduLogForConsole(text: string, telemetryFeature: string): string {
     if (!text || !VSO_COMMAND_PRESENCE_REGEX.test(text)) {
@@ -917,5 +955,20 @@ export function sanitizeKuduLogForConsole(text: string, telemetryFeature: string
         return text;
     }
 
-    return text.replace(/##vso\[/gi, '##_vso[').replace(/^##\[/gm, '##_[');
+    // Leading "##[" sequences carry no command name to match against the whitelist, so they are
+    // always neutralized when enforcing.
+    const sanitized = text.replace(/^##\[/gm, '##_[');
+
+    const allowedCommands = getAllowedLoggingCommands();
+    if (allowedCommands.size === 0) {
+        // Empty/unset whitelist: allow all "##vso[" commands (consistent with AzureFileCopy
+        // #22451). Only the always-on leading "##[" neutralization above is applied.
+        return sanitized;
+    }
+
+    // Escape only "##vso[" commands whose name is not on the whitelist; leave whitelisted
+    // commands (and their surrounding text) untouched.
+    return sanitized.replace(VSO_COMMAND_REPLACE_REGEX, (fullMatch: string, command: string) => {
+        return allowedCommands.has(command.toLowerCase()) ? fullMatch : '##_vso[' + command;
+    });
 }

--- a/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
@@ -844,8 +844,8 @@ export class Kudu {
 
 // Used only to decide whether there is anything to do at all (telemetry and/or enforcement).
 // Intentionally NOT restricted to any command-name charset, so the kill switch below does not
-// depend on the agent's current command-name parsing rules - any "##vso[" (or leading "##[")
-// occurrence is treated as something to neutralize when enforcement is on.
+// depend on the agent's current command-name parsing rules - any "##vso[" occurrence is treated
+// as something to neutralize when enforcement is on.
 const VSO_COMMAND_PRESENCE_REGEX = /##vso\[/i;
 
 // Used only to name detected commands for telemetry. This charset is a best-effort label and
@@ -865,8 +865,8 @@ const KUDU_LOG_SANITIZER_ENFORCE_PIPELINE_FEATURE = 'EnableKuduLogVsoCommandSani
 //                                not execute it (the line is still printed as readable text).
 //   - command whitelisted     -> left unchanged so legitimate usage keeps working.
 // This whitelist only ever narrows the set of "##vso[" commands that get escaped; it is consulted
-// only when enforcement (EnableKuduLogVsoCommandSanitization) is on. Leading "##[" sequences carry
-// no command name to match against the whitelist and are always neutralized when enforcing.
+// only when enforcement (EnableKuduLogVsoCommandSanitization) is on. Leading "##[" sequences are
+// never modified.
 const KUDU_LOG_SANITIZER_ALLOWED_COMMANDS_ENV_VAR = 'AGENT_ALLOWEDLOGGINGCOMMANDS';
 
 // Captures the command name after "##vso[" so it can be tested against the whitelist. The charset
@@ -911,7 +911,7 @@ function findVsoCommands(text: string): string[] {
 //   - enforced         : whether the EnableKuduLogVsoCommandSanitization feature is on.
 //   - allowlistPresent : whether a non-empty agent.allowedLoggingCommands allow-list was
 //                        configured. When the feature is on but this is false, "##vso[" commands
-//                        are allowed through (only leading "##[" sequences are neutralized).
+//                        are allowed through (nothing is neutralized).
 //   - escapedCount     : how many sequences were actually neutralized on this call. This is the
 //                        ground-truth "protection was applied" signal - enforced && escapedCount==0
 //                        means the run was an allow-all no-op that changed nothing.
@@ -945,10 +945,10 @@ function emitKuduLogSanitizerDetectionTelemetry(feature: string, enforced: boole
  *   always reported via telemetry.publish, regardless of the pipeline feature state.
  * - EnableKuduLogVsoCommandSanitization off (default today): text is returned completely
  *   unmodified - telemetry-only, zero behavior change for customers.
- * - EnableKuduLogVsoCommandSanitization on: enforce, but whitelist-aware. Any leading "##["
- *   sequence is neutralized. "##vso[" commands are neutralized only when they are NOT on the
- *   allow-list delivered via AGENT_ALLOWEDLOGGINGCOMMANDS (agent.allowedLoggingCommands); when the
- *   allow-list is empty/unset, no "##vso[" command is neutralized (allow all).
+ * - EnableKuduLogVsoCommandSanitization on: enforce, but whitelist-aware. "##vso[" commands are
+ *   neutralized only when they are NOT on the allow-list delivered via AGENT_ALLOWEDLOGGINGCOMMANDS
+ *   (agent.allowedLoggingCommands); when the allow-list is empty/unset, no "##vso[" command is
+ *   neutralized (allow all). Leading "##[" sequences are never modified.
  * - The emitted telemetry carries `enforced`, `allowlistPresent` and `escapedCount` so the rollout
  *   signal can tell "actively protecting" (escapedCount > 0) apart from an allow-all no-op
  *   (enforced but escapedCount == 0).
@@ -974,17 +974,12 @@ export function sanitizeKuduLogForConsole(text: string, telemetryFeature: string
 
     // Enforcing. Count how many sequences are actually neutralized so the telemetry can
     // distinguish "actively protecting" from an allow-all no-op (see PR #659 review): an empty
-    // allow-list lets every "##vso[" command through, so only leading "##[" sequences are escaped.
+    // allow-list lets every "##vso[" command through, so nothing is escaped.
     const allowedCommands = getAllowedLoggingCommands();
     const allowlistPresent = allowedCommands.size > 0;
     let escapedCount = 0;
 
-    // Leading "##[" sequences carry no command name to match against the whitelist, so they are
-    // always neutralized when enforcing.
-    let sanitized = text.replace(/^##\[/gm, () => {
-        escapedCount++;
-        return '##_[';
-    });
+    let sanitized = text;
 
     if (allowlistPresent) {
         // Escape only "##vso[" commands whose name is not on the whitelist; leave whitelisted
@@ -998,7 +993,7 @@ export function sanitizeKuduLogForConsole(text: string, telemetryFeature: string
         });
     }
     // else: empty/unset whitelist -> allow all "##vso[" commands (consistent with AzureFileCopy
-    // #22451). Only the always-on leading "##[" neutralization above is applied.
+    // #22451), so nothing is escaped.
 
     emitKuduLogSanitizerDetectionTelemetry(telemetryFeature, true, allowlistPresent, escapedCount, detectedCommands);
     return sanitized;

--- a/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts
@@ -905,11 +905,23 @@ function findVsoCommands(text: string): string[] {
 // Emits telemetry using the same "##vso[telemetry.publish ...]" channel as
 // azure-pipelines-tasks-utility-common/telemetry, without adding a new dependency to this
 // package for a small, self-issued payload.
-function emitKuduLogSanitizerDetectionTelemetry(feature: string, enforced: boolean, commands: string[]): void {
+//
+// The payload distinguishes "actively protecting" from an "allow-all no-op" so the rollout
+// signal is not ambiguous when the feature is on (see PR #659 review):
+//   - enforced         : whether the EnableKuduLogVsoCommandSanitization feature is on.
+//   - allowlistPresent : whether a non-empty agent.allowedLoggingCommands allow-list was
+//                        configured. When the feature is on but this is false, "##vso[" commands
+//                        are allowed through (only leading "##[" sequences are neutralized).
+//   - escapedCount     : how many sequences were actually neutralized on this call. This is the
+//                        ground-truth "protection was applied" signal - enforced && escapedCount==0
+//                        means the run was an allow-all no-op that changed nothing.
+function emitKuduLogSanitizerDetectionTelemetry(feature: string, enforced: boolean, allowlistPresent: boolean, escapedCount: number, commands: string[]): void {
     try {
         const payload = {
             event: enforced ? 'KuduLogVsoCommandsSanitized' : 'KuduLogVsoCommandsDetected',
             enforced: enforced,
+            allowlistPresent: allowlistPresent,
+            escapedCount: escapedCount,
             commandCount: commands.length,
             commands: commands.join(',')
         };
@@ -937,6 +949,9 @@ function emitKuduLogSanitizerDetectionTelemetry(feature: string, enforced: boole
  *   sequence is neutralized. "##vso[" commands are neutralized only when they are NOT on the
  *   allow-list delivered via AGENT_ALLOWEDLOGGINGCOMMANDS (agent.allowedLoggingCommands); when the
  *   allow-list is empty/unset, no "##vso[" command is neutralized (allow all).
+ * - The emitted telemetry carries `enforced`, `allowlistPresent` and `escapedCount` so the rollout
+ *   signal can tell "actively protecting" (escapedCount > 0) apart from an allow-all no-op
+ *   (enforced but escapedCount == 0).
  */
 export function sanitizeKuduLogForConsole(text: string, telemetryFeature: string): string {
     if (!text || !VSO_COMMAND_PRESENCE_REGEX.test(text)) {
@@ -948,27 +963,43 @@ export function sanitizeKuduLogForConsole(text: string, telemetryFeature: string
     // Command names are extracted purely for telemetry labeling - see comment on
     // VSO_COMMAND_NAME_REGEX/findVsoCommands above. Whether we got here (and whether we
     // enforce below) is decided solely by VSO_COMMAND_PRESENCE_REGEX.
-    emitKuduLogSanitizerDetectionTelemetry(telemetryFeature, activate, findVsoCommands(text));
+    const detectedCommands = findVsoCommands(text);
 
     if (!activate) {
-        // Telemetry-only: report above, but do not touch the text that gets printed.
+        // Telemetry-only: report the detection above, but do not touch the text that gets
+        // printed. Nothing is escaped and the allow-list is irrelevant in this mode.
+        emitKuduLogSanitizerDetectionTelemetry(telemetryFeature, false, false, 0, detectedCommands);
         return text;
     }
 
+    // Enforcing. Count how many sequences are actually neutralized so the telemetry can
+    // distinguish "actively protecting" from an allow-all no-op (see PR #659 review): an empty
+    // allow-list lets every "##vso[" command through, so only leading "##[" sequences are escaped.
+    const allowedCommands = getAllowedLoggingCommands();
+    const allowlistPresent = allowedCommands.size > 0;
+    let escapedCount = 0;
+
     // Leading "##[" sequences carry no command name to match against the whitelist, so they are
     // always neutralized when enforcing.
-    const sanitized = text.replace(/^##\[/gm, '##_[');
-
-    const allowedCommands = getAllowedLoggingCommands();
-    if (allowedCommands.size === 0) {
-        // Empty/unset whitelist: allow all "##vso[" commands (consistent with AzureFileCopy
-        // #22451). Only the always-on leading "##[" neutralization above is applied.
-        return sanitized;
-    }
-
-    // Escape only "##vso[" commands whose name is not on the whitelist; leave whitelisted
-    // commands (and their surrounding text) untouched.
-    return sanitized.replace(VSO_COMMAND_REPLACE_REGEX, (fullMatch: string, command: string) => {
-        return allowedCommands.has(command.toLowerCase()) ? fullMatch : '##_vso[' + command;
+    let sanitized = text.replace(/^##\[/gm, () => {
+        escapedCount++;
+        return '##_[';
     });
+
+    if (allowlistPresent) {
+        // Escape only "##vso[" commands whose name is not on the whitelist; leave whitelisted
+        // commands (and their surrounding text) untouched.
+        sanitized = sanitized.replace(VSO_COMMAND_REPLACE_REGEX, (fullMatch: string, command: string) => {
+            if (allowedCommands.has(command.toLowerCase())) {
+                return fullMatch;
+            }
+            escapedCount++;
+            return '##_vso[' + command;
+        });
+    }
+    // else: empty/unset whitelist -> allow all "##vso[" commands (consistent with AzureFileCopy
+    // #22451). Only the always-on leading "##[" neutralization above is applied.
+
+    emitKuduLogSanitizerDetectionTelemetry(telemetryFeature, true, allowlistPresent, escapedCount, detectedCommands);
+    return sanitized;
 }

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.279.5",
+    "version": "3.280.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azure-arm-rest",
-            "version": "3.279.5",
+            "version": "3.280.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^4.13.1",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.279.5",
+    "version": "3.280.0",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### **Description**

Changes the Kudu deployment-log sanitizer from neutralizing **all** `##vso[` logging commands to neutralizing only **non-whitelisted** ones, mirroring the AzureFileCopy approach in [azure-pipelines-tasks#22451](https://github.com/microsoft/azure-pipelines-tasks/pull/22451).

`sanitizeKuduLogForConsole` (in `common-npm-packages/azure-arm-rest/azure-arm-app-service-kudu.ts`) is used by the App Service / Function deployment tasks to print remote Kudu/Oryx build logs. Previously, when enforcement was on it escaped every `##vso[` command, blocking legitimate logging commands too. It now consults the server-delivered allow-list.

Related ADO Work Item: [AB#2440075](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2440075) · MSRC 125166 / ICM 31000000654080 (CWE-77 command injection).

Behavior when the `EnableKuduLogVsoCommandSanitization` pipeline feature is **on**:
- Allow-list read from `AGENT_ALLOWEDLOGGINGCOMMANDS` (pipeline variable `agent.allowedLoggingCommands`), comma-separated, case-insensitive.
- **Empty/unset allow-list → allow all** (escape nothing) — consistent with #22451.
- Non-empty allow-list → escape `##vso[<cmd>` → `##_vso[<cmd>` only for commands **not** on the list; whitelisted commands pass through verbatim.
- **Leading `##[` bracket (formatting) sequences are never modified** — only `##vso[` commands are ever neutralized.
- Feature **off** → telemetry-only, text unmodified (no behavior change).

Telemetry: the emitted payload carries `enforced`, `allowlistPresent`, and `escapedCount` so the rollout signal can distinguish "actively protecting" (`escapedCount > 0`) from an allow-all no-op (`enforced` but `escapedCount == 0`). Detection events (`KuduLogVsoCommandsDetected` / `KuduLogVsoCommandsSanitized`) are unchanged.

No public API change (`sanitizeKuduLogForConsole(text, telemetryFeature)`).

---

### **Package Name**
`azure-pipelines-tasks-azure-arm-rest` (bumped `3.279.5` → `3.280.0`)

---

### **Risk Assessment** (Low / Medium / High)
**Low.** Change is confined to the enforcement branch of a single function that is only active when the `EnableKuduLogVsoCommandSanitization` feature is enabled (still not broadly enabled). With the allow-all-on-empty default, absence of an allow-list preserves today's behavior of not modifying output. No signature change, so consumers only need a dependency bump to adopt.

---

### **Unit Tests Added or Updated**
- [x] Unit tests added or updated
- [x] Manual tests performed

---

### **Additional Testing Performed**
Extended `Tests/L0-kudu-log-sanitizer-tests.ts` with whitelist cases: whitelisted command preserved, non-whitelisted escaped, case-insensitive match, empty-list-allows-all, telemetry `allowlistPresent`/`escapedCount` assertions, and leading `##[` sequences left untouched (both with and without an allow-list). Ran the sanitizer suite: **10 passing** (isolated via `mocha --grep`). Other azure-arm-rest L0 timeouts observed are pre-existing flakes (AKS / OpenSSL checks) unrelated to this change.

---

### **Documentation Changes Required** (Yes / No)
**No.**

---

### **Dependencies**
None introduced. Consuming tasks (AzureRmWebAppDeploymentV3/V4/V5, AzureWebAppV1, AzureWebAppContainerV1, AzureFunctionAppV1/V2, AzureFunctionAppContainerV1) will pick up the new behavior via a dependency bump to this package once published — no task source changes required.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Package version was bumped — see [versioning guide](https://semver.org/)
- [x] Verified the package behaves as expected
- [x] CLA signed (if applicable) — see [Contributor License Agreement](https://cla.opensource.microsoft.com)
