### PR TITLE
[azure-arm-rest] Allow resolved Azure CLI path propagation

### DIFF
--- a/common-npm-packages/azure-arm-rest/Tests/L0-azure-cli-utility-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/L0-azure-cli-utility-tests.ts
@@ -11,6 +11,7 @@ export function AzureCliUtilityTests() {
 
         tr.runAsync()
             .then(() => {
+                assert(tr.stdOutContained('ALL_AZURE_CLI_INVOCATIONS_USE_RESOLVED_PATH'));
                 assert(tr.stdOutContained('Retrying OIDC token fetch. Retries left: 2'));
                 assert(tr.stdOutContained('Retrying OIDC token fetch. Retries left: 0'));
                 assert(tr.stdOutContained('Error while trying to get OIDC token: Error: 1'));

--- a/common-npm-packages/azure-arm-rest/Tests/azure-cli-utility-tests.ts
+++ b/common-npm-packages/azure-arm-rest/Tests/azure-cli-utility-tests.ts
@@ -1,5 +1,7 @@
+import assert = require("assert");
 import { WebApi } from "azure-devops-node-api";
-import { initOIDCToken2 } from "../azCliUtility";
+import * as tl from "azure-pipelines-task-lib/task";
+import { initOIDCToken2, loginAzureRM, setAzureCloudBasedOnServiceEndpoint } from "../azCliUtility";
 
 class TaskApiNull {
     async createOidcToken() {
@@ -44,6 +46,63 @@ class WebApiMockThrowing {
 }
 
 export class AzureCliUtilityTests {
+    public static async resolvedAzureCliPathTest() {
+        const azureCliPath = "C:\\Program Files\\Microsoft SDKs\\Azure\\CLI2\\wbin\\az.cmd";
+        const invocations: string[] = [];
+        const originalExecSync = tl.execSync;
+        const originalGetEndpointAuthorizationScheme = tl.getEndpointAuthorizationScheme;
+        const originalGetEndpointAuthorizationParameter = tl.getEndpointAuthorizationParameter;
+        const originalGetEndpointDataParameter = tl.getEndpointDataParameter;
+        const originalSetSecret = tl.setSecret;
+
+        try {
+            (tl as any).execSync = (tool: string, args: string) => {
+                invocations.push(`${tool} ${args}`);
+                return {
+                    code: 0,
+                    stdout: args === "--version" ? "azure-cli 2.66.0" : "",
+                    stderr: ""
+                };
+            };
+            (tl as any).getEndpointAuthorizationScheme = () => "serviceprincipal";
+            (tl as any).getEndpointAuthorizationParameter = (_connectedService: string, parameterName: string) => {
+                const parameters = {
+                    authenticationType: "key",
+                    serviceprincipalid: "client-id",
+                    tenantid: "tenant-id",
+                    serviceprincipalkey: "client-secret"
+                };
+                return parameters[parameterName];
+            };
+            (tl as any).getEndpointDataParameter = (_connectedService: string, parameterName: string) => {
+                const parameters = {
+                    environment: "AzureCloud",
+                    SubscriptionID: "subscription-id"
+                };
+                return parameters[parameterName];
+            };
+            (tl as any).setSecret = () => {};
+
+            setAzureCloudBasedOnServiceEndpoint("connected-service", azureCliPath);
+            await loginAzureRM("connected-service", azureCliPath);
+
+            assert.strictEqual(invocations.length, 4);
+            assert(invocations.every(invocation => invocation.startsWith(`${azureCliPath} `)));
+            assert(invocations.some(invocation => invocation.endsWith("cloud set -n AzureCloud")));
+            assert(invocations.some(invocation => invocation.endsWith("--version")));
+            assert(invocations.some(invocation => invocation.indexOf(" login --service-principal ") >= 0));
+            assert(invocations.some(invocation => invocation.endsWith('account set --subscription "subscription-id"')));
+            console.log("ALL_AZURE_CLI_INVOCATIONS_USE_RESOLVED_PATH");
+        }
+        finally {
+            (tl as any).execSync = originalExecSync;
+            (tl as any).getEndpointAuthorizationScheme = originalGetEndpointAuthorizationScheme;
+            (tl as any).getEndpointAuthorizationParameter = originalGetEndpointAuthorizationParameter;
+            (tl as any).getEndpointDataParameter = originalGetEndpointDataParameter;
+            (tl as any).setSecret = originalSetSecret;
+        }
+    }
+
     public static async initOIDCTokenTestRetryMechanism() {
         try {
             await initOIDCToken2(new WebApiMockNull() as WebApi, 'https://dev.azure.com/organization', 'project', 'pipeline', 'job', 'task', 0, 0);
@@ -62,6 +121,7 @@ export class AzureCliUtilityTests {
 }
 
 async function RUNTESTS() {
+    await AzureCliUtilityTests.resolvedAzureCliPathTest();
     await AzureCliUtilityTests.initOIDCTokenTestRetryMechanism();
     await AzureCliUtilityTests.initOIDCTokenTestAggregateError();
 }

--- a/common-npm-packages/azure-arm-rest/azCliUtility.ts
+++ b/common-npm-packages/azure-arm-rest/azCliUtility.ts
@@ -18,15 +18,15 @@ const MAX_CREATE_OIDC_TOKEN_BACKOFF_TIMEOUT = 15000;
 
 tl.setResourcePath(path.join(__dirname, 'module.json'), true);
 
-export function setAzureCloudBasedOnServiceEndpoint(connectedService: string): void {
+export function setAzureCloudBasedOnServiceEndpoint(connectedService: string, azureCliPath: string = "az"): void {
     var environment = tl.getEndpointDataParameter(connectedService, 'environment', true);
     if (!!environment) {
         console.log(tl.loc('SettingAzureCloud', environment));
-        throwIfError(tl.execSync("az", "cloud set -n " + environment));
+        throwIfError(tl.execSync(azureCliPath, "cloud set -n " + environment));
     }
 }
 
-export async function loginAzureRM(connectedService: string): Promise<void> {
+export async function loginAzureRM(connectedService: string, azureCliPath: string = "az"): Promise<void> {
     var authScheme: string = tl.getEndpointAuthorizationScheme(connectedService, true);
 
     if (authScheme.toLowerCase() == "workloadidentityfederation") {
@@ -38,7 +38,7 @@ export async function loginAzureRM(connectedService: string): Promise<void> {
         const args = `login --service-principal -u "${servicePrincipalId}" --tenant "${tenantId}" --allow-no-subscriptions --federated-token "${federatedToken}"`;
 
         //login using OpenID Connect federation
-        throwIfError(tl.execSync("az", args), tl.loc("LoginFailed"));
+        throwIfError(tl.execSync(azureCliPath, args), tl.loc("LoginFailed"));
     }
     else if (authScheme.toLowerCase() == "serviceprincipal") {
         let authType: string = tl.getEndpointAuthorizationParameter(connectedService, 'authenticationType', true);
@@ -48,7 +48,7 @@ export async function loginAzureRM(connectedService: string): Promise<void> {
         let isCertificateParameterSupported: boolean = false;
         let authParam: string = "--password";
 
-        const azVersionResult: IExecSyncResult = tl.execSync("az", "--version");
+        const azVersionResult: IExecSyncResult = tl.execSync(azureCliPath, "--version");
         throwIfError(azVersionResult);
         isCertificateParameterSupported = isAzVersionGreaterOrEqual(azVersionResult.stdout, "2.66.0");
 
@@ -69,11 +69,11 @@ export async function loginAzureRM(connectedService: string): Promise<void> {
         let escapedCliPassword = cliPassword.replace(/"/g, '\\"');
         tl.setSecret(escapedCliPassword.replace(/\\/g, '\"'));
         //login using svn
-        throwIfError(tl.execSync("az", `login --service-principal -u "${servicePrincipalId}" ${authParam}="${escapedCliPassword}" --tenant "${tenantId}" --allow-no-subscriptions`), tl.loc("LoginFailed"));
+        throwIfError(tl.execSync(azureCliPath, `login --service-principal -u "${servicePrincipalId}" ${authParam}="${escapedCliPassword}" --tenant "${tenantId}" --allow-no-subscriptions`), tl.loc("LoginFailed"));
     }
     else if(authScheme.toLowerCase() == "managedserviceidentity") {
         //login using msi
-        throwIfError(tl.execSync("az", "login --identity"), tl.loc("MSILoginFailed"));
+        throwIfError(tl.execSync(azureCliPath, "login --identity"), tl.loc("MSILoginFailed"));
     }
     else {
         throw tl.loc('AuthSchemeNotSupported', authScheme);
@@ -82,7 +82,7 @@ export async function loginAzureRM(connectedService: string): Promise<void> {
     var subscriptionID: string = tl.getEndpointDataParameter(connectedService, "SubscriptionID", true);
     if (!!subscriptionID) {
         //set the subscription imported to the current subscription
-        throwIfError(tl.execSync("az", "account set --subscription \"" + subscriptionID + "\""), tl.loc("ErrorInSettingUpSubscription"));
+        throwIfError(tl.execSync(azureCliPath, "account set --subscription \"" + subscriptionID + "\""), tl.loc("ErrorInSettingUpSubscription"));
     }
 }
 

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.280.0",
+    "version": "3.280.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azure-arm-rest",
-            "version": "3.280.0",
+            "version": "3.280.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^4.13.1",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.280.0",
+    "version": "3.280.1",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### **Description**
Allow callers of the shared Azure CLI authentication helpers to supply an already resolved Azure CLI executable path. This prevents callers from falling back to bare `az` command resolution for cloud selection and credential-bearing login operations.

The new parameter is optional and defaults to `az`, preserving behavior for all existing consumers. The package version is bumped to 3.280.1.

---

### **Package Name**
azure-pipelines-tasks-azure-arm-rest

---

### **Risk Assessment** (Low / Medium / High)
Low. Existing callers retain the current behavior because the new executable-path argument is optional and defaults to `az`. Only callers explicitly supplying a resolved path use the hardened behavior.

---

### **Unit Tests Added or Updated**
- [x] Unit tests added or updated
- [ ] Manual tests performed

---

### **Additional Testing Performed**
- Package build completed successfully.
- Full azure-arm-rest L0 suite passed: 39 tests.
- Regression coverage verifies cloud selection, Azure CLI version detection, service-principal login, and subscription selection all use the supplied executable path.

---

### **Documentation Changes Required** (Yes / No)
No. The new optional argument is backward compatible and intended for internal task consumers.

---

### **Dependencies**
No dependencies introduced or updated.

---

### **Checklist**
- [x] Related issue linked (N/A - prerequisite for microsoft/azure-pipelines-tasks#22503)
- [x] Package version was bumped — see [versioning guide](https://semver.org/)
- [x] Verified the package behaves as expected
- [x] CLA signed (Microsoft contributor)