### PR TITLE
docker-common: bump version to 2.280.1 (fix package-lock.json drift)

### DIFF
--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.279.0",
+    "version": "2.280.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.279.0",
+            "version": "2.280.1",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.280.0",
+    "version": "2.280.1",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Description
PR #658 published `docker-common@2.280.0` but only bumped `package.json`'s version, missing the corresponding bump in `package-lock.json` (the lockfile stayed at `2.279.0`). Since `2.280.0` is already published to npm, that exact version can't be regenerated/republished with a corrected lockfile.

This PR bumps to the next version, `2.280.1`, with `package.json` and `package-lock.json` regenerated together via `npm version` so both stay in sync.

## Changes
- `common-npm-packages/docker-common/package.json`: version `2.280.0` -> `2.280.1`.
- `common-npm-packages/docker-common/package-lock.json`: version `2.279.0` -> `2.280.1` (root and self-referential package entry), regenerated via `npm version`.

## Related
- Follow-up to #658.